### PR TITLE
feat: migrate inventory app to React Native with web support

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './src/screens/HomeScreen';
+import CategoryScreen from './src/screens/CategoryScreen';
+import ShoppingListScreen from './src/screens/ShoppingListScreen';
+import { InventoryProvider } from './src/context/InventoryContext';
+import { ShoppingProvider } from './src/context/ShoppingContext';
+import { StatusBar } from 'expo-status-bar';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <InventoryProvider>
+      <ShoppingProvider>
+        <NavigationContainer>
+          <StatusBar style="auto" />
+          <Stack.Navigator>
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen
+              name="Fridge"
+              component={CategoryScreen}
+              initialParams={{ category: 'fridge' }}
+              options={{ title: 'Nevera' }}
+            />
+            <Stack.Screen
+              name="Freezer"
+              component={CategoryScreen}
+              initialParams={{ category: 'freezer' }}
+              options={{ title: 'Congelador' }}
+            />
+            <Stack.Screen
+              name="Pantry"
+              component={CategoryScreen}
+              initialParams={{ category: 'pantry' }}
+              options={{ title: 'Despensa' }}
+            />
+            <Stack.Screen name="Shopping" component={ShoppingListScreen} options={{ title: 'Compras' }} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ShoppingProvider>
+    </InventoryProvider>
+  );
+}

--- a/MiAppNevera/assets/foods.json
+++ b/MiAppNevera/assets/foods.json
@@ -1,0 +1,5 @@
+{
+  "fridge": ["Milk", "Eggs"],
+  "freezer": ["Ice Cream", "Peas"],
+  "pantry": ["Pasta", "Rice"]
+}

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -2,19 +2,23 @@
   "name": "MiAppNevera",
   "version": "0.0.1",
   "private": true,
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
   },
   "dependencies": {
-    "react-dom": "^19.1.1",
-    "react-native": "0.80.2",
-    "react-native-web": "^0.21.0"
-  },
-  "scripts": {
-    "web": "react-scripts start",
-    "web:build": "react-scripts build",
-    "android": "react-native run-android",
-    "ios": "react-native run-ios"
-  },
-
+    "expo": "^51.0.0",
+    "expo-splash-screen": "~0.20.5",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.73.4",
+    "react-native-web": "~0.19.6",
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17"
+  }
 }

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -1,0 +1,46 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import foods from '../../assets/foods.json';
+
+const InventoryContext = createContext();
+
+export const InventoryProvider = ({children}) => {
+  const [inventory, setInventory] = useState({fridge: [], freezer: [], pantry: []});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('inventory');
+        if (stored) {
+          setInventory(JSON.parse(stored));
+        } else {
+          setInventory(foods);
+        }
+      } catch (e) {
+        console.error('Failed to load inventory', e);
+      }
+    })();
+  }, []);
+
+  const persist = async (data) => {
+    setInventory(data);
+    try {
+      await AsyncStorage.setItem('inventory', JSON.stringify(data));
+    } catch (e) {
+      console.error('Failed to save inventory', e);
+    }
+  };
+
+  const addItem = (category, item) => {
+    const updated = {...inventory, [category]: [...inventory[category], item]};
+    persist(updated);
+  };
+
+  return (
+    <InventoryContext.Provider value={{inventory, addItem}}>
+      {children}
+    </InventoryContext.Provider>
+  );
+};
+
+export const useInventory = () => useContext(InventoryContext);

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -1,0 +1,43 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ShoppingContext = createContext();
+
+export const ShoppingProvider = ({children}) => {
+  const [list, setList] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('shopping');
+        if (stored) {
+          setList(JSON.parse(stored));
+        }
+      } catch (e) {
+        console.error('Failed to load shopping list', e);
+      }
+    })();
+  }, []);
+
+  const persist = async (data) => {
+    setList(data);
+    try {
+      await AsyncStorage.setItem('shopping', JSON.stringify(data));
+    } catch (e) {
+      console.error('Failed to save shopping list', e);
+    }
+  };
+
+  const addItem = (item) => {
+    const updated = [...list, item];
+    persist(updated);
+  };
+
+  return (
+    <ShoppingContext.Provider value={{list, addItem}}>
+      {children}
+    </ShoppingContext.Provider>
+  );
+};
+
+export const useShopping = () => useContext(ShoppingContext);

--- a/MiAppNevera/src/screens/CategoryScreen.js
+++ b/MiAppNevera/src/screens/CategoryScreen.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Button, ScrollView, Text, TextInput, View } from 'react-native';
+import { useInventory } from '../context/InventoryContext';
+
+export default function CategoryScreen({ route }) {
+  const { category } = route.params;
+  const { inventory, addItem } = useInventory();
+  const [text, setText] = useState('');
+
+  const onAdd = () => {
+    if (text.trim()) {
+      addItem(category, text.trim());
+      setText('');
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 10 }}>
+        {category.charAt(0).toUpperCase() + category.slice(1)}
+      </Text>
+      <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+        <TextInput
+          style={{ flex: 1, borderWidth: 1, marginRight: 10, padding: 5 }}
+          value={text}
+          onChangeText={setText}
+          placeholder="Añadir alimento"
+        />
+        <Button title="Añadir" onPress={onAdd} />
+      </View>
+      <ScrollView>
+        {inventory[category]?.map((item, idx) => (
+          <Text key={idx} style={{ padding: 5 }}>
+            {item}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/MiAppNevera/src/screens/HomeScreen.js
+++ b/MiAppNevera/src/screens/HomeScreen.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button, View } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', gap: 10, padding: 20 }}>
+      <Button title="Nevera" onPress={() => navigation.navigate('Fridge')} />
+      <Button title="Congelador" onPress={() => navigation.navigate('Freezer')} />
+      <Button title="Despensa" onPress={() => navigation.navigate('Pantry')} />
+      <Button title="Compras" onPress={() => navigation.navigate('Shopping')} />
+    </View>
+  );
+}

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { Button, ScrollView, Text, TextInput, View } from 'react-native';
+import { useShopping } from '../context/ShoppingContext';
+
+export default function ShoppingListScreen() {
+  const { list, addItem } = useShopping();
+  const [text, setText] = useState('');
+
+  const onAdd = () => {
+    if (text.trim()) {
+      addItem(text.trim());
+      setText('');
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+        <TextInput
+          style={{ flex: 1, borderWidth: 1, marginRight: 10, padding: 5 }}
+          value={text}
+          onChangeText={setText}
+          placeholder="Añadir a compras"
+        />
+        <Button title="Añadir" onPress={onAdd} />
+      </View>
+      <ScrollView>
+        {list.map((item, idx) => (
+          <Text key={idx} style={{ padding: 5 }}>
+            {item}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # App-Nevera
+
+Aplicación de inventario de alimentos escrita en React Native con soporte para web.
+
+## Estructura
+- `MiAppNevera/App.js`: punto de entrada que configura la navegación entre las pantallas.
+- `MiAppNevera/src/screens`: implementa las pantallas de inicio, categorías (nevera, congelador, despensa) y lista de compras.
+- `MiAppNevera/src/context`: hooks de estado con persistencia en `AsyncStorage`.
+- `MiAppNevera/assets/foods.json`: datos iniciales con ejemplos de alimentos.
+
+## Desarrollo
+1. Instalar dependencias
+   ```bash
+   cd MiAppNevera
+   npm install
+   ```
+2. Ejecutar en web
+   ```bash
+   npm run web
+   ```
+3. Ejecutar en Android
+   ```bash
+   npm run android
+   ```
+4. Ejecutar en iOS
+   ```bash
+   npm run ios
+   ```
+5. Iniciar el bundler de Expo (elige plataforma desde el menú)
+   ```bash
+   npm start
+   ```
+
+El estado de inventario y lista de compras se guarda localmente usando `AsyncStorage`,
+permitiendo uso sin conexión. La misma base de código funciona en Android, iOS y web
+mediante `react-native-web` y Expo.


### PR DESCRIPTION
## Summary
- migrate project to React Native/Expo with web support
- add inventory and shopping list contexts with AsyncStorage persistence
- implement screens for categories and shopping list plus navigation

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6896485210988324a33b51a8815c317d