### PR TITLE
Fix icon path resolution for Expo app

### DIFF
--- a/MiAppNevera/metro.config.js
+++ b/MiAppNevera/metro.config.js
@@ -1,0 +1,9 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const config = getDefaultConfig(__dirname);
+
+// Include the icons folder located outside of the project root
+config.watchFolders = [path.resolve(__dirname, '..', 'icons')];
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- allow Metro bundler to watch project root icons

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68965c23176483248f2df73e04f547a8