### PR TITLE
fix: ensure metro resolves external icons

### DIFF
--- a/MiAppNevera/metro.config.js
+++ b/MiAppNevera/metro.config.js
@@ -4,6 +4,14 @@ const path = require('path');
 const config = getDefaultConfig(__dirname);
 
 // Include the icons folder located outside of the project root
-config.watchFolders = [path.resolve(__dirname, '..', 'icons')];
+const iconsPath = path.resolve(__dirname, '..', 'icons');
+config.watchFolders = [iconsPath];
+
+// Ensure modules are resolved from this project's node_modules even when
+// bundling files from outside of the project root (such as the icons folder).
+config.resolver = {
+  ...config.resolver,
+  nodeModulesPaths: [path.resolve(__dirname, 'node_modules')],
+};
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- add nodeModulesPaths so Metro can resolve assets outside project root

## Testing
- `npm test --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_6897a12b83bc83248bd4e8f567f3d7a7