### PR TITLE
feat: organize inventory with categories and detailed item entry

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import HomeScreen from './src/screens/HomeScreen';
-import CategoryScreen from './src/screens/CategoryScreen';
+import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
 import { InventoryProvider } from './src/context/InventoryContext';
 import { ShoppingProvider } from './src/context/ShoppingContext';
@@ -17,26 +16,16 @@ export default function App() {
         <NavigationContainer>
           <StatusBar style="auto" />
           <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
             <Stack.Screen
-              name="Fridge"
-              component={CategoryScreen}
-              initialParams={{ category: 'fridge' }}
+              name="Inventory"
+              component={InventoryScreen}
               options={{ title: 'Nevera' }}
             />
             <Stack.Screen
-              name="Freezer"
-              component={CategoryScreen}
-              initialParams={{ category: 'freezer' }}
-              options={{ title: 'Congelador' }}
+              name="Shopping"
+              component={ShoppingListScreen}
+              options={{ title: 'Compras' }}
             />
-            <Stack.Screen
-              name="Pantry"
-              component={CategoryScreen}
-              initialParams={{ category: 'pantry' }}
-              options={{ title: 'Despensa' }}
-            />
-            <Stack.Screen name="Shopping" component={ShoppingListScreen} options={{ title: 'Compras' }} />
           </Stack.Navigator>
         </NavigationContainer>
       </ShoppingProvider>

--- a/MiAppNevera/assets/foods.json
+++ b/MiAppNevera/assets/foods.json
@@ -1,6 +1,7 @@
 {
   "fridge": [
     {"name": "Tomate", "quantity": 2, "unit": "units"},
+    {"name": "Manzana", "quantity": 3, "unit": "units"},
     {"name": "Zanahoria", "quantity": 5, "unit": "units"}
   ],
   "freezer": [

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, TextInput, Button, TouchableOpacity } from 'react-native';
+
+export default function AddItemModal({ visible, foodName, initialLocation = 'fridge', onSave, onClose }) {
+  const [location, setLocation] = useState(initialLocation);
+  const [quantity, setQuantity] = useState('1');
+  const [unit, setUnit] = useState('units');
+  const [regDate, setRegDate] = useState('');
+  const [expDate, setExpDate] = useState('');
+  const [note, setNote] = useState('');
+
+  useEffect(() => {
+    if (visible) {
+      setLocation(initialLocation);
+      setQuantity('1');
+      setUnit('units');
+      setRegDate('');
+      setExpDate('');
+      setNote('');
+    }
+  }, [visible, initialLocation]);
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex: 1, padding: 20 }}>
+        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>{foodName}</Text>
+        <Text style={{ marginBottom: 5 }}>Ubicación</Text>
+        <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+          {[
+            { key: 'fridge', label: 'Nevera' },
+            { key: 'freezer', label: 'Congelador' },
+            { key: 'pantry', label: 'Despensa' },
+          ].map(opt => (
+            <TouchableOpacity
+              key={opt.key}
+              style={{
+                padding: 8,
+                borderWidth: 1,
+                borderColor: '#ccc',
+                marginRight: 10,
+                backgroundColor: location === opt.key ? '#ddd' : '#fff',
+              }}
+              onPress={() => setLocation(opt.key)}
+            >
+              <Text>{opt.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <Text>Cantidad</Text>
+        <TextInput
+          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+          value={quantity}
+          onChangeText={setQuantity}
+          keyboardType="numeric"
+        />
+        <Text>Unidad</Text>
+        <TextInput
+          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+          value={unit}
+          onChangeText={setUnit}
+        />
+        <Text>Fecha de registro</Text>
+        <TextInput
+          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+          placeholder="YYYY-MM-DD"
+          value={regDate}
+          onChangeText={setRegDate}
+        />
+        <Text>Fecha de caducidad</Text>
+        <TextInput
+          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+          placeholder="YYYY-MM-DD"
+          value={expDate}
+          onChangeText={setExpDate}
+        />
+        <Text>Nota</Text>
+        <TextInput
+          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+          value={note}
+          onChangeText={setNote}
+        />
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Button title="Volver" onPress={onClose} />
+          <Button
+            title="Guardar"
+            onPress={() =>
+              onSave({
+                location,
+                quantity: parseInt(quantity, 10) || 0,
+                unit,
+                registered: regDate,
+                expiration: expDate,
+                note,
+              })
+            }
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -1,7 +1,7 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import foods from '../../assets/foods.json';
-import {getFoodIcon} from '../foodIcons';
+import {getFoodIcon, getFoodCategory} from '../foodIcons';
 
 const InventoryContext = createContext();
 
@@ -11,7 +11,11 @@ export const InventoryProvider = ({children}) => {
   function attachIcons(data) {
     const withIcons = {};
     Object.keys(data).forEach(cat => {
-      withIcons[cat] = data[cat].map(item => ({...item, icon: getFoodIcon(item.name)}));
+      withIcons[cat] = data[cat].map(item => ({
+        ...item,
+        icon: getFoodIcon(item.name),
+        foodCategory: getFoodCategory(item.name),
+      }));
     });
     return withIcons;
   }
@@ -40,10 +44,31 @@ export const InventoryProvider = ({children}) => {
     }
   };
 
-  const addItem = (category, name, quantity = 1, unit = 'units') => {
+  const addItem = (
+    category,
+    name,
+    quantity = 1,
+    unit = 'units',
+    registered = '',
+    expiration = '',
+    note = '',
+  ) => {
     const icon = getFoodIcon(name);
-    const newItem = {name, quantity, unit, icon};
-    const updated = {...inventory, [category]: [...inventory[category], newItem]};
+    const foodCategory = getFoodCategory(name);
+    const newItem = {
+      name,
+      quantity,
+      unit,
+      icon,
+      registered,
+      expiration,
+      note,
+      foodCategory,
+    };
+    const updated = {
+      ...inventory,
+      [category]: [...inventory[category], newItem],
+    };
     persist(updated);
   };
 

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -157,4 +157,14 @@ export function getFoodIcon(name) {
   return foodIcons[normalizeFoodName(name)];
 }
 
+export function getFoodCategory(name) {
+  const normalized = normalizeFoodName(name);
+  for (const [cat, data] of Object.entries(categories)) {
+    if (data.items.includes(normalized)) {
+      return cat;
+    }
+  }
+  return null;
+}
+
 export default foodIcons;

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, Image, Button, TouchableOpacity } from 'react-native';
+import { useInventory } from '../context/InventoryContext';
+import FoodPickerModal from '../components/FoodPickerModal';
+import AddItemModal from '../components/AddItemModal';
+import { categories } from '../foodIcons';
+
+function StorageSelector({ current, onChange }) {
+  const opts = [
+    { key: 'fridge', label: '🥶' },
+    { key: 'freezer', label: '❄️' },
+    { key: 'pantry', label: '🗃️' },
+  ];
+  return (
+    <View style={{ flexDirection: 'row', justifyContent: 'space-around', padding: 10 }}>
+      {opts.map(opt => (
+        <TouchableOpacity key={opt.key} onPress={() => onChange(opt.key)}>
+          <Text style={{ fontSize: 24, opacity: current === opt.key ? 1 : 0.4 }}>{opt.label}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+export default function InventoryScreen() {
+  const { inventory, addItem, updateQuantity, removeItem } = useInventory();
+  const [storage, setStorage] = useState('fridge');
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [selectedFood, setSelectedFood] = useState(null);
+  const [addVisible, setAddVisible] = useState(false);
+
+  const grouped = inventory[storage].reduce((acc, item, index) => {
+    const cat = item.foodCategory || 'otros';
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push({ ...item, index });
+    return acc;
+  }, {});
+
+  const groupOrder = Object.keys(categories);
+
+  const onSelectFood = name => {
+    setSelectedFood(name);
+    setPickerVisible(false);
+    setAddVisible(true);
+  };
+
+  const onSave = data => {
+    addItem(data.location, selectedFood, data.quantity, data.unit, data.registered, data.expiration, data.note);
+    setAddVisible(false);
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <StorageSelector current={storage} onChange={setStorage} />
+      <View style={{ padding: 20, flex: 1 }}>
+        <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+        <ScrollView style={{ marginTop: 10 }}>
+          {groupOrder.map(cat => {
+            const items = grouped[cat];
+            if (!items || items.length === 0) return null;
+            return (
+              <View key={cat} style={{ marginBottom: 15 }}>
+                <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 5 }}>
+                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                </Text>
+                {items.map(item => (
+                  <View
+                    key={item.index}
+                    style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 5 }}
+                  >
+                    {item.icon && (
+                      <Image source={item.icon} style={{ width: 32, height: 32, marginRight: 10 }} />
+                    )}
+                    <Text style={{ flex: 1 }}>{item.name}</Text>
+                    <Button title="-" onPress={() => updateQuantity(storage, item.index, -1)} />
+                    <Text style={{ marginHorizontal: 10 }}>{item.quantity}</Text>
+                    <Button title="+" onPress={() => updateQuantity(storage, item.index, 1)} />
+                    <Button title="Eliminar" onPress={() => removeItem(storage, item.index)} />
+                  </View>
+                ))}
+              </View>
+            );
+          })}
+        </ScrollView>
+      </View>
+      <FoodPickerModal
+        visible={pickerVisible}
+        onSelect={onSelectFood}
+        onClose={() => setPickerVisible(false)}
+      />
+      <AddItemModal
+        visible={addVisible}
+        foodName={selectedFood}
+        initialLocation={storage}
+        onSave={onSave}
+        onClose={() => setAddVisible(false)}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- show fridge contents grouped by food categories with icons to switch storage areas
- add detailed item modal to choose location, quantity, units, dates and notes
- categorize foods when adding and load sample items for demo

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897a912c844832493c7aaed21a2981f