### PR TITLE
Add item icon and edit modal

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, View, Text, TextInput, Button, TouchableOpacity } from 'react-native';
+import { Modal, View, Text, TextInput, Button, TouchableOpacity, Image } from 'react-native';
 
-export default function AddItemModal({ visible, foodName, initialLocation = 'fridge', onSave, onClose }) {
+export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const [location, setLocation] = useState(initialLocation);
   const [quantity, setQuantity] = useState('1');
   const [unit, setUnit] = useState('units');
@@ -24,6 +24,12 @@ export default function AddItemModal({ visible, foodName, initialLocation = 'fri
     <Modal visible={visible} animationType="slide">
       <View style={{ flex: 1, padding: 20 }}>
         <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>{foodName}</Text>
+        {foodIcon && (
+          <Image
+            source={foodIcon}
+            style={{ width: 60, height: 60, alignSelf: 'center', marginBottom: 10 }}
+          />
+        )}
         <Text style={{ marginBottom: 5 }}>Ubicación</Text>
         <View style={{ flexDirection: 'row', marginBottom: 10 }}>
           {[
@@ -54,11 +60,27 @@ export default function AddItemModal({ visible, foodName, initialLocation = 'fri
           keyboardType="numeric"
         />
         <Text>Unidad</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          value={unit}
-          onChangeText={setUnit}
-        />
+        <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+          {[
+            { key: 'units', label: 'Unidades' },
+            { key: 'kg', label: 'Kg' },
+            { key: 'l', label: 'L' },
+          ].map(opt => (
+            <TouchableOpacity
+              key={opt.key}
+              style={{
+                padding: 8,
+                borderWidth: 1,
+                borderColor: '#ccc',
+                marginRight: 10,
+                backgroundColor: unit === opt.key ? '#ddd' : '#fff',
+              }}
+              onPress={() => setUnit(opt.key)}
+            >
+              <Text>{opt.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
         <Text>Fecha de registro</Text>
         <TextInput
           style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, TextInput, Button, TouchableOpacity, Image } from 'react-native';
+
+export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
+  const [location, setLocation] = useState('fridge');
+  const [quantity, setQuantity] = useState('1');
+  const [unit, setUnit] = useState('units');
+  const [regDate, setRegDate] = useState('');
+  const [expDate, setExpDate] = useState('');
+  const [note, setNote] = useState('');
+  const [confirmVisible, setConfirmVisible] = useState(false);
+
+  useEffect(() => {
+    if (visible && item) {
+      setLocation(item.location || 'fridge');
+      setQuantity(String(item.quantity));
+      setUnit(item.unit);
+      setRegDate(item.registered || '');
+      setExpDate(item.expiration || '');
+      setNote(item.note || '');
+    }
+  }, [visible, item]);
+
+  const handleSave = () => {
+    onSave({
+      location,
+      quantity: parseInt(quantity, 10) || 0,
+      unit,
+      registered: regDate,
+      expiration: expDate,
+      note,
+    });
+  };
+
+  return (
+    <>
+      <Modal visible={visible} animationType="slide">
+        <View style={{ flex: 1, padding: 20 }}>
+          {item?.icon && (
+            <Image
+              source={item.icon}
+              style={{ width: 60, height: 60, alignSelf: 'center', marginBottom: 10 }}
+            />
+          )}
+          <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>{item?.name}</Text>
+          <Text style={{ marginBottom: 5 }}>Ubicación</Text>
+          <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+            {[
+              { key: 'fridge', label: 'Nevera' },
+              { key: 'freezer', label: 'Congelador' },
+              { key: 'pantry', label: 'Despensa' },
+            ].map(opt => (
+              <TouchableOpacity
+                key={opt.key}
+                style={{
+                  padding: 8,
+                  borderWidth: 1,
+                  borderColor: '#ccc',
+                  marginRight: 10,
+                  backgroundColor: location === opt.key ? '#ddd' : '#fff',
+                }}
+                onPress={() => setLocation(opt.key)}
+              >
+                <Text>{opt.label}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text>Cantidad</Text>
+          <TextInput
+            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+            value={quantity}
+            onChangeText={setQuantity}
+            keyboardType="numeric"
+          />
+          <Text>Unidad</Text>
+          <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+            {[
+              { key: 'units', label: 'Unidades' },
+              { key: 'kg', label: 'Kg' },
+              { key: 'l', label: 'L' },
+            ].map(opt => (
+              <TouchableOpacity
+                key={opt.key}
+                style={{
+                  padding: 8,
+                  borderWidth: 1,
+                  borderColor: '#ccc',
+                  marginRight: 10,
+                  backgroundColor: unit === opt.key ? '#ddd' : '#fff',
+                }}
+                onPress={() => setUnit(opt.key)}
+              >
+                <Text>{opt.label}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text>Fecha de registro</Text>
+          <TextInput
+            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+            placeholder="YYYY-MM-DD"
+            value={regDate}
+            onChangeText={setRegDate}
+          />
+          <Text>Fecha de caducidad</Text>
+          <TextInput
+            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+            placeholder="YYYY-MM-DD"
+            value={expDate}
+            onChangeText={setExpDate}
+          />
+          <Text>Nota</Text>
+          <TextInput
+            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+            value={note}
+            onChangeText={setNote}
+          />
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+            <Button title="Volver" onPress={onClose} />
+            <Button title="Guardar" onPress={handleSave} />
+          </View>
+          <View style={{ marginTop: 20 }}>
+            <Button title="Eliminar" color="red" onPress={() => setConfirmVisible(true)} />
+          </View>
+        </View>
+      </Modal>
+      <Modal visible={confirmVisible} transparent animationType="fade">
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }}>
+          <View style={{ backgroundColor: '#fff', padding: 20, alignItems: 'center', width: '80%' }}>
+            {item?.icon && (
+              <Image source={item.icon} style={{ width: 60, height: 60, marginBottom: 10 }} />
+            )}
+            <Text style={{ marginBottom: 20 }}>¿Seguro que deseas eliminar {item?.name}?</Text>
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between', width: '100%' }}>
+              <Button title="Cancelar" onPress={() => setConfirmVisible(false)} />
+              <Button
+                title="Eliminar"
+                color="red"
+                onPress={() => {
+                  setConfirmVisible(false);
+                  onDelete();
+                }}
+              />
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -72,6 +72,33 @@ export const InventoryProvider = ({children}) => {
     persist(updated);
   };
 
+  const updateItem = (
+    oldCategory,
+    index,
+    {location, quantity, unit, registered, expiration, note},
+  ) => {
+    const item = inventory[oldCategory][index];
+    const updatedItem = {
+      ...item,
+      quantity,
+      unit,
+      registered,
+      expiration,
+      note,
+    };
+    const newCategory = location;
+    if (newCategory === oldCategory) {
+      const updatedCategory = inventory[oldCategory].map((it, idx) =>
+        idx === index ? updatedItem : it,
+      );
+      persist({...inventory, [oldCategory]: updatedCategory});
+    } else {
+      const removedOld = inventory[oldCategory].filter((_, idx) => idx !== index);
+      const addedNew = [...inventory[newCategory], updatedItem];
+      persist({...inventory, [oldCategory]: removedOld, [newCategory]: addedNew});
+    }
+  };
+
   const updateQuantity = (category, index, delta) => {
     const updatedCategory = inventory[category].map((item, idx) =>
       idx === index
@@ -87,7 +114,7 @@ export const InventoryProvider = ({children}) => {
   };
 
   return (
-    <InventoryContext.Provider value={{inventory, addItem, updateQuantity, removeItem}}>
+    <InventoryContext.Provider value={{inventory, addItem, updateItem, updateQuantity, removeItem}}>
       {children}
     </InventoryContext.Provider>
   );


### PR DESCRIPTION
## Summary
- show selected food icon and unit selection when adding items
- allow editing existing items with detailed modal and delete confirmation
- support updating stored items and passing icons in inventory screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897ac4a5bcc8324a0e54e600bd4392e