### PR TITLE
feat: add shopping list interface

### DIFF
--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -1,0 +1,61 @@
+import React, {useEffect, useState} from 'react';
+import {Modal, View, Text, TextInput, Button, TouchableOpacity, Image} from 'react-native';
+
+export default function AddShoppingItemModal({visible, foodName, foodIcon, onSave, onClose}) {
+  const [quantity, setQuantity] = useState('1');
+  const [unit, setUnit] = useState('units');
+
+  useEffect(() => {
+    if (visible) {
+      setQuantity('1');
+      setUnit('units');
+    }
+  }, [visible]);
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{flex:1, padding:20}}>
+        <Text style={{fontSize:18, fontWeight:'bold', marginBottom:10}}>{foodName}</Text>
+        {foodIcon && (
+          <Image source={foodIcon} style={{width:60, height:60, alignSelf:'center', marginBottom:10}} />
+        )}
+        <Text>Cantidad</Text>
+        <TextInput
+          style={{borderWidth:1, marginBottom:10, padding:5}}
+          value={quantity}
+          onChangeText={setQuantity}
+          keyboardType="numeric"
+        />
+        <Text>Unidad</Text>
+        <View style={{flexDirection:'row', marginBottom:10}}>
+          {[
+            {key:'units', label:'Unidades'},
+            {key:'kg', label:'Kg'},
+            {key:'l', label:'L'},
+          ].map(opt => (
+            <TouchableOpacity
+              key={opt.key}
+              style={{
+                padding:8,
+                borderWidth:1,
+                borderColor:'#ccc',
+                marginRight:10,
+                backgroundColor: unit === opt.key ? '#ddd' : '#fff',
+              }}
+              onPress={() => setUnit(opt.key)}
+            >
+              <Text>{opt.label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <View style={{flexDirection:'row', justifyContent:'space-between'}}>
+          <Button title="Volver" onPress={onClose} />
+          <Button
+            title="Guardar"
+            onPress={() => onSave({quantity: parseInt(quantity,10) || 0, unit})}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -1,5 +1,6 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {getFoodIcon, getFoodCategory} from '../foodIcons';
 
 const ShoppingContext = createContext();
 
@@ -11,7 +12,12 @@ export const ShoppingProvider = ({children}) => {
       try {
         const stored = await AsyncStorage.getItem('shopping');
         if (stored) {
-          setList(JSON.parse(stored));
+          const parsed = JSON.parse(stored).map(item => ({
+            ...item,
+            icon: item.icon || getFoodIcon(item.name),
+            foodCategory: item.foodCategory || getFoodCategory(item.name),
+          }));
+          setList(parsed);
         }
       } catch (e) {
         console.error('Failed to load shopping list', e);
@@ -28,10 +34,16 @@ export const ShoppingProvider = ({children}) => {
     }
   };
 
-  const addItem = (name, category = 'general', quantity = 1, unit = 'units') => {
-    const newItem = {name, category, quantity, unit, purchased: false};
-    const updated = [...list, newItem];
-    persist(updated);
+  const addItem = (name, quantity = 1, unit = 'units') => {
+    const newItem = {
+      name,
+      quantity,
+      unit,
+      icon: getFoodIcon(name),
+      foodCategory: getFoodCategory(name),
+      purchased: false,
+    };
+    persist([...list, newItem]);
   };
 
   const togglePurchased = (index) => {

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -85,6 +85,12 @@ export default function InventoryScreen({ navigation }) {
           >
             <Text style={{ fontSize: 18 }}>🔍</Text>
           </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('Shopping')}
+            style={{ marginRight: 15 }}
+          >
+            <Text style={{ fontSize: 18 }}>🛒</Text>
+          </TouchableOpacity>
           <TouchableOpacity onPress={() => setMenuVisible(true)}>
             <Text style={{ fontSize: 24 }}>⋮</Text>
           </TouchableOpacity>

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -1,65 +1,150 @@
-import React, { useState } from 'react';
-import { Button, ScrollView, Text, TextInput, View, TouchableOpacity } from 'react-native';
-import { useShopping } from '../context/ShoppingContext';
+import React, {useState} from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Button,
+  Image,
+  Modal,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import {useShopping} from '../context/ShoppingContext';
+import {useInventory} from '../context/InventoryContext';
+import FoodPickerModal from '../components/FoodPickerModal';
+import AddShoppingItemModal from '../components/AddShoppingItemModal';
+import {getFoodIcon} from '../foodIcons';
 
 export default function ShoppingListScreen() {
-  const { list, addItem, togglePurchased, removeItem } = useShopping();
-  const [name, setName] = useState('');
-  const [quantity, setQuantity] = useState('1');
-  const [category, setCategory] = useState('general');
+  const {list, addItem, togglePurchased, removeItem} = useShopping();
+  const {inventory} = useInventory();
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [addVisible, setAddVisible] = useState(false);
+  const [selectedFood, setSelectedFood] = useState(null);
+  const [autoVisible, setAutoVisible] = useState(false);
 
-  const onAdd = () => {
-    if (name.trim()) {
-      const qty = parseInt(quantity, 10);
-      addItem(name.trim(), category, isNaN(qty) ? 0 : qty);
-      setName('');
-      setQuantity('1');
-      setCategory('general');
+  const onSelectFood = name => {
+    setSelectedFood({name, icon: getFoodIcon(name)});
+    setPickerVisible(false);
+    setAddVisible(true);
+  };
+
+  const onSave = ({quantity, unit}) => {
+    if (selectedFood) {
+      addItem(selectedFood.name, quantity, unit);
+      setSelectedFood(null);
+      setAddVisible(false);
     }
   };
 
+  const handleAutoAdd = () => {
+    const zeroItems = ['fridge', 'freezer', 'pantry'].flatMap(loc =>
+      inventory[loc].filter(item => item.quantity === 0),
+    );
+    zeroItems.forEach(it => {
+      if (!list.some(l => l.name === it.name)) {
+        addItem(it.name, 1, it.unit);
+      }
+    });
+    setAutoVisible(false);
+  };
+
+  const grouped = {};
+  list.forEach((item, index) => {
+    const cat = item.foodCategory || 'otros';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push({item, index});
+  });
+
   return (
-    <View style={{ flex: 1, padding: 20 }}>
-      <View style={{ flexDirection: 'row', marginBottom: 10 }}>
-        <TextInput
-          style={{ flex: 1, borderWidth: 1, marginRight: 10, padding: 5 }}
-          value={name}
-          onChangeText={setName}
-          placeholder="Artículo"
-        />
-        <TextInput
-          style={{ width: 60, borderWidth: 1, marginRight: 10, padding: 5 }}
-          value={quantity}
-          onChangeText={setQuantity}
-          keyboardType="numeric"
-        />
-        <TextInput
-          style={{ width: 100, borderWidth: 1, marginRight: 10, padding: 5 }}
-          value={category}
-          onChangeText={setCategory}
-          placeholder="Categoría"
-        />
-        <Button title="Añadir" onPress={onAdd} />
+    <View style={{flex:1, padding:20}}>
+      <View style={{flexDirection:'row', justifyContent:'space-between', marginBottom:10}}>
+        <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+        <TouchableOpacity onPress={() => setAutoVisible(true)}>
+          <Text style={{fontSize:24}}>⚡</Text>
+        </TouchableOpacity>
       </View>
       <ScrollView>
-        {list.map((item, idx) => (
-          <TouchableOpacity
-            key={idx}
-            onPress={() => togglePurchased(idx)}
-            onLongPress={() => removeItem(idx)}
-          >
-            <Text
-              style={{
-                padding: 5,
-                textDecorationLine: item.purchased ? 'line-through' : 'none',
-                color: item.purchased ? 'gray' : 'black',
-              }}
-            >
-              {item.name} - {item.quantity} {item.unit} ({item.category})
-            </Text>
-          </TouchableOpacity>
+        {Object.entries(grouped).map(([cat, items]) => (
+          <View key={cat} style={{marginBottom:10}}>
+            <Text style={{fontSize:18, fontWeight:'bold', marginBottom:5}}>{cat}</Text>
+            {items.map(({item, index}) => (
+              <TouchableOpacity
+                key={index}
+                onPress={() => togglePurchased(index)}
+                onLongPress={() => removeItem(index)}
+              >
+                <View
+                  style={{
+                    flexDirection:'row',
+                    alignItems:'center',
+                    padding:5,
+                    backgroundColor: item.purchased ? '#ddd' : 'transparent',
+                  }}
+                >
+                  {item.icon && (
+                    <Image
+                      source={item.icon}
+                      style={{width:30, height:30, marginRight:10}}
+                    />
+                  )}
+                  <Text
+                    style={{
+                      textDecorationLine: item.purchased ? 'line-through' : 'none',
+                      color: item.purchased ? 'gray' : 'black',
+                    }}
+                  >
+                    {item.name} - {item.quantity} {item.unit}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            ))}
+          </View>
         ))}
       </ScrollView>
+
+      <FoodPickerModal
+        visible={pickerVisible}
+        onSelect={onSelectFood}
+        onClose={() => setPickerVisible(false)}
+      />
+      <AddShoppingItemModal
+        visible={addVisible}
+        foodName={selectedFood?.name}
+        foodIcon={selectedFood?.icon}
+        onSave={onSave}
+        onClose={() => setAddVisible(false)}
+      />
+
+      <Modal
+        visible={autoVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setAutoVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setAutoVisible(false)}>
+          <View
+            style={{
+              flex:1,
+              justifyContent:'center',
+              alignItems:'center',
+              backgroundColor:'rgba(0,0,0,0.3)',
+            }}
+          >
+            <TouchableWithoutFeedback>
+              <View style={{backgroundColor:'#fff', padding:20, borderRadius:8}}>
+                <Text style={{marginBottom:10}}>
+                  ¿Desea añadir todos los elementos que presenten una cantidad de 0 a la lista de compras? Todos los alimentos que ya se encuentren en la lista no se agregarán.
+                </Text>
+                <View style={{flexDirection:'row', justifyContent:'space-around'}}>
+                  <Button title="Cancelar" onPress={() => setAutoVisible(false)} />
+                  <Button title="Aceptar" onPress={handleAutoAdd} />
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add quick access button to shopping list
- implement categorized shopping list with lightning bulk add
- support icons and units for shopping items

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897f7434d7483249dca57b511535c36