### PR TITLE
feat: add batch shopping list actions

### DIFF
--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, TextInput, Button, TouchableOpacity, Image, ScrollView } from 'react-native';
+
+export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
+  const today = new Date().toISOString().split('T')[0];
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    if (visible) {
+      setData(
+        items.map(() => ({
+          location: 'fridge',
+          quantity: '1',
+          unit: 'units',
+          regDate: today,
+          expDate: '',
+        })),
+      );
+    }
+  }, [visible, items, today]);
+
+  const updateField = (index, field, value) => {
+    setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <ScrollView style={{ flex: 1, padding: 20 }}>
+        {items.map((item, idx) => (
+          <View key={idx} style={{ marginBottom: 20 }}>
+            <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>
+              {item.name}
+            </Text>
+            {item.icon && (
+              <Image
+                source={item.icon}
+                style={{ width: 60, height: 60, alignSelf: 'center', marginBottom: 10 }}
+              />
+            )}
+            <Text style={{ marginBottom: 5 }}>Ubicación</Text>
+            <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+              {[
+                { key: 'fridge', label: 'Nevera' },
+                { key: 'freezer', label: 'Congelador' },
+                { key: 'pantry', label: 'Despensa' },
+              ].map(opt => (
+                <TouchableOpacity
+                  key={opt.key}
+                  style={{
+                    padding: 8,
+                    borderWidth: 1,
+                    borderColor: '#ccc',
+                    marginRight: 10,
+                    backgroundColor: data[idx]?.location === opt.key ? '#ddd' : '#fff',
+                  }}
+                  onPress={() => updateField(idx, 'location', opt.key)}
+                >
+                  <Text>{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text>Cantidad</Text>
+            <TextInput
+              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+              value={data[idx]?.quantity}
+              onChangeText={t => updateField(idx, 'quantity', t)}
+              keyboardType="numeric"
+            />
+            <Text>Unidad</Text>
+            <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+              {[
+                { key: 'units', label: 'Unidades' },
+                { key: 'kg', label: 'Kg' },
+                { key: 'l', label: 'L' },
+              ].map(opt => (
+                <TouchableOpacity
+                  key={opt.key}
+                  style={{
+                    padding: 8,
+                    borderWidth: 1,
+                    borderColor: '#ccc',
+                    marginRight: 10,
+                    backgroundColor: data[idx]?.unit === opt.key ? '#ddd' : '#fff',
+                  }}
+                  onPress={() => updateField(idx, 'unit', opt.key)}
+                >
+                  <Text>{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text>Fecha de registro</Text>
+            <TextInput
+              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+              placeholder="YYYY-MM-DD"
+              value={data[idx]?.regDate}
+              onChangeText={t => updateField(idx, 'regDate', t)}
+            />
+            <Text>Fecha de caducidad</Text>
+            <TextInput
+              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+              placeholder="YYYY-MM-DD"
+              value={data[idx]?.expDate}
+              onChangeText={t => updateField(idx, 'expDate', t)}
+            />
+          </View>
+        ))}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20 }}>
+          <Button title="Volver" onPress={onClose} />
+          <Button title="Guardar" onPress={() => onSave(data)} />
+        </View>
+      </ScrollView>
+    </Modal>
+  );
+}
+

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -46,6 +46,18 @@ export const ShoppingProvider = ({children}) => {
     persist([...list, newItem]);
   };
 
+  const addItems = items => {
+    const newItems = items.map(({name, quantity = 1, unit = 'units'}) => ({
+      name,
+      quantity,
+      unit,
+      icon: getFoodIcon(name),
+      foodCategory: getFoodCategory(name),
+      purchased: false,
+    }));
+    persist([...list, ...newItems]);
+  };
+
   const togglePurchased = (index) => {
     const updated = list.map((item, idx) =>
       idx === index ? {...item, purchased: !item.purchased} : item,
@@ -58,8 +70,24 @@ export const ShoppingProvider = ({children}) => {
     persist(updated);
   };
 
+  const removeItems = (indices) => {
+    const set = new Set(indices);
+    const updated = list.filter((_, idx) => !set.has(idx));
+    persist(updated);
+  };
+
+  const markPurchased = (indices) => {
+    const set = new Set(indices);
+    const updated = list.map((item, idx) =>
+      set.has(idx) ? {...item, purchased: true} : item,
+    );
+    persist(updated);
+  };
+
   return (
-    <ShoppingContext.Provider value={{list, addItem, togglePurchased, removeItem}}>
+    <ShoppingContext.Provider
+      value={{list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased}}
+    >
       {children}
     </ShoppingContext.Provider>
   );


### PR DESCRIPTION
## Summary
- support adding multiple zero-quantity items at once
- allow multi-select in shopping list with select all, delete, and save
- add modal to batch configure and store purchased items

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897fb4715f48324ada068e701ddca71