### PR TITLE
feat: batch add items with notes and edit screen icons

### DIFF
--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, View, Text, TextInput, Button, TouchableOpacity, Image, ScrollView } from 'react-native';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Button,
+  TouchableOpacity,
+  Image,
+  ScrollView,
+} from 'react-native';
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -14,6 +23,7 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
           unit: 'units',
           regDate: today,
           expDate: '',
+          note: '',
         })),
       );
     }
@@ -27,7 +37,16 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
     <Modal visible={visible} animationType="slide">
       <ScrollView style={{ flex: 1, padding: 20 }}>
         {items.map((item, idx) => (
-          <View key={idx} style={{ marginBottom: 20 }}>
+          <View
+            key={idx}
+            style={{
+              marginBottom: 20,
+              borderWidth: 1,
+              borderColor: '#ccc',
+              borderRadius: 8,
+              padding: 10,
+            }}
+          >
             <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>
               {item.name}
             </Text>
@@ -101,6 +120,12 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
               placeholder="YYYY-MM-DD"
               value={data[idx]?.expDate}
               onChangeText={t => updateField(idx, 'expDate', t)}
+            />
+            <Text>Nota</Text>
+            <TextInput
+              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+              value={data[idx]?.note}
+              onChangeText={t => updateField(idx, 'note', t)}
             />
           </View>
         ))}

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -1,7 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, View, Text, TextInput, Button, TouchableOpacity, Image } from 'react-native';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Button,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import { useShopping } from '../context/ShoppingContext';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
+  const { addItem: addShoppingItem } = useShopping();
   const [location, setLocation] = useState('fridge');
   const [quantity, setQuantity] = useState('1');
   const [unit, setUnit] = useState('units');
@@ -36,6 +46,31 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
     <>
       <Modal visible={visible} animationType="slide">
         <View style={{ flex: 1, padding: 20 }}>
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 10,
+            }}
+          >
+            <TouchableOpacity onPress={onClose}>
+              <Text style={{ fontSize: 24 }}>←</Text>
+            </TouchableOpacity>
+            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+              <TouchableOpacity
+                onPress={() =>
+                  addShoppingItem(item.name, 1, item.unit)
+                }
+                style={{ marginRight: 15 }}
+              >
+                <Text style={{ fontSize: 24 }}>🧺</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => setConfirmVisible(true)}>
+                <Text style={{ fontSize: 24 }}>🗑️</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
           {item?.icon && (
             <Image
               source={item.icon}
@@ -114,13 +149,20 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             value={note}
             onChangeText={setNote}
           />
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <Button title="Volver" onPress={onClose} />
-            <Button title="Guardar" onPress={handleSave} />
-          </View>
-          <View style={{ marginTop: 20 }}>
-            <Button title="Eliminar" color="red" onPress={() => setConfirmVisible(true)} />
-          </View>
+          <TouchableOpacity
+            onPress={handleSave}
+            style={{
+              position: 'absolute',
+              bottom: 20,
+              alignSelf: 'center',
+              backgroundColor: '#2196f3',
+              paddingVertical: 10,
+              paddingHorizontal: 20,
+              borderRadius: 6,
+            }}
+          >
+            <Text style={{ color: '#fff', fontSize: 16 }}>Guardar</Text>
+          </TouchableOpacity>
         </View>
       </Modal>
       <Modal visible={confirmVisible} transparent animationType="fade">

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -14,6 +14,7 @@ import { useInventory } from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
 import AddItemModal from '../components/AddItemModal';
 import EditItemModal from '../components/EditItemModal';
+import BatchAddItemModal from '../components/BatchAddItemModal';
 import { categories, getFoodIcon } from '../foodIcons';
 
 function StorageSelector({ current, onChange }) {
@@ -40,6 +41,8 @@ export default function InventoryScreen({ navigation }) {
   const [selectedFood, setSelectedFood] = useState(null);
   const [addVisible, setAddVisible] = useState(false);
   const [editingItem, setEditingItem] = useState(null);
+  const [multiAddVisible, setMultiAddVisible] = useState(false);
+  const [multiItems, setMultiItems] = useState([]);
 
   const [search, setSearch] = useState('');
   const [menuVisible, setMenuVisible] = useState(false);
@@ -47,7 +50,7 @@ export default function InventoryScreen({ navigation }) {
   const [viewVisible, setViewVisible] = useState(false);
   const [sortOrder, setSortOrder] = useState('name');
   const [groupBy, setGroupBy] = useState('category');
-  const [viewType, setViewType] = useState('list');
+  const [viewType, setViewType] = useState('grid');
   const [tempSortOrder, setTempSortOrder] = useState(sortOrder);
   const [tempGroupBy, setTempGroupBy] = useState(groupBy);
   const [tempViewType, setTempViewType] = useState(viewType);
@@ -156,6 +159,13 @@ export default function InventoryScreen({ navigation }) {
     setAddVisible(true);
   };
 
+  const onMultiSelectFoods = names => {
+    const items = names.map(name => ({ name, icon: getFoodIcon(name) }));
+    setMultiItems(items);
+    setPickerVisible(false);
+    setMultiAddVisible(true);
+  };
+
   const onSave = data => {
     addItem(
       data.location,
@@ -167,6 +177,24 @@ export default function InventoryScreen({ navigation }) {
       data.note,
     );
     setAddVisible(false);
+  };
+
+  const handleBatchAddSave = entries => {
+    entries.forEach((entry, idx) => {
+      const { location, quantity, unit, regDate, expDate, note } = entry;
+      const item = multiItems[idx];
+      addItem(
+        location,
+        item.name,
+        parseInt(quantity, 10) || 0,
+        unit,
+        regDate,
+        expDate,
+        note,
+      );
+    });
+    setMultiAddVisible(false);
+    setMultiItems([]);
   };
 
   const toggleSelection = (location, index) => {
@@ -669,6 +697,7 @@ export default function InventoryScreen({ navigation }) {
       <FoodPickerModal
         visible={pickerVisible}
         onSelect={onSelectFood}
+        onMultiSelect={onMultiSelectFoods}
         onClose={() => setPickerVisible(false)}
       />
       <AddItemModal
@@ -678,6 +707,12 @@ export default function InventoryScreen({ navigation }) {
         initialLocation={storage}
         onSave={onSave}
         onClose={() => setAddVisible(false)}
+      />
+      <BatchAddItemModal
+        visible={multiAddVisible}
+        items={multiItems}
+        onSave={handleBatchAddSave}
+        onClose={() => setMultiAddVisible(false)}
       />
       <EditItemModal
         visible={!!editingItem}

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -86,7 +86,7 @@ export default function ShoppingListScreen() {
 
   const handleBatchSave = entries => {
     entries.forEach((entry, idx) => {
-      const {location, quantity, unit, regDate, expDate} = entry;
+      const {location, quantity, unit, regDate, expDate, note} = entry;
       const item = list[selected[idx]];
       addInventoryItem(
         location,
@@ -95,6 +95,7 @@ export default function ShoppingListScreen() {
         unit,
         regDate,
         expDate,
+        note,
       );
     });
     markPurchased(selected);


### PR DESCRIPTION
## Summary
- enable multi-select food picker to batch add items with notes
- default inventory view is grid and batch saving supports notes
- redesign edit item modal with icon controls and shopping list shortcut

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898070165408324bd3fec224af3a35f