### PR TITLE
Agregar icono de volver y cancelar selección múltiple

### DIFF
--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -70,7 +70,18 @@ export default function FoodPickerModal({
     <>
       <Modal visible={visible} animationType="slide">
         <View style={{ flex: 1, padding: 20 }}>
-          <View style={{ flexDirection: 'row', justifyContent: 'flex-end', marginBottom: 10 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 10,
+          }}
+        >
+          <TouchableOpacity onPress={onClose}>
+            <Text style={{ fontSize: 24 }}>←</Text>
+          </TouchableOpacity>
+          <View style={{ flexDirection: 'row' }}>
             <TouchableOpacity
               onPress={() =>
                 setSearchVisible(v => {
@@ -86,6 +97,7 @@ export default function FoodPickerModal({
               <Text style={{ fontSize: 24 }}>⋮</Text>
             </TouchableOpacity>
           </View>
+        </View>
           {/* Top half: category icons */}
           <View style={{ flex: 1 }}>
             <ScrollView horizontal contentContainerStyle={{ alignItems: 'center' }}>
@@ -173,9 +185,7 @@ export default function FoodPickerModal({
               />
               <Button title="Guardar" onPress={handleSave} />
             </View>
-          ) : (
-            <Button title="Cerrar" onPress={onClose} />
-          )}
+          ) : null}
         </View>
       </View>
     </Modal>

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -473,6 +473,21 @@ export default function InventoryScreen({ navigation }) {
               borderRadius: 6,
               margin: 4,
             }}
+            onPress={() => {
+              setSelectedItems([]);
+              setMultiSelect(false);
+            }}
+          >
+            <Text style={{ fontSize: 16 }}>❌</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={{
+              backgroundColor: '#e0e0e0',
+              paddingVertical: 8,
+              paddingHorizontal: 12,
+              borderRadius: 6,
+              margin: 4,
+            }}
             onPress={selectAll}
           >
             <Text style={{ fontSize: 16 }}>Seleccionar todo</Text>
@@ -499,7 +514,7 @@ export default function InventoryScreen({ navigation }) {
             }}
             onPress={() => setTransferType('move')}
           >
-            <Text style={{ color: '#fff', fontSize: 16 }}>Mover</Text>
+            <Text style={{ color: '#fff', fontSize: 16 }}>🔀</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={{
@@ -511,7 +526,7 @@ export default function InventoryScreen({ navigation }) {
             }}
             onPress={() => setTransferType('copy')}
           >
-            <Text style={{ color: '#fff', fontSize: 16 }}>Copiar</Text>
+            <Text style={{ color: '#fff', fontSize: 16 }}>📄</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={{
@@ -535,7 +550,7 @@ export default function InventoryScreen({ navigation }) {
             }}
             onPress={() => setConfirmVisible(true)}
           >
-            <Text style={{ color: '#fff', fontSize: 16 }}>Eliminar</Text>
+            <Text style={{ color: '#fff', fontSize: 16 }}>🗑️</Text>
           </TouchableOpacity>
         </View>
       )}


### PR DESCRIPTION
## Summary
- Mostrar icono de volver en el selector de alimentos y quitar botón "Cerrar"
- Usar iconos para mover, copiar y eliminar en selección múltiple
- Añadir botón para cancelar la selección múltiple

## Testing
- `npm test` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6898f0b2da8083249a7ba98f9a639be6