### PR TITLE
Add basic recipe book feature with shopping list integration

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -5,6 +5,9 @@ import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
 import { InventoryProvider } from './src/context/InventoryContext';
 import { ShoppingProvider } from './src/context/ShoppingContext';
+import RecipeBookScreen from './src/screens/RecipeBookScreen';
+import RecipeDetailScreen from './src/screens/RecipeDetailScreen';
+import { RecipeProvider } from './src/context/RecipeContext';
 import { StatusBar } from 'expo-status-bar';
 
 const Stack = createNativeStackNavigator();
@@ -13,21 +16,33 @@ export default function App() {
   return (
     <InventoryProvider>
       <ShoppingProvider>
-        <NavigationContainer>
-          <StatusBar style="auto" />
-          <Stack.Navigator>
-            <Stack.Screen
-              name="Inventory"
-              component={InventoryScreen}
-              options={{ title: 'Nevera' }}
-            />
-            <Stack.Screen
-              name="Shopping"
-              component={ShoppingListScreen}
-              options={{ title: 'Compras' }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <RecipeProvider>
+          <NavigationContainer>
+            <StatusBar style="auto" />
+            <Stack.Navigator>
+              <Stack.Screen
+                name="Inventory"
+                component={InventoryScreen}
+                options={{ title: 'Nevera' }}
+              />
+              <Stack.Screen
+                name="Shopping"
+                component={ShoppingListScreen}
+                options={{ title: 'Compras' }}
+              />
+              <Stack.Screen
+                name="Recipes"
+                component={RecipeBookScreen}
+                options={{ title: 'Recetario' }}
+              />
+              <Stack.Screen
+                name="RecipeDetail"
+                component={RecipeDetailScreen}
+                options={{ title: 'Receta' }}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </RecipeProvider>
       </ShoppingProvider>
     </InventoryProvider>
   );

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -1,0 +1,101 @@
+import React, {useState} from 'react';
+import {Modal, View, Text, TextInput, TouchableOpacity, ScrollView} from 'react-native';
+import FoodPickerModal from './FoodPickerModal';
+
+export default function AddRecipeModal({visible, onSave, onClose}) {
+  const [name, setName] = useState('');
+  const [image, setImage] = useState('');
+  const [persons, setPersons] = useState('1');
+  const [difficulty, setDifficulty] = useState('');
+  const [ingredients, setIngredients] = useState([]);
+  const [steps, setSteps] = useState('');
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  const addIngredient = foodName => {
+    setIngredients([...ingredients, {name: foodName, quantity: '1', unit: 'units'}]);
+    setPickerVisible(false);
+  };
+
+  const updateIngredient = (index, field, value) => {
+    setIngredients(ings => ings.map((ing, idx) => (idx === index ? {...ing, [field]: value} : ing)));
+  };
+
+  const save = () => {
+    onSave({
+      name,
+      image,
+      persons: parseInt(persons, 10) || 0,
+      difficulty,
+      steps,
+      ingredients: ingredients.map(ing => ({
+        name: ing.name,
+        quantity: parseFloat(ing.quantity) || 0,
+        unit: ing.unit,
+      })),
+    });
+    setName('');
+    setImage('');
+    setPersons('1');
+    setDifficulty('');
+    setSteps('');
+    setIngredients([]);
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{flex:1,padding:20}}>
+        <TouchableOpacity onPress={onClose} style={{marginBottom:10}}>
+          <Text style={{fontSize:24}}>←</Text>
+        </TouchableOpacity>
+        <ScrollView>
+          <Text>Nombre</Text>
+          <TextInput style={{borderWidth:1,marginBottom:10,padding:5}} value={name} onChangeText={setName} />
+          <Text>Foto (URL)</Text>
+          <TextInput style={{borderWidth:1,marginBottom:10,padding:5}} value={image} onChangeText={setImage} />
+          <Text>Personas</Text>
+          <TextInput keyboardType='numeric' style={{borderWidth:1,marginBottom:10,padding:5}} value={persons} onChangeText={setPersons} />
+          <Text>Dificultad</Text>
+          <TextInput style={{borderWidth:1,marginBottom:10,padding:5}} value={difficulty} onChangeText={setDifficulty} />
+          <Text>Ingredientes</Text>
+          {ingredients.map((ing, idx) => (
+            <View key={idx} style={{flexDirection:'row',alignItems:'center',marginBottom:5}}>
+              <Text style={{flex:1}}>{ing.name}</Text>
+              <TextInput
+                style={{borderWidth:1,width:60,marginHorizontal:5,padding:5}}
+                keyboardType='numeric'
+                value={ing.quantity}
+                onChangeText={t => updateIngredient(idx, 'quantity', t)}
+              />
+              <TextInput
+                style={{borderWidth:1,width:60,padding:5}}
+                value={ing.unit}
+                onChangeText={t => updateIngredient(idx, 'unit', t)}
+              />
+            </View>
+          ))}
+          <TouchableOpacity onPress={() => setPickerVisible(true)} style={{marginBottom:10}}>
+            <Text style={{color:'blue'}}>Añadir ingrediente</Text>
+          </TouchableOpacity>
+          <Text>Pasos</Text>
+          <TextInput
+            multiline
+            style={{borderWidth:1,marginBottom:10,padding:5,height:80}}
+            value={steps}
+            onChangeText={setSteps}
+          />
+          <TouchableOpacity
+            onPress={save}
+            style={{backgroundColor:'#2196f3',padding:10,borderRadius:6,alignSelf:'center'}}
+          >
+            <Text style={{color:'#fff'}}>Guardar</Text>
+          </TouchableOpacity>
+        </ScrollView>
+        <FoodPickerModal
+          visible={pickerVisible}
+          onSelect={addIngredient}
+          onClose={() => setPickerVisible(false)}
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/MiAppNevera/src/context/RecipeContext.js
+++ b/MiAppNevera/src/context/RecipeContext.js
@@ -1,0 +1,64 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {getFoodIcon} from '../foodIcons';
+
+const RecipeContext = createContext();
+
+export const RecipeProvider = ({children}) => {
+  const [recipes, setRecipes] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('recipes');
+        if (stored) {
+          setRecipes(JSON.parse(stored));
+        }
+      } catch (e) {
+        console.error('Failed to load recipes', e);
+      }
+    })();
+  }, []);
+
+  const persist = data => {
+    setRecipes(data);
+    AsyncStorage.setItem('recipes', JSON.stringify(data)).catch(e => {
+      console.error('Failed to save recipes', e);
+    });
+  };
+
+  const addRecipe = recipe => {
+    const withIcons = {
+      ...recipe,
+      ingredients: recipe.ingredients.map(ing => ({
+        ...ing,
+        icon: ing.icon || getFoodIcon(ing.name),
+      })),
+    };
+    persist([...recipes, withIcons]);
+  };
+
+  const updateRecipe = (index, recipe) => {
+    const withIcons = {
+      ...recipe,
+      ingredients: recipe.ingredients.map(ing => ({
+        ...ing,
+        icon: ing.icon || getFoodIcon(ing.name),
+      })),
+    };
+    const updated = recipes.map((r, idx) => (idx === index ? withIcons : r));
+    persist(updated);
+  };
+
+  const removeRecipe = index => {
+    persist(recipes.filter((_, idx) => idx !== index));
+  };
+
+  return (
+    <RecipeContext.Provider value={{recipes, addRecipe, updateRecipe, removeRecipe}}>
+      {children}
+    </RecipeContext.Provider>
+  );
+};
+
+export const useRecipes = () => useContext(RecipeContext);

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -93,6 +93,12 @@ export default function InventoryScreen({ navigation }) {
             <Text style={{ fontSize: 18 }}>🔍</Text>
           </TouchableOpacity>
           <TouchableOpacity
+            onPress={() => navigation.navigate('Recipes')}
+            style={{ marginRight: 15 }}
+          >
+            <Text style={{ fontSize: 18 }}>📖</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
             onPress={() => navigation.navigate('Shopping')}
             style={{ marginRight: 15 }}
           >

--- a/MiAppNevera/src/screens/RecipeBookScreen.js
+++ b/MiAppNevera/src/screens/RecipeBookScreen.js
@@ -1,0 +1,67 @@
+import React, {useLayoutEffect, useState} from 'react';
+import {View, Text, ScrollView, Image, TouchableOpacity} from 'react-native';
+import {useRecipes} from '../context/RecipeContext';
+import {useInventory} from '../context/InventoryContext';
+import AddRecipeModal from '../components/AddRecipeModal';
+
+export default function RecipeBookScreen({navigation}) {
+  const {recipes, addRecipe} = useRecipes();
+  const {inventory} = useInventory();
+  const [addVisible, setAddVisible] = useState(false);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity onPress={() => setAddVisible(true)}>
+          <Text style={{fontSize:24}}>＋</Text>
+        </TouchableOpacity>
+      ),
+      title: 'Recetario',
+    });
+  }, [navigation]);
+
+  const hasIngredients = recipe => {
+    return recipe.ingredients.every(ing => {
+      const available = ['fridge','freezer','pantry'].reduce((sum, loc) => {
+        const item = inventory[loc].find(it => it.name === ing.name);
+        return sum + (item ? item.quantity : 0);
+      },0);
+      return available >= ing.quantity;
+    });
+  };
+
+  return (
+    <View style={{flex:1,padding:10}}>
+      <ScrollView contentContainerStyle={{flexDirection:'row',flexWrap:'wrap'}}>
+        {recipes.map((rec, idx) => {
+          const enough = hasIngredients(rec);
+          return (
+            <TouchableOpacity
+              key={idx}
+              style={{width:'50%',padding:5,opacity:enough?1:0.5}}
+              onPress={() => navigation.navigate('RecipeDetail',{index: idx})}
+            >
+              {rec.image ? (
+                <Image source={{uri:rec.image}} style={{width:'100%',height:100}} />
+              ) : (
+                <View style={{width:'100%',height:100,backgroundColor:'#ccc',justifyContent:'center',alignItems:'center'}}>
+                  <Text>Sin imagen</Text>
+                </View>
+              )}
+              <Text style={{fontWeight:'bold'}}>{rec.name}</Text>
+              <Text>Para {rec.persons} personas</Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+      <AddRecipeModal
+        visible={addVisible}
+        onSave={recipe => {
+          addRecipe(recipe);
+          setAddVisible(false);
+        }}
+        onClose={() => setAddVisible(false)}
+      />
+    </View>
+  );
+}

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -1,0 +1,62 @@
+import React, {useLayoutEffect} from 'react';
+import {View, Text, Image, ScrollView, TouchableOpacity} from 'react-native';
+import {useRecipes} from '../context/RecipeContext';
+import {useInventory} from '../context/InventoryContext';
+import {useShopping} from '../context/ShoppingContext';
+
+export default function RecipeDetailScreen({route, navigation}) {
+  const {index} = route.params;
+  const {recipes} = useRecipes();
+  const {inventory} = useInventory();
+  const {addItems} = useShopping();
+  const recipe = recipes[index];
+
+  const missing = recipe ? recipe.ingredients.filter(ing => {
+    const available = ['fridge','freezer','pantry'].reduce((sum, loc) => {
+      const item = inventory[loc].find(it => it.name === ing.name);
+      return sum + (item ? item.quantity : 0);
+    },0);
+    return available < ing.quantity;
+  }) : [];
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => {
+            const items = missing.map(ing => ({name: ing.name, quantity: ing.quantity, unit: ing.unit}));
+            if (items.length > 0) addItems(items);
+          }}
+        >
+          <Text style={{fontSize:24}}>🛒</Text>
+        </TouchableOpacity>
+      ),
+      title: recipe ? recipe.name : 'Receta',
+    });
+  }, [navigation, missing, recipe]);
+
+  if (!recipe) {
+    return (
+      <View style={{flex:1,justifyContent:'center',alignItems:'center'}}>
+        <Text>Receta no encontrada</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={{padding:20}}>
+      {recipe.image ? (
+        <Image source={{uri:recipe.image}} style={{width:'100%',height:200,marginBottom:10}} />
+      ) : null}
+      <Text style={{fontSize:24,fontWeight:'bold'}}>{recipe.name}</Text>
+      <Text>Para {recipe.persons} personas</Text>
+      <Text>Dificultad: {recipe.difficulty}</Text>
+      <Text style={{marginTop:10,fontWeight:'bold'}}>Ingredientes</Text>
+      {recipe.ingredients.map((ing, idx) => (
+        <Text key={idx}>- {ing.quantity} {ing.unit} {ing.name}</Text>
+      ))}
+      <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
+      <Text>{recipe.steps}</Text>
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
## Summary
- add recipe book context and screens for managing recipes
- insert recipe book button on inventory screen header
- allow adding recipes, viewing details, and sending missing ingredients to shopping list

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898f46915b4832486fa62654f7b966b