### PR TITLE
Display ingredient icons in recipe details

### DIFF
--- a/MiAppNevera/src/context/RecipeContext.js
+++ b/MiAppNevera/src/context/RecipeContext.js
@@ -12,7 +12,18 @@ export const RecipeProvider = ({children}) => {
       try {
         const stored = await AsyncStorage.getItem('recipes');
         if (stored) {
-          setRecipes(JSON.parse(stored));
+          const data = JSON.parse(stored);
+          const withIcons = data.map(rec => ({
+            ...rec,
+            ingredients: rec.ingredients.map(ing => ({
+              ...ing,
+              icon: ing.icon || getFoodIcon(ing.name),
+            })),
+          }));
+          setRecipes(withIcons);
+          AsyncStorage.setItem('recipes', JSON.stringify(withIcons)).catch(e => {
+            console.error('Failed to save recipes', e);
+          });
         }
       } catch (e) {
         console.error('Failed to load recipes', e);

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -4,6 +4,7 @@ import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';
 import AddRecipeModal from '../components/AddRecipeModal';
+import {getFoodIcon} from '../foodIcons';
 
 export default function RecipeDetailScreen({route, navigation}) {
   const {index} = route.params;
@@ -67,7 +68,15 @@ export default function RecipeDetailScreen({route, navigation}) {
         <Text>Dificultad: {recipe.difficulty}</Text>
         <Text style={{marginTop:10,fontWeight:'bold'}}>Ingredientes</Text>
         {recipe.ingredients.map((ing, idx) => (
-          <Text key={idx}>- {ing.quantity} {ing.unit} {ing.name}</Text>
+          <View key={idx} style={{flexDirection:'row',alignItems:'center'}}>
+            { (ing.icon || getFoodIcon(ing.name)) ? (
+              <Image
+                source={ing.icon || getFoodIcon(ing.name)}
+                style={{width:20,height:20,marginRight:5}}
+              />
+            ) : null }
+            <Text>{ing.quantity} {ing.unit} {ing.name}</Text>
+          </View>
         ))}
         <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
         <Text>{recipe.steps}</Text>


### PR DESCRIPTION
## Summary
- Show ingredient icons alongside names in recipe details
- Ensure stored recipes populate missing ingredient icons on load

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899075a3df483249e9054c23225a4e0