### PR TITLE
Integrate Quill editor for recipe notes

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -20,8 +20,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-cn-quill": "^0.7.20",
     "react-native-safe-area-context": "4.10.5",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "react-native-webview": "^13.15.0"
   }
 }

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import {
   Modal,
   View,
@@ -10,6 +10,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
+import QuillEditor, {QuillToolbar} from 'react-native-cn-quill';
 import FoodPickerModal from './FoodPickerModal';
 import {getFoodIcon} from '../foodIcons';
 
@@ -30,6 +31,7 @@ export default function AddRecipeModal({
   const [selected, setSelected] = useState([]);
   const [unitPickerVisible, setUnitPickerVisible] = useState(false);
   const [unitPickerIndex, setUnitPickerIndex] = useState(null);
+  const editorRef = useRef(null);
 
   useEffect(() => {
     if (visible && initialRecipe) {
@@ -123,13 +125,14 @@ export default function AddRecipeModal({
     setUnitPickerIndex(null);
   };
 
-  const save = () => {
+  const save = async () => {
+    const html = (await editorRef.current?.getHtml()) || steps;
     onSave({
       name,
       image,
       persons: parseInt(persons, 10) || 0,
       difficulty,
-      steps,
+      steps: html,
       ingredients: ingredients.map(ing => ({
         name: ing.name,
         quantity: parseFloat(ing.quantity) || 0,
@@ -301,14 +304,16 @@ export default function AddRecipeModal({
           <TouchableOpacity onPress={() => setPickerVisible(true)} style={{marginBottom:10}}>
             <Text style={{color:'blue'}}>Añadir ingrediente</Text>
           </TouchableOpacity>
-          <Text>Pasos (admite Markdown)</Text>
-          <TextInput
-            multiline
-            placeholder="Usa **negrita**, - listas, 1. enumeraciones"
-            style={{borderWidth:1,marginBottom:10,padding:5,height:80}}
-            value={steps}
-            onChangeText={setSteps}
-          />
+          <Text>Pasos</Text>
+          <View style={{height:200,marginBottom:10}}>
+            <QuillEditor
+              ref={editorRef}
+              initialHtml={steps}
+              onHtmlChange={d => setSteps(d.html)}
+              style={{flex:1,borderWidth:1}}
+            />
+          </View>
+          <QuillToolbar editor={editorRef} options="full" theme="light" />
           <TouchableOpacity
             onPress={save}
             style={{backgroundColor:'#2196f3',padding:10,borderRadius:6,alignSelf:'center'}}

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -9,7 +9,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
-import Markdown from 'react-native-markdown-display';
+import QuillEditor from 'react-native-cn-quill';
 import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';
@@ -115,7 +115,9 @@ export default function RecipeDetailScreen({route, navigation}) {
           </View>
         ))}
         <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
-        <Markdown>{recipe.steps}</Markdown>
+        <View style={{minHeight:100,marginTop:5}}>
+          <QuillEditor initialHtml={recipe.steps} readonly style={{flex:1}} />
+        </View>
       </ScrollView>
       <AddRecipeModal
         visible={editVisible}


### PR DESCRIPTION
## Summary
- replace markdown notes with react-native-cn-quill editor
- render recipe steps using read-only Quill
- add Quill and webview dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6899217913488324a87c26aaae266e9c