### PR TITLE
Integrate Quill editor for recipe notes

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -20,8 +20,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-cn-quill": "^0.7.20",
     "react-native-safe-area-context": "4.10.5",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "react-native-webview": "^13.15.0"
   }
 }

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -8,13 +8,18 @@ import {
   Modal,
   Button,
   TouchableWithoutFeedback,
+  Platform,
 } from 'react-native';
-import Markdown from 'react-native-markdown-display';
 import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';
 import AddRecipeModal from '../components/AddRecipeModal';
 import {getFoodIcon, getFoodCategory, categories} from '../foodIcons';
+
+let QuillEditor = null;
+if (Platform.OS !== 'web') {
+  QuillEditor = require('react-native-cn-quill').default;
+}
 
 export default function RecipeDetailScreen({route, navigation}) {
   const {index} = route.params;
@@ -115,7 +120,15 @@ export default function RecipeDetailScreen({route, navigation}) {
           </View>
         ))}
         <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
-        <Markdown>{recipe.steps}</Markdown>
+        {Platform.OS === 'web' ? (
+          <Text style={{marginTop:5}}>
+            {recipe.steps.replace(/<[^>]+>/g, '')}
+          </Text>
+        ) : (
+          <View style={{minHeight:100,marginTop:5}}>
+            <QuillEditor initialHtml={recipe.steps} readonly style={{flex:1}} />
+          </View>
+        )}
       </ScrollView>
       <AddRecipeModal
         visible={editVisible}


### PR DESCRIPTION
## Summary
- load Quill only on platforms that support WebView and fall back to simple inputs elsewhere
- render recipe steps as plain text on web when Quill is unavailable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6899217913488324a87c26aaae266e9c