### PR TITLE
feat: soporte web para notas de recetas

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -23,6 +23,7 @@
     "react-native-cn-quill": "^0.7.20",
     "react-native-safe-area-context": "4.10.5",
     "react-native-web": "~0.19.6",
-    "react-native-webview": "^13.15.0"
+    "react-native-webview": "^13.15.0",
+    "react-quill": "^2.0.0"
   }
 }

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -10,7 +10,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
-import QuillEditor, {QuillToolbar} from 'react-native-cn-quill';
+import QuillEditor, {QuillToolbar} from './QuillEditor';
 import FoodPickerModal from './FoodPickerModal';
 import {getFoodIcon} from '../foodIcons';
 

--- a/MiAppNevera/src/components/QuillEditor.js
+++ b/MiAppNevera/src/components/QuillEditor.js
@@ -1,0 +1,52 @@
+import React, {forwardRef, useRef, useImperativeHandle} from 'react';
+import {Platform, View} from 'react-native';
+
+let NativeEditor; let NativeToolbar;
+if (Platform.OS !== 'web') {
+  const rnq = require('react-native-cn-quill');
+  NativeEditor = rnq.default;
+  NativeToolbar = rnq.QuillToolbar;
+}
+
+const QuillEditor = forwardRef(({initialHtml, onHtmlChange, style, readonly, ...props}, ref) => {
+  if (Platform.OS === 'web') {
+    const ReactQuill = require('react-quill');
+    const webRef = useRef(null);
+    useImperativeHandle(ref, () => ({
+      getHtml: async () => webRef.current ? webRef.current.getEditor().root.innerHTML : '',
+    }));
+    return (
+      <View style={style}>
+        <ReactQuill
+          ref={webRef}
+          readOnly={readonly}
+          defaultValue={initialHtml}
+          onChange={html => onHtmlChange && onHtmlChange({html})}
+          theme="snow"
+          style={{height: '100%', width: '100%'}}
+        />
+      </View>
+    );
+  }
+  const nativeRef = useRef(null);
+  useImperativeHandle(ref, () => ({
+    getHtml: () => nativeRef.current?.getHtml(),
+  }));
+  return (
+    <NativeEditor
+      ref={nativeRef}
+      initialHtml={initialHtml}
+      onHtmlChange={onHtmlChange}
+      style={style}
+      readonly={readonly}
+      {...props}
+    />
+  );
+});
+
+export const QuillToolbar = props => {
+  if (Platform.OS === 'web') return null;
+  return <NativeToolbar {...props} />;
+};
+
+export default QuillEditor;

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -9,7 +9,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
-import QuillEditor from 'react-native-cn-quill';
+import QuillEditor from '../components/QuillEditor';
 import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';


### PR DESCRIPTION
## Summary
- agregar wrapper `QuillEditor` que usa `react-quill` en web y `react-native-cn-quill` en móvil
- usar el nuevo editor en AddRecipeModal y RecipeDetailScreen
- añadir dependencia `react-quill`

## Testing
- `npm test` (falla: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68992b74997c8324944234bbcc1ef548