### PR TITLE
feat: add rich text editor for recipe notes

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -20,8 +20,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-pell-rich-editor": "^1.10.0",
     "react-native-safe-area-context": "4.10.5",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "react-native-webview": "^13.15.0"
   }
 }

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 import {
   Modal,
   View,
@@ -9,7 +9,13 @@ import {
   Image,
   Button,
   TouchableWithoutFeedback,
+  Platform,
 } from 'react-native';
+import {
+  RichEditor,
+  RichToolbar,
+  actions,
+} from 'react-native-pell-rich-editor';
 import FoodPickerModal from './FoodPickerModal';
 import {getFoodIcon} from '../foodIcons';
 
@@ -30,6 +36,7 @@ export default function AddRecipeModal({
   const [selected, setSelected] = useState([]);
   const [unitPickerVisible, setUnitPickerVisible] = useState(false);
   const [unitPickerIndex, setUnitPickerIndex] = useState(null);
+  const richText = useRef(null);
 
   useEffect(() => {
     if (visible && initialRecipe) {
@@ -301,14 +308,35 @@ export default function AddRecipeModal({
           <TouchableOpacity onPress={() => setPickerVisible(true)} style={{marginBottom:10}}>
             <Text style={{color:'blue'}}>Añadir ingrediente</Text>
           </TouchableOpacity>
-          <Text>Pasos (admite Markdown)</Text>
-          <TextInput
-            multiline
-            placeholder="Usa **negrita**, - listas, 1. enumeraciones"
-            style={{borderWidth:1,marginBottom:10,padding:5,height:80}}
-            value={steps}
-            onChangeText={setSteps}
-          />
+          <Text>Pasos</Text>
+          {Platform.OS === 'web' ? (
+            <TextInput
+              multiline
+              placeholder="Escribe los pasos"
+              style={{borderWidth:1,marginBottom:10,padding:5,height:150}}
+              value={steps}
+              onChangeText={setSteps}
+            />
+          ) : (
+            <>
+              <RichEditor
+                ref={richText}
+                style={{borderWidth:1,marginBottom:10,minHeight:150}}
+                placeholder="Escribe los pasos"
+                initialContentHTML={steps}
+                onChange={setSteps}
+              />
+              <RichToolbar
+                editor={richText}
+                actions={[
+                  actions.setBold,
+                  actions.setItalic,
+                  actions.insertBulletsList,
+                  actions.insertOrderedList,
+                ]}
+              />
+            </>
+          )}
           <TouchableOpacity
             onPress={save}
             style={{backgroundColor:'#2196f3',padding:10,borderRadius:6,alignSelf:'center'}}

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -8,8 +8,9 @@ import {
   Modal,
   Button,
   TouchableWithoutFeedback,
+  Platform,
 } from 'react-native';
-import Markdown from 'react-native-markdown-display';
+import {RichEditor} from 'react-native-pell-rich-editor';
 import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';
@@ -115,7 +116,15 @@ export default function RecipeDetailScreen({route, navigation}) {
           </View>
         ))}
         <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
-        <Markdown>{recipe.steps}</Markdown>
+        {Platform.OS === 'web' ? (
+          <div dangerouslySetInnerHTML={{__html: recipe.steps}} />
+        ) : (
+          <RichEditor
+            initialContentHTML={recipe.steps}
+            disabled
+            editorStyle={{backgroundColor: 'transparent'}}
+          />
+        )}
       </ScrollView>
       <AddRecipeModal
         visible={editVisible}


### PR DESCRIPTION
## Summary
- integrate react-native-pell-rich-editor for recipe notes
- display rich text content and provide web-safe fallbacks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68993303390c83249cb4f1c025b9ccc6