### PR TITLE
feat: enhance recipe notes with rich text editor

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -20,8 +20,12 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-markdown-display": "^7.0.2",
+    "react-native-quill-editor": "^0.2.0",
+    "react-native-webview": "^13.15.0",
     "react-native-safe-area-context": "4.10.5",
     "react-native-web": "~0.19.6"
+  },
+  "devDependencies": {
+    "cpy-cli": "^5.0.0"
   }
 }

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -10,6 +10,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
+import QuillEditor from 'react-native-quill-editor';
 import FoodPickerModal from './FoodPickerModal';
 import {getFoodIcon} from '../foodIcons';
 
@@ -301,14 +302,16 @@ export default function AddRecipeModal({
           <TouchableOpacity onPress={() => setPickerVisible(true)} style={{marginBottom:10}}>
             <Text style={{color:'blue'}}>Añadir ingrediente</Text>
           </TouchableOpacity>
-          <Text>Pasos (admite Markdown)</Text>
-          <TextInput
-            multiline
-            placeholder="Usa **negrita**, - listas, 1. enumeraciones"
-            style={{borderWidth:1,marginBottom:10,padding:5,height:80}}
-            value={steps}
-            onChangeText={setSteps}
-          />
+          <Text>Pasos</Text>
+          <View style={{height:200,marginBottom:10}}>
+            <QuillEditor
+              key={visible ? 'visible' : 'hidden'}
+              defaultValue={steps}
+              onChange={setSteps}
+              style={{height:200}}
+              options={{placeholder:'Escribe los pasos...'}}
+            />
+          </View>
           <TouchableOpacity
             onPress={save}
             style={{backgroundColor:'#2196f3',padding:10,borderRadius:6,alignSelf:'center'}}

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -9,7 +9,7 @@ import {
   Button,
   TouchableWithoutFeedback,
 } from 'react-native';
-import Markdown from 'react-native-markdown-display';
+import {WebView} from 'react-native-webview';
 import {useRecipes} from '../context/RecipeContext';
 import {useInventory} from '../context/InventoryContext';
 import {useShopping} from '../context/ShoppingContext';
@@ -115,7 +115,10 @@ export default function RecipeDetailScreen({route, navigation}) {
           </View>
         ))}
         <Text style={{marginTop:10,fontWeight:'bold'}}>Pasos</Text>
-        <Markdown>{recipe.steps}</Markdown>
+        <WebView
+          source={{html: recipe.steps}}
+          style={{height:200, marginTop:5}}
+        />
       </ScrollView>
       <AddRecipeModal
         visible={editVisible}


### PR DESCRIPTION
## Summary
- replace markdown steps input with Quill rich text editor
- render saved steps with WebView for cross-platform display
- add rich text editor and WebView dependencies

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689935829ff88324a964147ecaf16427