### PR TITLE
fix: confirm location deletion and show missing ingredient details

### DIFF
--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -173,7 +173,9 @@ export default function RecipeDetailScreen({route, navigation}) {
                         style={{width: 20, height: 20, marginRight: 5}}
                       />
                     )}
-                    <Text>- {ing.name}</Text>
+                    <Text>
+                      - {ing.quantity} {getLabel(ing.quantity, ing.unit)} de {ing.name}
+                    </Text>
                   </View>
                 ))}
                 <View


### PR DESCRIPTION
## Summary
- add custom modal to confirm or block deleting locations
- display quantity and unit for missing ingredients when adding to shopping list

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68997034161c8324ae81e616f1f0e2bd