### PR TITLE
Enable image uploads and custom foods

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -14,19 +14,21 @@ import LocationSettingsScreen from './src/screens/LocationSettingsScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
+import { CustomFoodsProvider } from './src/context/CustomFoodsContext';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <UnitsProvider>
-      <LocationsProvider>
-        <InventoryProvider>
-          <ShoppingProvider>
-            <RecipeProvider>
-              <NavigationContainer>
-                <StatusBar style="auto" />
-                <Stack.Navigator>
+    <CustomFoodsProvider>
+      <UnitsProvider>
+        <LocationsProvider>
+          <InventoryProvider>
+            <ShoppingProvider>
+              <RecipeProvider>
+                <NavigationContainer>
+                  <StatusBar style="auto" />
+                  <Stack.Navigator>
                   <Stack.Screen
                     name="Inventory"
                     component={InventoryScreen}
@@ -62,12 +64,13 @@ export default function App() {
                     component={LocationSettingsScreen}
                     options={{ title: 'Gestión de ubicación' }}
                   />
-                </Stack.Navigator>
-              </NavigationContainer>
-            </RecipeProvider>
-          </ShoppingProvider>
-        </InventoryProvider>
-      </LocationsProvider>
-    </UnitsProvider>
+                  </Stack.Navigator>
+                </NavigationContainer>
+              </RecipeProvider>
+            </ShoppingProvider>
+          </InventoryProvider>
+        </LocationsProvider>
+      </UnitsProvider>
+    </CustomFoodsProvider>
   );
 }

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "^51.0.0",
+    "expo-image-picker": "~15.0.6",
     "expo-splash-screen": "~0.27.7",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",

--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TextInput, TouchableOpacity, Image, ScrollView, Button } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import FoodPickerModal from './FoodPickerModal';
+import { categories, getFoodIcon } from '../foodIcons';
+import { useCustomFoods } from '../context/CustomFoodsContext';
+
+export default function AddCustomFoodModal({ visible, onClose }) {
+  const { addCustomFood } = useCustomFoods();
+  const categoryNames = Object.keys(categories);
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState(categoryNames[0]);
+  const [iconUri, setIconUri] = useState(null);
+  const [baseIcon, setBaseIcon] = useState(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      setIconUri(result.assets[0].uri);
+      setBaseIcon(null);
+    }
+  };
+
+  const selectDefault = (foodName) => {
+    setBaseIcon(foodName);
+    setIconUri(null);
+    setPickerVisible(false);
+  };
+
+  const save = () => {
+    if (!name) return;
+    addCustomFood({ name, category, icon: iconUri, baseIcon });
+    setName('');
+    setCategory(categoryNames[0]);
+    setIconUri(null);
+    setBaseIcon(null);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex:1, padding:20 }}>
+        <TouchableOpacity onPress={onClose} style={{ marginBottom:10 }}>
+          <Text style={{ fontSize:24 }}>←</Text>
+        </TouchableOpacity>
+        <ScrollView>
+          <Text>Nombre</Text>
+          <TextInput
+            style={{ borderWidth:1, marginBottom:10, padding:5 }}
+            value={name}
+            onChangeText={setName}
+          />
+          <Text>Categoría</Text>
+          <View style={{ flexDirection:'row', flexWrap:'wrap', marginBottom:10 }}>
+            {categoryNames.map(cat => (
+              <TouchableOpacity
+                key={cat}
+                onPress={() => setCategory(cat)}
+                style={{
+                  padding:5,
+                  borderWidth:1,
+                  borderColor:'#ccc',
+                  marginRight:5,
+                  marginBottom:5,
+                  backgroundColor: category === cat ? '#ddd' : '#fff',
+                }}
+              >
+                <Text>{cat}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text>Icono</Text>
+          {(iconUri || baseIcon) && (
+            <Image
+              source={iconUri ? { uri: iconUri } : getFoodIcon(baseIcon)}
+              style={{ width:60, height:60, marginBottom:10 }}
+            />
+          )}
+          <View style={{ flexDirection:'row', marginBottom:10 }}>
+            <Button title="Predeterminado" onPress={() => setPickerVisible(true)} />
+            <View style={{ width:10 }} />
+            <Button title="Cargar" onPress={pickImage} />
+          </View>
+        </ScrollView>
+        <TouchableOpacity
+          onPress={save}
+          style={{
+            position:'absolute',
+            bottom:20,
+            alignSelf:'center',
+            backgroundColor:'#2196f3',
+            paddingVertical:10,
+            paddingHorizontal:20,
+            borderRadius:6,
+          }}
+        >
+          <Text style={{ color:'#fff', fontSize:16 }}>Guardar</Text>
+        </TouchableOpacity>
+        <FoodPickerModal
+          visible={pickerVisible}
+          onSelect={selectDefault}
+          onClose={() => setPickerVisible(false)}
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -13,6 +13,7 @@ import {
 import FoodPickerModal from './FoodPickerModal';
 import {getFoodIcon} from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
+import * as ImagePicker from 'expo-image-picker';
 
 export default function AddRecipeModal({
   visible,
@@ -32,6 +33,16 @@ export default function AddRecipeModal({
   const [selected, setSelected] = useState([]);
   const [unitPickerVisible, setUnitPickerVisible] = useState(false);
   const [unitPickerIndex, setUnitPickerIndex] = useState(null);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      setImage(result.assets[0].uri);
+    }
+  };
 
   useEffect(() => {
     if (visible && initialRecipe) {
@@ -62,10 +73,10 @@ export default function AddRecipeModal({
     }
   }, [visible, initialRecipe]);
 
-  const addIngredient = foodName => {
+  const addIngredient = (foodName, foodIcon) => {
     setIngredients([
       ...ingredients,
-      {name: foodName, quantity: '1', unit: units[0]?.key || 'units', icon: getFoodIcon(foodName)},
+      {name: foodName, quantity: '1', unit: units[0]?.key || 'units', icon: foodIcon || getFoodIcon(foodName)},
     ]);
     setPickerVisible(false);
   };
@@ -150,8 +161,17 @@ export default function AddRecipeModal({
         <ScrollView>
           <Text>Nombre</Text>
           <TextInput style={{borderWidth:1,marginBottom:10,padding:5}} value={name} onChangeText={setName} />
-          <Text>Foto (URL)</Text>
-          <TextInput style={{borderWidth:1,marginBottom:10,padding:5}} value={image} onChangeText={setImage} />
+          <Text>Foto</Text>
+          {image ? (
+            <Image source={{uri:image}} style={{width:'100%',height:200,marginBottom:10}} />
+          ) : null}
+          <Button title="Seleccionar imagen" onPress={pickImage} />
+          <TextInput
+            style={{borderWidth:1,marginVertical:10,padding:5}}
+            placeholder="o URL"
+            value={image}
+            onChangeText={setImage}
+          />
           <Text>Personas</Text>
           <View style={{flexDirection:'row',alignItems:'center',marginBottom:10}}>
             <TouchableOpacity

--- a/MiAppNevera/src/context/CustomFoodsContext.js
+++ b/MiAppNevera/src/context/CustomFoodsContext.js
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { normalizeFoodName, setCustomFoodsMap } from '../foodIcons';
+
+const CustomFoodsContext = createContext();
+
+export const CustomFoodsProvider = ({ children }) => {
+  const [customFoods, setCustomFoods] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('customFoods');
+        const parsed = stored ? JSON.parse(stored) : [];
+        setCustomFoods(parsed);
+        setCustomFoodsMap(parsed);
+      } catch (e) {
+        console.error('Failed to load custom foods', e);
+      }
+    })();
+  }, []);
+
+  const persist = data => {
+    setCustomFoods(data);
+    AsyncStorage.setItem('customFoods', JSON.stringify(data)).catch(e => {
+      console.error('Failed to save custom foods', e);
+    });
+    setCustomFoodsMap(data);
+  };
+
+  const addCustomFood = ({ name, category, icon, baseIcon }) => {
+    const key = normalizeFoodName(name);
+    const newFood = { name, category, icon: icon || null, baseIcon: baseIcon || null, key };
+    persist([...customFoods, newFood]);
+  };
+
+  return (
+    <CustomFoodsContext.Provider value={{ customFoods, addCustomFood }}>
+      {children}
+    </CustomFoodsContext.Provider>
+  );
+};
+
+export const useCustomFoods = () => useContext(CustomFoodsContext);
+

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -3,11 +3,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import foods from '../../assets/foods.json';
 import {getFoodIcon, getFoodCategory} from '../foodIcons';
 import { useLocations } from './LocationsContext';
+import { useCustomFoods } from './CustomFoodsContext';
 
 const InventoryContext = createContext();
 
 export const InventoryProvider = ({children}) => {
   const { locations } = useLocations();
+  const { customFoods } = useCustomFoods();
 
   const buildEmpty = () => {
     const obj = {};
@@ -45,7 +47,7 @@ export const InventoryProvider = ({children}) => {
         console.error('Failed to load inventory', e);
       }
     })();
-  }, [locations]);
+  }, [locations, customFoods]);
 
   useEffect(() => {
     setInventory(prev => {

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -1,11 +1,13 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {getFoodIcon, getFoodCategory} from '../foodIcons';
+import { useCustomFoods } from './CustomFoodsContext';
 
 const ShoppingContext = createContext();
 
 export const ShoppingProvider = ({children}) => {
   const [list, setList] = useState([]);
+  const { customFoods } = useCustomFoods();
 
   useEffect(() => {
     (async () => {
@@ -23,7 +25,7 @@ export const ShoppingProvider = ({children}) => {
         console.error('Failed to load shopping list', e);
       }
     })();
-  }, []);
+  }, [customFoods]);
 
   const persist = async (data) => {
     setList(data);

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -250,16 +250,35 @@ export const categories = {
   },
 };
 
+let customIconMap = {};
+let customCategoryMap = {};
+
+export function setCustomFoodsMap(foods) {
+  customIconMap = {};
+  customCategoryMap = {};
+  foods.forEach(f => {
+    customCategoryMap[f.key] = f.category;
+    if (f.icon) {
+      customIconMap[f.key] = { uri: f.icon };
+    } else if (f.baseIcon) {
+      const baseKey = normalizeFoodName(f.baseIcon);
+      customIconMap[f.key] = foodIcons[baseKey];
+    }
+  });
+}
+
 export function normalizeFoodName(name) {
   return name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]/g, '');
 }
 
 export function getFoodIcon(name) {
-  return foodIcons[normalizeFoodName(name)];
+  const key = normalizeFoodName(name);
+  return customIconMap[key] || foodIcons[key];
 }
 
 export function getFoodCategory(name) {
   const normalized = normalizeFoodName(name);
+  if (customCategoryMap[normalized]) return customCategoryMap[normalized];
   for (const [cat, data] of Object.entries(categories)) {
     if (data.items.includes(normalized)) {
       return cat;

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -171,8 +171,8 @@ export default function InventoryScreen({ navigation }) {
     groupOrder = ['all'];
   }
 
-  const onSelectFood = name => {
-    setSelectedFood({ name, icon: getFoodIcon(name) });
+  const onSelectFood = (name, icon) => {
+    setSelectedFood({ name, icon });
     setPickerVisible(false);
     setAddVisible(true);
   };

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -39,8 +39,8 @@ export default function ShoppingListScreen() {
   const [batchVisible, setBatchVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
 
-  const onSelectFood = name => {
-    setSelectedFood({name, icon: getFoodIcon(name)});
+  const onSelectFood = (name, icon) => {
+    setSelectedFood({name, icon});
     setPickerVisible(false);
     setAddVisible(true);
   };


### PR DESCRIPTION
## Summary
- allow recipe images to be selected from the device or a URL
- let users create custom foods with their own category and icon
- support custom food icons/categories across inventory and shopping lists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a4cfb30dc8324a60a7f285f2d08fa