### PR TITLE
Mejoras en recetarios e ingredientes personalizados

### DIFF
--- a/MiAppNevera/src/context/CustomFoodsContext.js
+++ b/MiAppNevera/src/context/CustomFoodsContext.js
@@ -34,8 +34,20 @@ export const CustomFoodsProvider = ({ children }) => {
     persist([...customFoods, newFood]);
   };
 
+  const updateCustomFood = (key, { name, category, icon, baseIcon }) => {
+    const newKey = normalizeFoodName(name);
+    const updated = customFoods.map(f =>
+      f.key === key ? { name, category, icon: icon || null, baseIcon: baseIcon || null, key: newKey } : f,
+    );
+    persist(updated);
+  };
+
+  const removeCustomFood = key => {
+    persist(customFoods.filter(f => f.key !== key));
+  };
+
   return (
-    <CustomFoodsContext.Provider value={{ customFoods, addCustomFood }}>
+    <CustomFoodsContext.Provider value={{ customFoods, addCustomFood, updateCustomFood, removeCustomFood }}>
       {children}
     </CustomFoodsContext.Provider>
   );

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -92,7 +92,7 @@ export default function RecipeDetailScreen({route, navigation}) {
         {recipe.image ? (
           <Image
             source={{uri:recipe.image}}
-            style={{width:'100%',aspectRatio:16/9,marginBottom:10}}
+            style={{width:'80%',aspectRatio:16/9,marginBottom:10,alignSelf:'center'}}
             resizeMode="cover"
           />
         ) : null}


### PR DESCRIPTION
## Resumen
- Ajustada la imagen de detalle de recetas para que se muestre más pequeña.
- Añadido mensaje explicativo y botón para gestionar ingredientes personalizados.
- Soporte para editar y eliminar ingredientes personalizados.

## Pruebas
- `npm test` *(falla: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a80ff87e08324a45e48d44cf8dd09