### PR TITLE
Add calendar date pickers for item registration and expiration

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -21,6 +21,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
+    "@react-native-community/datetimepicker": "^7.6.1",
     "react-native-markdown-display": "^7.0.2",
     "react-native-safe-area-context": "4.10.5",
     "react-native-web": "~0.19.6"

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -11,6 +11,7 @@ import {
 import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DateInput from './DateInput';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -146,18 +147,16 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
           ))}
         </View>
         <Text>Fecha de registro</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
+        <DateInput
           value={regDate}
-          onChangeText={setRegDate}
+          onChange={setRegDate}
+          style={{ marginBottom: 10 }}
         />
         <Text>Fecha de caducidad</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
+        <DateInput
           value={expDate}
-          onChangeText={setExpDate}
+          onChange={setExpDate}
+          style={{ marginBottom: 10 }}
         />
         <Text>Nota</Text>
         <TextInput

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DateInput from './DateInput';
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -146,18 +147,16 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
               ))}
             </View>
             <Text>Fecha de registro</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
+            <DateInput
               value={data[idx]?.regDate}
-              onChangeText={t => updateField(idx, 'regDate', t)}
+              onChange={date => updateField(idx, 'regDate', date)}
+              style={{ marginBottom: 10 }}
             />
             <Text>Fecha de caducidad</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
+            <DateInput
               value={data[idx]?.expDate}
-              onChangeText={t => updateField(idx, 'expDate', t)}
+              onChange={date => updateField(idx, 'expDate', date)}
+              style={{ marginBottom: 10 }}
             />
             <Text>Nota</Text>
             <TextInput

--- a/MiAppNevera/src/components/DateInput.js
+++ b/MiAppNevera/src/components/DateInput.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { TouchableOpacity, Text, Platform } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+export default function DateInput({ value, onChange, placeholder = 'YYYY-MM-DD', style }) {
+  const [show, setShow] = useState(false);
+
+  const dateValue = value ? new Date(value) : new Date();
+
+  const handleChange = (event, selectedDate) => {
+    setShow(false);
+    if (event.type === 'set' && selectedDate) {
+      const formatted = selectedDate.toISOString().split('T')[0];
+      onChange(formatted);
+    }
+  };
+
+  return (
+    <>
+      <TouchableOpacity onPress={() => setShow(true)} style={[{ borderWidth: 1, padding: 5, marginBottom: 10 }, style]}>
+        <Text style={{ color: value ? '#000' : '#888' }}>{value || placeholder}</Text>
+      </TouchableOpacity>
+      {show && (
+        <DateTimePicker
+          value={dateValue}
+          mode="date"
+          display={Platform.OS === 'android' ? 'calendar' : Platform.OS === 'ios' ? 'inline' : 'default'}
+          onChange={handleChange}
+        />
+      )}
+    </>
+  );
+}
+

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -12,6 +12,7 @@ import { useShopping } from '../context/ShoppingContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DateInput from './DateInput';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
   const { addItem: addShoppingItem } = useShopping();
@@ -162,18 +163,16 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             ))}
           </View>
           <Text>Fecha de registro</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
+          <DateInput
             value={regDate}
-            onChangeText={setRegDate}
+            onChange={setRegDate}
+            style={{ marginBottom: 10 }}
           />
           <Text>Fecha de caducidad</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
+          <DateInput
             value={expDate}
-            onChangeText={setExpDate}
+            onChange={setExpDate}
+            style={{ marginBottom: 10 }}
           />
           <Text>Nota</Text>
           <TextInput


### PR DESCRIPTION
## Summary
- add reusable `DateInput` that opens a mini calendar highlighting today
- use the new picker for registration/expiration dates in add/edit/batch item modals
- include `@react-native-community/datetimepicker` dependency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b906b0cb483248d0289859c916d43