### PR TITLE
Use cross-platform date pickers for item forms

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -8,7 +8,7 @@ import {
   Image,
   Alert,
 } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateInput from './DateInput';
 import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
@@ -23,8 +23,6 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const [regDate, setRegDate] = useState(today);
   const [expDate, setExpDate] = useState('');
   const [note, setNote] = useState('');
-  const [showRegPicker, setShowRegPicker] = useState(false);
-  const [showExpPicker, setShowExpPicker] = useState(false);
 
   const {addItem: addShoppingItem} = useShopping();
 
@@ -39,19 +37,6 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
     }
   }, [visible, initialLocation, today, units, locations]);
 
-  const handleRegChange = (event, selectedDate) => {
-    setShowRegPicker(false);
-    if (selectedDate) {
-      setRegDate(selectedDate.toISOString().split('T')[0]);
-    }
-  };
-
-  const handleExpChange = (event, selectedDate) => {
-    setShowExpPicker(false);
-    if (selectedDate) {
-      setExpDate(selectedDate.toISOString().split('T')[0]);
-    }
-  };
 
   return (
     <Modal visible={visible} animationType="slide">
@@ -163,41 +148,15 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
           ))}
         </View>
         <Text>Fecha de registro</Text>
-        <TouchableOpacity
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          onPress={() => setShowRegPicker(true)}
-        >
-          <Text>{regDate || 'YYYY-MM-DD'}</Text>
-        </TouchableOpacity>
+        <DateInput date={regDate} onChange={setRegDate} />
         <Text>Fecha de caducidad</Text>
-        <TouchableOpacity
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          onPress={() => setShowExpPicker(true)}
-        >
-          <Text>{expDate || 'YYYY-MM-DD'}</Text>
-        </TouchableOpacity>
+        <DateInput date={expDate} onChange={setExpDate} />
         <Text>Nota</Text>
         <TextInput
           style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
           value={note}
           onChangeText={setNote}
         />
-        {showRegPicker && (
-          <DateTimePicker
-            value={regDate ? new Date(regDate) : new Date()}
-            mode="date"
-            display="calendar"
-            onChange={handleRegChange}
-          />
-        )}
-        {showExpPicker && (
-          <DateTimePicker
-            value={expDate ? new Date(expDate) : new Date()}
-            mode="date"
-            display="calendar"
-            onChange={handleExpChange}
-          />
-        )}
         <TouchableOpacity
           onPress={() =>
             onSave({

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -9,7 +9,7 @@ import {
   Image,
   ScrollView,
 } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateInput from './DateInput';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 
@@ -18,7 +18,6 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const { units } = useUnits();
   const { locations } = useLocations();
   const [data, setData] = useState([]);
-  const [picker, setPicker] = useState({ show: false, index: null, field: null });
 
   useEffect(() => {
     if (visible) {
@@ -39,12 +38,6 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
   };
 
-  const handlePickerChange = (event, selectedDate) => {
-    if (selectedDate && picker.index !== null && picker.field) {
-      updateField(picker.index, picker.field, selectedDate.toISOString().split('T')[0]);
-    }
-    setPicker({ show: false, index: null, field: null });
-  };
 
   return (
     <Modal visible={visible} animationType="slide">
@@ -155,19 +148,15 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
               ))}
             </View>
             <Text>Fecha de registro</Text>
-            <TouchableOpacity
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              onPress={() => setPicker({ show: true, index: idx, field: 'regDate' })}
-            >
-              <Text>{data[idx]?.regDate || 'YYYY-MM-DD'}</Text>
-            </TouchableOpacity>
+            <DateInput
+              date={data[idx]?.regDate}
+              onChange={value => updateField(idx, 'regDate', value)}
+            />
             <Text>Fecha de caducidad</Text>
-            <TouchableOpacity
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              onPress={() => setPicker({ show: true, index: idx, field: 'expDate' })}
-            >
-              <Text>{data[idx]?.expDate || 'YYYY-MM-DD'}</Text>
-            </TouchableOpacity>
+            <DateInput
+              date={data[idx]?.expDate}
+              onChange={value => updateField(idx, 'expDate', value)}
+            />
             <Text>Nota</Text>
             <TextInput
               style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
@@ -176,18 +165,6 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
             />
           </View>
         ))}
-        {picker.show && (
-          <DateTimePicker
-            value={
-              picker.index !== null && data[picker.index]?.[picker.field]
-                ? new Date(data[picker.index][picker.field])
-                : new Date()
-            }
-            mode="date"
-            display="calendar"
-            onChange={handlePickerChange}
-          />
-        )}
         <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20 }}>
           <Button title="Volver" onPress={onClose} />
           <Button title="Guardar" onPress={() => onSave(data)} />

--- a/MiAppNevera/src/components/DateInput.js
+++ b/MiAppNevera/src/components/DateInput.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Platform, Text, TextInput, TouchableOpacity } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+export default function DateInput({ date, onChange }) {
+  const [show, setShow] = useState(false);
+  const displayDate = date || 'YYYY-MM-DD';
+
+  if (Platform.OS === 'web') {
+    return (
+      <TextInput
+        style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+        value={date}
+        type="date"
+        onChange={e => onChange(e.target.value)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <TouchableOpacity
+        style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+        onPress={() => setShow(true)}
+      >
+        <Text>{displayDate}</Text>
+      </TouchableOpacity>
+      {show && (
+        <DateTimePicker
+          value={date ? new Date(date) : new Date()}
+          mode="date"
+          display={Platform.OS === 'ios' ? 'spinner' : 'calendar'}
+          onChange={(event, selectedDate) => {
+            setShow(false);
+            if (selectedDate) {
+              onChange(selectedDate.toISOString().split('T')[0]);
+            }
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Image,
 } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateInput from './DateInput';
 import { useShopping } from '../context/ShoppingContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
 import { useUnits } from '../context/UnitsContext';
@@ -26,8 +26,6 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   const [note, setNote] = useState('');
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [shoppingVisible, setShoppingVisible] = useState(false);
-  const [showRegPicker, setShowRegPicker] = useState(false);
-  const [showExpPicker, setShowExpPicker] = useState(false);
 
   useEffect(() => {
     if (visible && item) {
@@ -51,19 +49,6 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
     });
   };
 
-  const handleRegChange = (event, selectedDate) => {
-    setShowRegPicker(false);
-    if (selectedDate) {
-      setRegDate(selectedDate.toISOString().split('T')[0]);
-    }
-  };
-
-  const handleExpChange = (event, selectedDate) => {
-    setShowExpPicker(false);
-    if (selectedDate) {
-      setExpDate(selectedDate.toISOString().split('T')[0]);
-    }
-  };
 
   return (
     <>
@@ -179,41 +164,15 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             ))}
           </View>
           <Text>Fecha de registro</Text>
-          <TouchableOpacity
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            onPress={() => setShowRegPicker(true)}
-          >
-            <Text>{regDate || 'YYYY-MM-DD'}</Text>
-          </TouchableOpacity>
+          <DateInput date={regDate} onChange={setRegDate} />
           <Text>Fecha de caducidad</Text>
-          <TouchableOpacity
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            onPress={() => setShowExpPicker(true)}
-          >
-            <Text>{expDate || 'YYYY-MM-DD'}</Text>
-          </TouchableOpacity>
+          <DateInput date={expDate} onChange={setExpDate} />
           <Text>Nota</Text>
           <TextInput
             style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
             value={note}
             onChangeText={setNote}
           />
-          {showRegPicker && (
-            <DateTimePicker
-              value={regDate ? new Date(regDate) : new Date()}
-              mode="date"
-              display="calendar"
-              onChange={handleRegChange}
-            />
-          )}
-          {showExpPicker && (
-            <DateTimePicker
-              value={expDate ? new Date(expDate) : new Date()}
-              mode="date"
-              display="calendar"
-              onChange={handleExpChange}
-            />
-          )}
           <TouchableOpacity
             onPress={handleSave}
             style={{


### PR DESCRIPTION
## Summary
- add reusable `DateInput` component for calendar selection across devices and web
- replace manual date fields in add, edit, and batch-add modals with `DateInput`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689b99069ec08324aa565fd69283f733