### PR TITLE
Use platform-specific calendar pickers

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -7,11 +7,18 @@ import {
   TouchableOpacity,
   Image,
   Alert,
+  Platform,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+
+const datePickerDisplay = Platform.select({
+  ios: 'inline',
+  android: 'calendar',
+  default: 'default',
+});
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -186,7 +193,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
           <DateTimePicker
             value={regDate ? new Date(regDate) : new Date()}
             mode="date"
-            display="calendar"
+            display={datePickerDisplay}
             onChange={handleRegChange}
           />
         )}
@@ -194,7 +201,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
           <DateTimePicker
             value={expDate ? new Date(expDate) : new Date()}
             mode="date"
-            display="calendar"
+            display={datePickerDisplay}
             onChange={handleExpChange}
           />
         )}

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -8,10 +8,17 @@ import {
   TouchableOpacity,
   Image,
   ScrollView,
+  Platform,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+
+const datePickerDisplay = Platform.select({
+  ios: 'inline',
+  android: 'calendar',
+  default: 'default',
+});
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -184,7 +191,7 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
                 : new Date()
             }
             mode="date"
-            display="calendar"
+            display={datePickerDisplay}
             onChange={handlePickerChange}
           />
         )}

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -7,12 +7,19 @@ import {
   Button,
   TouchableOpacity,
   Image,
+  Platform,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useShopping } from '../context/ShoppingContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+
+const datePickerDisplay = Platform.select({
+  ios: 'inline',
+  android: 'calendar',
+  default: 'default',
+});
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
   const { addItem: addShoppingItem } = useShopping();
@@ -202,7 +209,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             <DateTimePicker
               value={regDate ? new Date(regDate) : new Date()}
               mode="date"
-              display="calendar"
+              display={datePickerDisplay}
               onChange={handleRegChange}
             />
           )}
@@ -210,7 +217,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             <DateTimePicker
               value={expDate ? new Date(expDate) : new Date()}
               mode="date"
-              display="calendar"
+              display={datePickerDisplay}
               onChange={handleExpChange}
             />
           )}


### PR DESCRIPTION
## Summary
- Ensure Add Item modal uses platform-aware date picker
- Apply platform-specific date picker in Edit Item and Batch Add modals

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b99069ec08324aa565fd69283f733