### PR TITLE
Add cross-platform date picker for item forms

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~3.2.3",
     "@react-native-async-storage/async-storage": "1.23.1",
+    "@react-native-community/datetimepicker": "^7.7.0",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "^51.0.0",

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -3,7 +3,6 @@ import {
   Modal,
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   Image,
   Alert,
@@ -11,6 +10,7 @@ import {
 import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DatePicker from './DatePicker';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -146,19 +146,9 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
           ))}
         </View>
         <Text>Fecha de registro</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
-          value={regDate}
-          onChangeText={setRegDate}
-        />
+        <DatePicker date={regDate} onChange={setRegDate} />
         <Text>Fecha de caducidad</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
-          value={expDate}
-          onChangeText={setExpDate}
-        />
+        <DatePicker date={expDate} onChange={setExpDate} />
         <Text>Nota</Text>
         <TextInput
           style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -3,14 +3,15 @@ import {
   Modal,
   View,
   Text,
-  TextInput,
   Button,
   TouchableOpacity,
   Image,
   ScrollView,
+  TextInput,
 } from 'react-native';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DatePicker from './DatePicker';
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -146,18 +147,14 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
               ))}
             </View>
             <Text>Fecha de registro</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
-              value={data[idx]?.regDate}
-              onChangeText={t => updateField(idx, 'regDate', t)}
+            <DatePicker
+              date={data[idx]?.regDate}
+              onChange={t => updateField(idx, 'regDate', t)}
             />
             <Text>Fecha de caducidad</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
-              value={data[idx]?.expDate}
-              onChangeText={t => updateField(idx, 'expDate', t)}
+            <DatePicker
+              date={data[idx]?.expDate}
+              onChange={t => updateField(idx, 'expDate', t)}
             />
             <Text>Nota</Text>
             <TextInput

--- a/MiAppNevera/src/components/DatePicker.js
+++ b/MiAppNevera/src/components/DatePicker.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Platform, TouchableOpacity, Text, View } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+export default function DatePicker({ date, onChange }) {
+  const [show, setShow] = useState(false);
+
+  const handleChange = (event, selectedDate) => {
+    setShow(false);
+    if (selectedDate) {
+      const iso = selectedDate.toISOString().split('T')[0];
+      onChange(iso);
+    }
+  };
+
+  if (Platform.OS === 'web') {
+    return (
+      <input
+        type="date"
+        value={date}
+        onChange={e => onChange(e.target.value)}
+        style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+      />
+    );
+  }
+
+  return (
+    <View>
+      <TouchableOpacity
+        onPress={() => setShow(true)}
+        style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
+      >
+        <Text>{date || 'YYYY-MM-DD'}</Text>
+      </TouchableOpacity>
+      {show && (
+        <DateTimePicker
+          value={date ? new Date(date) : new Date()}
+          mode="date"
+          display="calendar"
+          onChange={handleChange}
+        />
+      )}
+    </View>
+  );
+}

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -3,7 +3,6 @@ import {
   Modal,
   View,
   Text,
-  TextInput,
   Button,
   TouchableOpacity,
   Image,
@@ -12,6 +11,7 @@ import { useShopping } from '../context/ShoppingContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DatePicker from './DatePicker';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
   const { addItem: addShoppingItem } = useShopping();
@@ -162,19 +162,9 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             ))}
           </View>
           <Text>Fecha de registro</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
-            value={regDate}
-            onChangeText={setRegDate}
-          />
+          <DatePicker date={regDate} onChange={setRegDate} />
           <Text>Fecha de caducidad</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
-            value={expDate}
-            onChangeText={setExpDate}
-          />
+          <DatePicker date={expDate} onChange={setExpDate} />
           <Text>Nota</Text>
           <TextInput
             style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}


### PR DESCRIPTION
## Summary
- add @react-native-community/datetimepicker dependency
- create reusable DatePicker component with web and mobile support
- use DatePicker in add/edit/batch item modals for registration and expiration dates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9ac3a2488324a895db129127ca38