### PR TITLE
refactor: memoize context providers

### DIFF
--- a/MiAppNevera/src/context/LocationsContext.js
+++ b/MiAppNevera/src/context/LocationsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const defaultLocations = [
@@ -33,27 +33,30 @@ export const LocationsProvider = ({ children }) => {
     });
   }, [locations]);
 
-  const addLocation = (name, icon) => {
+  const addLocation = useCallback((name, icon) => {
     const key = name.toLowerCase();
     setLocations(prev => [...prev, { key, name, icon, active: true }]);
-  };
+  }, []);
 
-  const updateLocation = (key, name, icon) => {
+  const updateLocation = useCallback((key, name, icon) => {
     setLocations(prev => prev.map(l => (l.key === key ? { ...l, name, icon } : l)));
-  };
+  }, []);
 
-  const removeLocation = key => {
+  const removeLocation = useCallback(key => {
     setLocations(prev => prev.filter(l => l.key !== key));
-  };
+  }, []);
 
-  const toggleActive = key => {
+  const toggleActive = useCallback(key => {
     setLocations(prev => prev.map(l => (l.key === key ? { ...l, active: !l.active } : l)));
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ locations, addLocation, updateLocation, removeLocation, toggleActive }),
+    [locations, addLocation, updateLocation, removeLocation, toggleActive],
+  );
 
   return (
-    <LocationsContext.Provider
-      value={{ locations, addLocation, updateLocation, removeLocation, toggleActive }}
-    >
+    <LocationsContext.Provider value={value}>
       {children}
     </LocationsContext.Provider>
   );

--- a/MiAppNevera/src/context/UnitsContext.js
+++ b/MiAppNevera/src/context/UnitsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const defaultUnits = [
@@ -33,27 +33,32 @@ export const UnitsProvider = ({ children }) => {
     });
   }, [units]);
 
-  const addUnit = (singular, plural) => {
+  const addUnit = useCallback((singular, plural) => {
     const key = plural.toLowerCase();
     setUnits(prev => [...prev, { key, singular, plural }]);
-  };
+  }, []);
 
-  const updateUnit = (key, singular, plural) => {
+  const updateUnit = useCallback((key, singular, plural) => {
     setUnits(prev => prev.map(u => (u.key === key ? { ...u, singular, plural } : u)));
-  };
+  }, []);
 
-  const removeUnit = key => {
+  const removeUnit = useCallback(key => {
     setUnits(prev => prev.filter(u => u.key !== key));
-  };
+  }, []);
 
-  const getLabel = (quantity, key) => {
+  const getLabel = useCallback((quantity, key) => {
     const unit = units.find(u => u.key === key);
     if (!unit) return key;
     return Number(quantity) === 1 ? unit.singular : unit.plural;
-  };
+  }, [units]);
+
+  const value = useMemo(
+    () => ({ units, addUnit, updateUnit, removeUnit, getLabel }),
+    [units, addUnit, updateUnit, removeUnit, getLabel],
+  );
 
   return (
-    <UnitsContext.Provider value={{ units, addUnit, updateUnit, removeUnit, getLabel }}>
+    <UnitsContext.Provider value={value}>
       {children}
     </UnitsContext.Provider>
   );


### PR DESCRIPTION
## Summary
- reduce unnecessary renders by memoizing data and actions in context providers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689bf8033080832499d03f59819ec7e1