### PR TITLE
feat: add cross-platform date picker for item forms

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@expo/metro-config": "^0.20.17",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-community/datetimepicker": "^7.7.0",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "^53.0.20",

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -11,6 +11,7 @@ import {
 import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DatePicker from './DatePicker';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -145,20 +146,8 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </TouchableOpacity>
           ))}
         </View>
-        <Text>Fecha de registro</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
-          value={regDate}
-          onChangeText={setRegDate}
-        />
-        <Text>Fecha de caducidad</Text>
-        <TextInput
-          style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-          placeholder="YYYY-MM-DD"
-          value={expDate}
-          onChangeText={setExpDate}
-        />
+        <DatePicker label="Fecha de registro" value={regDate} onChange={setRegDate} />
+        <DatePicker label="Fecha de caducidad" value={expDate} onChange={setExpDate} />
         <Text>Nota</Text>
         <TextInput
           style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import DatePicker from './DatePicker';
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -145,19 +146,15 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
                 </TouchableOpacity>
               ))}
             </View>
-            <Text>Fecha de registro</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
+            <DatePicker
+              label="Fecha de registro"
               value={data[idx]?.regDate}
-              onChangeText={t => updateField(idx, 'regDate', t)}
+              onChange={t => updateField(idx, 'regDate', t)}
             />
-            <Text>Fecha de caducidad</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-              placeholder="YYYY-MM-DD"
+            <DatePicker
+              label="Fecha de caducidad"
               value={data[idx]?.expDate}
-              onChangeText={t => updateField(idx, 'expDate', t)}
+              onChange={t => updateField(idx, 'expDate', t)}
             />
             <Text>Nota</Text>
             <TextInput

--- a/MiAppNevera/src/components/DatePicker.js
+++ b/MiAppNevera/src/components/DatePicker.js
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { Platform, View, Text, TextInput, TouchableOpacity, StyleSheet, Animated } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+export default function DatePicker({ label, value, onChange }) {
+  const [show, setShow] = useState(false);
+  const fadeAnim = React.useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim]);
+
+  const handleChange = (event, selectedDate) => {
+    if (Platform.OS !== 'web') setShow(false);
+    if (selectedDate) {
+      const iso = selectedDate.toISOString().split('T')[0];
+      onChange(iso);
+    }
+  };
+
+  const displayValue = value || '';
+
+  return (
+    <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
+      {label && <Text style={styles.label}>{label}</Text>}
+      {Platform.OS === 'web' ? (
+        <TextInput
+          type="date"
+          value={displayValue}
+          onChangeText={onChange}
+          style={styles.input}
+        />
+      ) : (
+        <>
+          <TouchableOpacity onPress={() => setShow(true)}>
+            <TextInput
+              style={styles.input}
+              value={displayValue}
+              placeholder="YYYY-MM-DD"
+              editable={false}
+            />
+          </TouchableOpacity>
+          {show && (
+            <DateTimePicker
+              value={displayValue ? new Date(displayValue) : new Date()}
+              mode="date"
+              display="default"
+              onChange={handleChange}
+            />
+          )}
+        </>
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 10,
+  },
+  label: {
+    marginBottom: 5,
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    borderRadius: 4,
+    backgroundColor: '#fff',
+  },
+});

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useShopping } from '../context/ShoppingContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
+import DatePicker from './DatePicker';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 
@@ -161,20 +162,8 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
               </TouchableOpacity>
             ))}
           </View>
-          <Text>Fecha de registro</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
-            value={regDate}
-            onChangeText={setRegDate}
-          />
-          <Text>Fecha de caducidad</Text>
-          <TextInput
-            style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}
-            placeholder="YYYY-MM-DD"
-            value={expDate}
-            onChangeText={setExpDate}
-          />
+          <DatePicker label="Fecha de registro" value={regDate} onChange={setRegDate} />
+          <DatePicker label="Fecha de caducidad" value={expDate} onChange={setExpDate} />
           <Text>Nota</Text>
           <TextInput
             style={{ borderWidth: 1, marginBottom: 10, padding: 5 }}


### PR DESCRIPTION
## Summary
- add reusable `DatePicker` component with fade-in animation and web support
- replace manual date inputs with the calendar picker in add, edit and batch add modals
- include `@react-native-community/datetimepicker` dependency for consistent cross-platform behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bfcb736ac8324ac3c44d4b8dcb493