### PR TITLE
fix: enable calendar popup in DatePicker

### DIFF
--- a/MiAppNevera/src/components/DatePicker.js
+++ b/MiAppNevera/src/components/DatePicker.js
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Platform, View, Text, TextInput, TouchableOpacity, StyleSheet, Animated } from 'react-native';
+import {
+  Platform,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Animated,
+} from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 export default function DatePicker({ label, value, onChange }) {
@@ -28,21 +36,24 @@ export default function DatePicker({ label, value, onChange }) {
     <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
       {label && <Text style={styles.label}>{label}</Text>}
       {Platform.OS === 'web' ? (
-        <TextInput
+        // Use a native HTML input for web to get the browser date picker UI
+        <input
           type="date"
           value={displayValue}
-          onChangeText={onChange}
-          style={styles.input}
+          onChange={e => onChange(e.target.value)}
+          style={webInputStyle}
         />
       ) : (
         <>
           <TouchableOpacity onPress={() => setShow(true)}>
-            <TextInput
-              style={styles.input}
-              value={displayValue}
-              placeholder="YYYY-MM-DD"
-              editable={false}
-            />
+            <View pointerEvents="none">
+              <TextInput
+                style={styles.input}
+                value={displayValue}
+                placeholder="YYYY-MM-DD"
+                editable={false}
+              />
+            </View>
           </TouchableOpacity>
           {show && (
             <DateTimePicker
@@ -75,3 +86,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
 });
+
+// Plain object styles for the web <input/> element
+const webInputStyle = {
+  borderWidth: 1,
+  borderColor: '#ccc',
+  padding: 8,
+  borderRadius: 4,
+  backgroundColor: '#fff',
+  width: '100%',
+  boxSizing: 'border-box',
+};


### PR DESCRIPTION
## Summary
- use native HTML date input for web DatePicker to show calendar UI
- ensure TextInput presses open DateTimePicker on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689bffa61d2c8324a0c63385343bc1a1