### PR TITLE
Add default expiration dates for foods

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -12,6 +12,7 @@ import {useShopping} from '../context/ShoppingContext';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
+import { getDefaultExpiration } from '../foodIcons';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -32,10 +33,10 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
       setQuantity(1);
       setUnit(units[0]?.key || 'units');
       setRegDate(today);
-      setExpDate('');
+      setExpDate(getDefaultExpiration(foodName, today));
       setNote('');
     }
-  }, [visible, initialLocation, today, units, locations]);
+  }, [visible, initialLocation, today, units, locations, foodName]);
 
   return (
     <Modal visible={visible} animationType="slide">

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -12,6 +12,7 @@ import {
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
+import { getDefaultExpiration } from '../foodIcons';
 
 export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   const today = new Date().toISOString().split('T')[0];
@@ -22,12 +23,12 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
   useEffect(() => {
     if (visible) {
       setData(
-        items.map(() => ({
+        items.map(it => ({
           location: locations[0]?.key || 'fridge',
           quantity: '1',
           unit: units[0]?.key || 'units',
           regDate: today,
-          expDate: '',
+          expDate: getDefaultExpiration(it.name, today),
           note: '',
         })),
       );

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -13,6 +13,7 @@ import AddShoppingItemModal from './AddShoppingItemModal';
 import DatePicker from './DatePicker';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import { getDefaultExpiration } from '../foodIcons';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
   const { addItem: addShoppingItem } = useShopping();
@@ -32,8 +33,9 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
       setLocation(item.location || locations[0]?.key || 'fridge');
       setQuantity(String(item.quantity));
       setUnit(item.unit);
-      setRegDate(item.registered || '');
-      setExpDate(item.expiration || '');
+      const reg = item.registered || '';
+      setRegDate(reg);
+      setExpDate(item.expiration || getDefaultExpiration(item.name, reg || new Date().toISOString().split('T')[0]));
       setNote(item.note || '');
     }
   }, [visible, item]);

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -11,7 +11,7 @@ import {
   TouchableWithoutFeedback,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import foodIcons, { categories, getFoodIcon } from '../foodIcons';
+import foodIcons, { categories, getFoodIcon, foodLabels } from '../foodIcons';
 import AddCustomFoodModal from './AddCustomFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 
@@ -60,7 +60,9 @@ export default function FoodPickerModal({
 
   const handleSave = () => {
     if (onMultiSelect && selected.length) {
-      const names = selected.map(k => customFoodMap[k]?.name || k);
+      const names = selected.map(
+        k => customFoodMap[k]?.name || foodLabels[k] || k,
+      );
       onMultiSelect(names);
     }
     setSelectMode(false);
@@ -75,7 +77,11 @@ export default function FoodPickerModal({
   const defaultFoods = categories[currentCategory].items
     .filter(name => !hiddenFoods.includes(name))
     .filter(name => name.toLowerCase().includes(search.toLowerCase()))
-    .map(name => ({ key: name, label: name, icon: foodIcons[name] }));
+    .map(name => ({
+      key: name,
+      label: foodLabels[name] || name,
+      icon: foodIcons[name],
+    }));
 
   const customList = customFoods
     .filter(f => f.category === currentCategory)

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -1,7 +1,7 @@
 import React, {createContext, useContext, useEffect, useState, useCallback, useMemo} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import foods from '../../assets/foods.json';
-import {getFoodIcon, getFoodCategory} from '../foodIcons';
+import {getFoodIcon, getFoodCategory, getDefaultExpiration} from '../foodIcons';
 import { useLocations } from './LocationsContext';
 import { useCustomFoods } from './CustomFoodsContext';
 
@@ -22,13 +22,21 @@ export const InventoryProvider = ({children}) => {
   const [inventory, setInventory] = useState(buildEmpty);
 
   function attachIcons(data) {
+    const today = new Date().toISOString().split('T')[0];
     const withIcons = {};
     Object.keys(data).forEach(cat => {
-      withIcons[cat] = data[cat].map(item => ({
-        ...item,
-        icon: getFoodIcon(item.name),
-        foodCategory: getFoodCategory(item.name),
-      }));
+      withIcons[cat] = data[cat].map(item => {
+        const registered = item.registered || today;
+        const expiration =
+          item.expiration || getDefaultExpiration(item.name, registered);
+        return {
+          ...item,
+          icon: getFoodIcon(item.name),
+          foodCategory: getFoodCategory(item.name),
+          registered,
+          expiration,
+        };
+      });
     });
     return withIcons;
   }
@@ -78,6 +86,8 @@ export const InventoryProvider = ({children}) => {
     expiration = '',
     note = '',
   ) => {
+    const reg = registered || new Date().toISOString().split('T')[0];
+    const exp = expiration || getDefaultExpiration(name, reg);
     const icon = getFoodIcon(name);
     const foodCategory = getFoodCategory(name);
     const newItem = {
@@ -85,8 +95,8 @@ export const InventoryProvider = ({children}) => {
       quantity,
       unit,
       icon,
-      registered,
-      expiration,
+      registered: reg,
+      expiration: exp,
       note,
       foodCategory,
     };

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -250,12 +250,24 @@ export const categories = {
   },
 };
 
+export const expirationDays = {
+  'frijoles': 365,
+  'guisantes': 180,
+  'lentejas': 365,
+  'maiz': 365,
+  'manzana': 30,
+  'tomate': 7,
+  'zanahoria': 14,
+};
+
 let customIconMap = {};
 let customCategoryMap = {};
+let customExpirationMap = {};
 
 export function setCustomFoodsMap(foods) {
   customIconMap = {};
   customCategoryMap = {};
+  customExpirationMap = {};
   foods.forEach(f => {
     customCategoryMap[f.key] = f.category;
     if (f.icon) {
@@ -263,6 +275,9 @@ export function setCustomFoodsMap(foods) {
     } else if (f.baseIcon) {
       const baseKey = normalizeFoodName(f.baseIcon);
       customIconMap[f.key] = foodIcons[baseKey];
+    }
+    if (f.expiresIn) {
+      customExpirationMap[f.key] = f.expiresIn;
     }
   });
 }
@@ -285,6 +300,15 @@ export function getFoodCategory(name) {
     }
   }
   return null;
+}
+
+export function getDefaultExpiration(name, fromDate = new Date()) {
+  const key = normalizeFoodName(name);
+  const days = customExpirationMap[key] ?? expirationDays[key];
+  if (!days) return '';
+  const base = new Date(fromDate);
+  base.setDate(base.getDate() + days);
+  return base.toISOString().split('T')[0];
 }
 
 export default foodIcons;

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -215,6 +215,222 @@ const foodIcons = {
   'zumodenaranja': require('./../../icons/Bebidas/zumo_de_naranja_icon.png'),
 };
 
+export const foodLabels = {
+  'aceituna': 'Aceituna',
+  'acelga': 'Acelga',
+  'agave': 'Agave',
+  'agua': 'Agua',
+  'aguacate': 'Aguacate',
+  'ajipicante': 'Ají Picante',
+  'ajo': 'Ajo',
+  'albahaca': 'Albahaca',
+  'alcachofa': 'Alcachofa',
+  'algasmarinas': 'Algas Marinas',
+  'algodon': 'Algodón',
+  'almendra': 'Almendra',
+  'aloevera': 'Aloe Vera',
+  'anacardo': 'Anacardo',
+  'anemonademar': 'Anémona De Mar',
+  'angelote': 'Angelote',
+  'anguila': 'Anguila',
+  'apio': 'Apio',
+  'asado': 'Asado',
+  'atun': 'Atún',
+  'avellana': 'Avellana',
+  'bacalao': 'Bacalao',
+  'ballena': 'Ballena',
+  'bambu': 'Bambú',
+  'banco': 'Banco',
+  'batata': 'Batata',
+  'batidordecocteles': 'Batidor De Coctéles',
+  'bayas': 'Bayas',
+  'bebidaenergetica': 'Bebida Energética',
+  'bellota': 'Bellota',
+  'berenjenas': 'Berenjenas',
+  'blanco': 'Blanco',
+  'brocoli': 'Brócoli',
+  'caballodemar': 'Caballo De Mar',
+  'cacao': 'Cacao',
+  'cactus': 'Cactus',
+  'cafe': 'Café',
+  'cafehelado': 'Café Helado',
+  'cajadejugo': 'Caja De Jugo',
+  'cajadeleche': 'Caja De Leche',
+  'calabacin': 'Calabacín',
+  'calabaza': 'Calabaza',
+  'calamar': 'Calamar',
+  'camaron': 'Camarón',
+  'canadeazucar': 'Caña De Azúcar',
+  'canela': 'Canela',
+  'cangrejo': 'Cangrejo',
+  'cangrejoermitano': 'Cangrejo Ermitaño',
+  'capuchino': 'Capuchino',
+  'cardamomo': 'Cardamomo',
+  'carne': 'Carne',
+  'cascara': 'Cáscara',
+  'castana': 'Castaña',
+  'caucho': 'Caucho',
+  'cebolla': 'Cebolla',
+  'cebollin': 'Cebollín',
+  'cerdo': 'Cerdo',
+  'cereza': 'Cereza',
+  'cerveza': 'Cerveza',
+  'chalote': 'Chalote',
+  'champan': 'Champán',
+  'chia': 'Chía',
+  'chocolatecaliente': 'Chocolate Caliente',
+  'clavo': 'Clavo',
+  'coco': 'Coco',
+  'coctel': 'Cóctel',
+  'coliflor': 'Coliflor',
+  'colrizada': 'Col Rizada',
+  'concha': 'Concha',
+  'conodepino': 'Cono De Pino',
+  'coral': 'Coral',
+  'cordero': 'Cordero',
+  'cosmopolita': 'Cosmopolita',
+  'costillas': 'Costillas',
+  'dalgona': 'Dalgona',
+  'delfin': 'Delfín',
+  'dragondefruta': 'Dragon De Fruta',
+  'durian': 'Durian',
+  'edamame': 'Edamame',
+  'erizodemar': 'Erizo De Mar',
+  'esparragos': 'Espárragos',
+  'espina': 'Espina',
+  'espinacas': 'Espinacas',
+  'estrellademar': 'Estrella De Mar',
+  'ficus': 'Ficus',
+  'filete': 'Filete',
+  'frambuesa': 'Frambuesa',
+  'fresa': 'Fresa',
+  'frijoles': 'Frijoles',
+  'frijolesrojos': 'Frijoles Rojos',
+  'fruta': 'Fruta',
+  'frutaestrella': 'Fruta Estrella',
+  'garbanzos': 'Garbanzos',
+  'gaviota': 'Gaviota',
+  'girasol': 'Girasol',
+  'goji': 'Goji',
+  'granada': 'Granada',
+  'granosdecafe': 'Granos De Café',
+  'guisantes': 'Guisantes',
+  'habadesoja': 'Haba De Soja',
+  'hamburguesa': 'Hamburguesa',
+  'hierba': 'Hierba',
+  'higado': 'Hígado',
+  'hinojo': 'Hinojo',
+  'horchata': 'Horchata',
+  'idolomoro': 'Ídolo Moro',
+  'infusion': 'Infusión',
+  'jengibre': 'Jengibre',
+  'judiasverdes': 'Judías Verdes',
+  'kiwi': 'Kiwi',
+  'kombucha': 'Kombucha',
+  'langosta': 'Langosta',
+  'lata': 'Lata',
+  'lattemacchiato': 'Latte Macchiato',
+  'leche': 'Leche',
+  'lecheconchocolate': 'Leche Con Chocolate',
+  'lechedefresa': 'Leche De Fresa',
+  'lechuga': 'Lechuga',
+  'lentejas': 'Lentejas',
+  'lima': 'Lima',
+  'limon': 'Limón',
+  'limonada': 'Limonada',
+  'lychee': 'Lychee',
+  'macadamia': 'Macadamia',
+  'maiz': 'Maíz',
+  'malteada': 'Malteada',
+  'mango': 'Mango',
+  'mangostan': 'Mangostán',
+  'mani': 'Maní',
+  'manzana': 'Manzana',
+  'manzanarosa': 'Manzana Rosa',
+  'maracuya': 'Maracuyá',
+  'margarita': 'Margarita',
+  'martini': 'Martini',
+  'matcha': 'Matcha',
+  'medusa': 'Medusa',
+  'mejillon': 'Mejillón',
+  'melocoton': 'Melocotón',
+  'melon': 'Melón',
+  'membrillo': 'Membrillo',
+  'mimosa': 'Mimosa',
+  'mojito': 'Mojito',
+  'nabo': 'Nabo',
+  'naranja': 'Naranja',
+  'natillasappel': 'Natillas Appel',
+  'nuecesdebrasil': 'Nueces De Brasil',
+  'nuez': 'Nuez',
+  'nuezmoscada': 'Nuez Moscada',
+  'orca': 'Orca',
+  'pacana': 'Pacana',
+  'palillodetambor': 'Palillo De Tambor',
+  'palmeradatilera': 'Palmera Datilera',
+  'papaya': 'Papaya',
+  'patatas': 'Patatas',
+  'pepino': 'Pepino',
+  'pera': 'Pera',
+  'pez': 'Pez',
+  'pezcirujano': 'Pez Cirujano',
+  'pezespada': 'Pez Espada',
+  'pezglobo': 'Pez Globo',
+  'pezluna': 'Pez Luna',
+  'pezmartillo': 'Pez Martillo',
+  'pezpayaso': 'Pez Payaso',
+  'pezvolador': 'Pez Volador',
+  'physalis': 'Physalis',
+  'pimienta': 'Pimienta',
+  'pina': 'Piña',
+  'pistacho': 'Pistacho',
+  'platano': 'Plátano',
+  'pollo': 'Pollo',
+  'puerro': 'Puerro',
+  'pulpo': 'Pulpo',
+  'punetazo': 'Puñetazo',
+  'rabano': 'Rábano',
+  'ramune': 'Ramune',
+  'rape': 'Rape',
+  'rayo': 'Rayo',
+  'reajustesalarial': 'Reajuste Salarial',
+  'remolacha': 'Remolacha',
+  'repollo': 'Repollo',
+  'repollorojo': 'Repollo Rojo',
+  'rinon': 'Riñón',
+  'salami': 'Salami',
+  'salchicha': 'Salchicha',
+  'salmon': 'Salmón',
+  'sandia': 'Sandía',
+  'sangria': 'Sangría',
+  'sardina': 'Sardina',
+  'semilladecalabaza': 'Semilla De Calabaza',
+  'semilladegirasol': 'Semilla De Girasol',
+  'semilladelino': 'Semilla De Lino',
+  'serpientedemar': 'Serpiente De Mar',
+  'sesamo': 'Sésamo',
+  'seta': 'Seta',
+  'soda': 'Soda',
+  'sodaconhelado': 'Soda Con Helado',
+  'tamarindo': 'Tamarindo',
+  'te': 'Té',
+  'tedeburbujas': 'Té De Burbujas',
+  'tehelado': 'Té Helado',
+  'tetera': 'Tetera',
+  'tiburon': 'Tiburón',
+  'tomate': 'Tomate',
+  'tortuga': 'Tortuga',
+  'trigo': 'Trigo',
+  'uva': 'Uva',
+  'vegetal': 'Vegetal',
+  'vino': 'Vino',
+  'wasabi': 'Wasabi',
+  'whisky': 'Whisky',
+  'zalamero': 'Zalamero',
+  'zanahoria': 'Zanahoria',
+  'zumodenaranja': 'Zumo De Naranja',
+};
+
 export const categories = {
   'bebidas': {
     icon: require('./../../icons/Categorias/Bebidas.png'),
@@ -250,65 +466,22 @@ export const categories = {
   },
 };
 
-export const expirationDays = {
-  'frijoles': 365,
-  'guisantes': 180,
-  'lentejas': 365,
-  'maiz': 365,
-  'manzana': 30,
-  'tomate': 7,
-  'zanahoria': 14,
-};
-
-let customIconMap = {};
-let customCategoryMap = {};
-let customExpirationMap = {};
-
-export function setCustomFoodsMap(foods) {
-  customIconMap = {};
-  customCategoryMap = {};
-  customExpirationMap = {};
-  foods.forEach(f => {
-    customCategoryMap[f.key] = f.category;
-    if (f.icon) {
-      customIconMap[f.key] = { uri: f.icon };
-    } else if (f.baseIcon) {
-      const baseKey = normalizeFoodName(f.baseIcon);
-      customIconMap[f.key] = foodIcons[baseKey];
-    }
-    if (f.expiresIn) {
-      customExpirationMap[f.key] = f.expiresIn;
-    }
-  });
-}
-
 export function normalizeFoodName(name) {
   return name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]/g, '');
 }
 
 export function getFoodIcon(name) {
-  const key = normalizeFoodName(name);
-  return customIconMap[key] || foodIcons[key];
+  return foodIcons[normalizeFoodName(name)];
 }
 
 export function getFoodCategory(name) {
   const normalized = normalizeFoodName(name);
-  if (customCategoryMap[normalized]) return customCategoryMap[normalized];
   for (const [cat, data] of Object.entries(categories)) {
     if (data.items.includes(normalized)) {
       return cat;
     }
   }
   return null;
-}
-
-export function getDefaultExpiration(name, fromDate = new Date()) {
-  const key = normalizeFoodName(name);
-  const days = customExpirationMap[key] ?? expirationDays[key];
-  if (!days) return '';
-  const base = new Date(fromDate);
-  base.setDate(base.getDate() + days);
-  return base.toISOString().split('T')[0];
 }
 
 export default foodIcons;


### PR DESCRIPTION
## Summary
- add default expiration map and helper to `foodIcons`
- auto-fill expiration when loading or adding items
- prefill expiration fields in add/edit modals

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d00e9a954832489f8c1629ae7aaf3