### PR TITLE
Add user data reset option

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -11,6 +11,7 @@ import { RecipeProvider } from './src/context/RecipeContext';
 import SettingsScreen from './src/screens/SettingsScreen';
 import UnitSettingsScreen from './src/screens/UnitSettingsScreen';
 import LocationSettingsScreen from './src/screens/LocationSettingsScreen';
+import UserDataScreen from './src/screens/UserDataScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
@@ -63,6 +64,11 @@ export default function App() {
                     name="LocationSettings"
                     component={LocationSettingsScreen}
                     options={{ title: 'Gestión de ubicación' }}
+                  />
+                  <Stack.Screen
+                    name="UserData"
+                    component={UserDataScreen}
+                    options={{ title: 'Datos de usuario' }}
                   />
                   </Stack.Navigator>
                 </NavigationContainer>

--- a/MiAppNevera/src/screens/SettingsScreen.js
+++ b/MiAppNevera/src/screens/SettingsScreen.js
@@ -1,11 +1,71 @@
-import React from 'react';
-import { View, Button } from 'react-native';
+import React, { useLayoutEffect, useState } from 'react';
+import {
+  View,
+  Button,
+  Modal,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Text,
+} from 'react-native';
 
 export default function SettingsScreen({ navigation }) {
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity onPress={() => setMenuVisible(true)}>
+          <Text
+            style={{
+              fontSize: 24,
+              paddingHorizontal: 6,
+              backgroundColor: '#eee',
+              borderRadius: 4,
+            }}
+          >
+            ⋮
+          </Text>
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation]);
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', padding: 20, gap: 10 }}>
       <Button title="Tipos de unidad" onPress={() => navigation.navigate('UnitSettings')} />
       <Button title="Gestión de ubicación" onPress={() => navigation.navigate('LocationSettings')} />
+
+      <Modal
+        visible={menuVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setMenuVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setMenuVisible(false)}>
+          <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.3)' }}>
+            <TouchableWithoutFeedback>
+              <View
+                style={{
+                  position: 'absolute',
+                  top: 40,
+                  right: 10,
+                  backgroundColor: '#fff',
+                  padding: 10,
+                  borderRadius: 8,
+                }}
+              >
+                <Button
+                  title="Datos de usuario"
+                  onPress={() => {
+                    setMenuVisible(false);
+                    navigation.navigate('UserData');
+                  }}
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
     </View>
   );
 }

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Button, Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export default function UserDataScreen() {
+  const confirmClear = () => {
+    Alert.alert(
+      'Confirmar',
+      '¿Eliminar todos los datos de usuario? Esta acción no se puede deshacer.',
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        {
+          text: 'Eliminar',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await AsyncStorage.clear();
+              Alert.alert('Datos borrados', 'La aplicación se ha restablecido.');
+            } catch (e) {
+              Alert.alert('Error', 'No se pudo borrar los datos.');
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Button title="Eliminar todos los datos de usuario" onPress={confirmClear} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add menu in Settings to access user data options
- allow clearing all stored user data with confirmation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d123139308324b969287995ac6716