### PR TITLE
Add user data reset option

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -11,6 +11,7 @@ import { RecipeProvider } from './src/context/RecipeContext';
 import SettingsScreen from './src/screens/SettingsScreen';
 import UnitSettingsScreen from './src/screens/UnitSettingsScreen';
 import LocationSettingsScreen from './src/screens/LocationSettingsScreen';
+import UserDataScreen from './src/screens/UserDataScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
@@ -63,6 +64,11 @@ export default function App() {
                     name="LocationSettings"
                     component={LocationSettingsScreen}
                     options={{ title: 'Gestión de ubicación' }}
+                  />
+                  <Stack.Screen
+                    name="UserData"
+                    component={UserDataScreen}
+                    options={{ title: 'Datos de usuario' }}
                   />
                   </Stack.Navigator>
                 </NavigationContainer>

--- a/MiAppNevera/src/context/CustomFoodsContext.js
+++ b/MiAppNevera/src/context/CustomFoodsContext.js
@@ -47,9 +47,18 @@ export const CustomFoodsProvider = ({ children }) => {
   const removeCustomFood = useCallback(key => {
     persist(prev => prev.filter(f => f.key !== key));
   }, [persist]);
+
+  const resetCustomFoods = useCallback(() => {
+    setCustomFoods([]);
+    setCustomFoodsMap([]);
+    AsyncStorage.removeItem('customFoods').catch(e => {
+      console.error('Failed to clear custom foods', e);
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({ customFoods, addCustomFood, updateCustomFood, removeCustomFood }),
-    [customFoods, addCustomFood, updateCustomFood, removeCustomFood],
+    () => ({ customFoods, addCustomFood, updateCustomFood, removeCustomFood, resetCustomFoods }),
+    [customFoods, addCustomFood, updateCustomFood, removeCustomFood, resetCustomFoods],
   );
 
   return (

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -147,9 +147,17 @@ export const InventoryProvider = ({children}) => {
     });
   }, [persist]);
 
+  const resetInventory = useCallback(() => {
+    const initial = { ...buildEmpty(), ...attachIcons(foods) };
+    AsyncStorage.removeItem('inventory').catch(e => {
+      console.error('Failed to clear inventory', e);
+    });
+    setInventory(initial);
+  }, [buildEmpty]);
+
   const value = useMemo(
-    () => ({inventory, addItem, updateItem, updateQuantity, removeItem}),
-    [inventory, addItem, updateItem, updateQuantity, removeItem],
+    () => ({inventory, addItem, updateItem, updateQuantity, removeItem, resetInventory}),
+    [inventory, addItem, updateItem, updateQuantity, removeItem, resetInventory],
   );
 
   return (

--- a/MiAppNevera/src/context/LocationsContext.js
+++ b/MiAppNevera/src/context/LocationsContext.js
@@ -50,9 +50,16 @@ export const LocationsProvider = ({ children }) => {
     setLocations(prev => prev.map(l => (l.key === key ? { ...l, active: !l.active } : l)));
   }, []);
 
+  const resetLocations = useCallback(() => {
+    setLocations(defaultLocations);
+    AsyncStorage.removeItem('locations').catch(e => {
+      console.error('Failed to clear locations', e);
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({ locations, addLocation, updateLocation, removeLocation, toggleActive }),
-    [locations, addLocation, updateLocation, removeLocation, toggleActive],
+    () => ({ locations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations }),
+    [locations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations],
   );
 
   return (

--- a/MiAppNevera/src/context/RecipeContext.js
+++ b/MiAppNevera/src/context/RecipeContext.js
@@ -67,9 +67,16 @@ export const RecipeProvider = ({children}) => {
     persist(prev => prev.filter((_, idx) => idx !== index));
   }, [persist]);
 
+  const resetRecipes = useCallback(() => {
+    setRecipes([]);
+    AsyncStorage.removeItem('recipes').catch(e => {
+      console.error('Failed to clear recipes', e);
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({recipes, addRecipe, updateRecipe, removeRecipe}),
-    [recipes, addRecipe, updateRecipe, removeRecipe],
+    () => ({recipes, addRecipe, updateRecipe, removeRecipe, resetRecipes}),
+    [recipes, addRecipe, updateRecipe, removeRecipe, resetRecipes],
   );
 
   return (

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -83,9 +83,16 @@ export const ShoppingProvider = ({children}) => {
     ));
   }, [persist]);
 
+  const resetShopping = useCallback(() => {
+    setList([]);
+    AsyncStorage.removeItem('shopping').catch(e => {
+      console.error('Failed to clear shopping list', e);
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased}),
-    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased],
+    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping}),
+    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping],
   );
 
   return (

--- a/MiAppNevera/src/context/UnitsContext.js
+++ b/MiAppNevera/src/context/UnitsContext.js
@@ -52,9 +52,16 @@ export const UnitsProvider = ({ children }) => {
     return Number(quantity) === 1 ? unit.singular : unit.plural;
   }, [units]);
 
+  const resetUnits = useCallback(() => {
+    setUnits(defaultUnits);
+    AsyncStorage.removeItem('units').catch(e => {
+      console.error('Failed to clear units', e);
+    });
+  }, []);
+
   const value = useMemo(
-    () => ({ units, addUnit, updateUnit, removeUnit, getLabel }),
-    [units, addUnit, updateUnit, removeUnit, getLabel],
+    () => ({ units, addUnit, updateUnit, removeUnit, getLabel, resetUnits }),
+    [units, addUnit, updateUnit, removeUnit, getLabel, resetUnits],
   );
 
   return (

--- a/MiAppNevera/src/screens/SettingsScreen.js
+++ b/MiAppNevera/src/screens/SettingsScreen.js
@@ -6,6 +6,7 @@ export default function SettingsScreen({ navigation }) {
     <View style={{ flex: 1, justifyContent: 'center', padding: 20, gap: 10 }}>
       <Button title="Tipos de unidad" onPress={() => navigation.navigate('UnitSettings')} />
       <Button title="Gestión de ubicación" onPress={() => navigation.navigate('LocationSettings')} />
+      <Button title="Datos de usuario" onPress={() => navigation.navigate('UserData')} />
     </View>
   );
 }

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Button, Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useInventory } from '../context/InventoryContext';
+import { useUnits } from '../context/UnitsContext';
+import { useLocations } from '../context/LocationsContext';
+import { useShopping } from '../context/ShoppingContext';
+import { useRecipes } from '../context/RecipeContext';
+import { useCustomFoods } from '../context/CustomFoodsContext';
+
+export default function UserDataScreen() {
+  const { resetInventory } = useInventory();
+  const { resetUnits } = useUnits();
+  const { resetLocations } = useLocations();
+  const { resetShopping } = useShopping();
+  const { resetRecipes } = useRecipes();
+  const { resetCustomFoods } = useCustomFoods();
+
+  const resetAll = async () => {
+    try {
+      await AsyncStorage.clear();
+    } catch (e) {
+      console.error('Failed to clear storage', e);
+    }
+    resetCustomFoods();
+    resetUnits();
+    resetLocations();
+    resetInventory();
+    resetShopping();
+    resetRecipes();
+  };
+
+  const confirmReset = () => {
+    Alert.alert(
+      'Confirmar',
+      'Esto eliminará todos los datos de usuario. ¿Deseas continuar?',
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        { text: 'Eliminar', style: 'destructive', onPress: resetAll },
+      ],
+    );
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Button title="Eliminar todos los datos de usuario" onPress={confirmReset} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Add 'Datos de usuario' button to settings
- Implement user data screen with global reset and confirmation
- Expose reset helpers across data contexts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d152d8b588324b0930e25b14fafb9