### PR TITLE
Remove default foods from initial inventory data

### DIFF
--- a/MiAppNevera/assets/foods.json
+++ b/MiAppNevera/assets/foods.json
@@ -1,15 +1,5 @@
 {
-  "fridge": [
-    {"name": "Tomate", "quantity": 2, "unit": "units"},
-    {"name": "Manzana", "quantity": 3, "unit": "units"},
-    {"name": "Zanahoria", "quantity": 5, "unit": "units"}
-  ],
-  "freezer": [
-    {"name": "Guisantes", "quantity": 1, "unit": "units"},
-    {"name": "Maíz", "quantity": 1, "unit": "units"}
-  ],
-  "pantry": [
-    {"name": "Frijoles", "quantity": 1, "unit": "units"},
-    {"name": "Lentejas", "quantity": 1, "unit": "units"}
-  ]
+  "fridge": [],
+  "freezer": [],
+  "pantry": []
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Aplicación de inventario de alimentos escrita en React Native con soporte para 
 - `MiAppNevera/App.js`: punto de entrada que configura la navegación entre las pantallas.
 - `MiAppNevera/src/screens`: implementa las pantallas de inicio, categorías (nevera, congelador, despensa) y lista de compras.
 - `MiAppNevera/src/context`: hooks de estado con persistencia en `AsyncStorage`.
-- `MiAppNevera/assets/foods.json`: datos iniciales con ejemplos de alimentos.
+- `MiAppNevera/assets/foods.json`: estructura de inventario inicial (vacía por defecto).
 
 ## Desarrollo
 1. Instalar dependencias


### PR DESCRIPTION
## Summary
- clear placeholder foods from initial dataset so resetting data leaves empty inventory
- update README to note initial inventory file is empty by default

## Testing
- `npm test` *(fails: Missing script: "test"*)


------
https://chatgpt.com/codex/tasks/task_e_689e33250f4483249144e153c1c9665b