### PR TITLE
feat: show days until expiration

### DIFF
--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -354,6 +354,12 @@ export default function InventoryScreen({ navigation }) {
                   items.map(item => {
                     const key = `${item.location}-${item.index}`;
                     const selected = selectedItems.some(it => it.key === key);
+                    const daysLeft = item.expiration
+                      ? Math.ceil(
+                          (new Date(item.expiration) - new Date()) /
+                            (1000 * 60 * 60 * 24),
+                        )
+                      : null;
                     return (
                       <TouchableOpacity
                         key={key}
@@ -382,10 +388,28 @@ export default function InventoryScreen({ navigation }) {
                         }}
                       >
                         {item.icon && (
-                          <Image
-                            source={item.icon}
-                            style={{ width: 32, height: 32, marginRight: 10 }}
-                          />
+                          <View style={{ position: 'relative', marginRight: 10 }}>
+                            <Image
+                              source={item.icon}
+                              style={{ width: 32, height: 32 }}
+                            />
+                            {daysLeft !== null && (
+                              <View
+                                style={{
+                                  position: 'absolute',
+                                  top: 0,
+                                  left: 0,
+                                  backgroundColor: '#fff',
+                                  paddingHorizontal: 2,
+                                  borderRadius: 3,
+                                  minWidth: 12,
+                                  alignItems: 'center',
+                                }}
+                              >
+                                <Text style={{ fontSize: 8 }}>D-{daysLeft}</Text>
+                              </View>
+                            )}
+                          </View>
                         )}
                         <Text>{item.name}</Text>
                         <Text style={{ marginLeft: 10 }}>
@@ -402,6 +426,12 @@ export default function InventoryScreen({ navigation }) {
                     {items.map(item => {
                       const key = `${item.location}-${item.index}`;
                       const selected = selectedItems.some(it => it.key === key);
+                      const daysLeft = item.expiration
+                        ? Math.ceil(
+                            (new Date(item.expiration) - new Date()) /
+                              (1000 * 60 * 60 * 24),
+                          )
+                        : null;
                       return (
                         <TouchableOpacity
                           key={key}
@@ -436,10 +466,28 @@ export default function InventoryScreen({ navigation }) {
                             }}
                           >
                             {item.icon && (
-                              <Image
-                                source={item.icon}
-                                style={{ width: 40, height: 40, marginBottom: 4 }}
-                              />
+                              <View style={{ position: 'relative' }}>
+                                <Image
+                                  source={item.icon}
+                                  style={{ width: 40, height: 40, marginBottom: 4 }}
+                                />
+                                {daysLeft !== null && (
+                                  <View
+                                    style={{
+                                      position: 'absolute',
+                                      top: 0,
+                                      left: 0,
+                                      backgroundColor: '#fff',
+                                      paddingHorizontal: 2,
+                                      borderRadius: 3,
+                                      minWidth: 14,
+                                      alignItems: 'center',
+                                    }}
+                                  >
+                                    <Text style={{ fontSize: 8 }}>D-{daysLeft}</Text>
+                                  </View>
+                                )}
+                              </View>
                             )}
                             <Text style={{ textAlign: 'center', fontSize: 12 }}>
                               {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}


### PR DESCRIPTION
## Summary
- overlay small badge with remaining days until expiration on inventory items

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689e380e0e7c8324a0565fbb618a1697