### PR TITLE
Handle zero-quantity items with notes during batch save

### DIFF
--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -99,7 +99,11 @@ export default function ShoppingListScreen() {
       locations.forEach(loc => {
         for (let i = inventory[loc.key].length - 1; i >= 0; i--) {
           const invItem = inventory[loc.key][i];
-          if (invItem.name === item.name && invItem.quantity === 0) {
+          if (
+            invItem.name === item.name &&
+            invItem.quantity === 0 &&
+            (!invItem.note || invItem.note.trim() === '')
+          ) {
             removeInventoryItem(loc.key, i);
           }
         }


### PR DESCRIPTION
## Summary
- Preserve zero-quantity inventory items that have notes when saving multiple shopping items
- Only replace zero-quantity inventory entries lacking notes with new saved items

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e930dd33483249c77cd4a09a63be5