### PR TITLE
Handle zero-quantity shopping list items

### DIFF
--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -59,7 +59,7 @@ export default function ShoppingListScreen() {
     );
     const newItems = zeroItems
       .filter(it => !list.some(l => l.name === it.name))
-      .map(it => ({name: it.name, quantity: 1, unit: it.unit}));
+      .map(it => ({name: it.name, quantity: 0, unit: it.unit}));
     if (newItems.length) {
       addItems(newItems);
     }
@@ -99,7 +99,11 @@ export default function ShoppingListScreen() {
       locations.forEach(loc => {
         for (let i = inventory[loc.key].length - 1; i >= 0; i--) {
           const invItem = inventory[loc.key][i];
-          if (invItem.name === item.name && invItem.quantity === 0) {
+          if (
+            invItem.name === item.name &&
+            invItem.quantity === 0 &&
+            !invItem.note
+          ) {
             removeInventoryItem(loc.key, i);
           }
         }


### PR DESCRIPTION
## Summary
- Add zero-quantity items from inventory to shopping list only when absent
- Skip removal of zero-quantity inventory items that have notes when saving

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e998e83f08324b3d53867e978fea1