### PR TITLE
Fix shopping list batch save and zero quantity cleanup

### DIFF
--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -176,7 +176,18 @@ export default function BatchAddItemModal({ visible, items, onSave, onClose }) {
         ))}
         <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 20 }}>
           <Button title="Volver" onPress={onClose} />
-          <Button title="Guardar" onPress={() => onSave(data)} />
+          <Button
+            title="Guardar"
+            onPress={() =>
+              onSave(
+                data.map((d, idx) => ({
+                  ...d,
+                  index: items[idx].index,
+                  name: items[idx].name,
+                })),
+              )
+            }
+          />
         </View>
       </ScrollView>
     </Modal>

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -59,6 +59,21 @@ export default function InventoryScreen({ navigation }) {
   const [multiItems, setMultiItems] = useState([]);
   const overlaySize = Dimensions.get('window').width * 0.06;
 
+  const cleanZeroItems = name => {
+    locations.forEach(loc => {
+      for (let i = inventory[loc.key].length - 1; i >= 0; i--) {
+        const invItem = inventory[loc.key][i];
+        if (
+          invItem.name === name &&
+          invItem.quantity === 0 &&
+          (!invItem.note || invItem.note.trim() === '')
+        ) {
+          removeItem(loc.key, i);
+        }
+      }
+    });
+  };
+
   const [search, setSearch] = useState('');
   const [menuVisible, setMenuVisible] = useState(false);
   const [sortVisible, setSortVisible] = useState(false);
@@ -189,32 +204,34 @@ export default function InventoryScreen({ navigation }) {
   };
 
   const onSave = data => {
-    addItem(
-      data.location,
-      selectedFood.name,
-      data.quantity,
-      data.unit,
-      data.registered,
-      data.expiration,
-      data.note,
-    );
+    cleanZeroItems(selectedFood.name);
+    const qty = parseFloat(data.quantity) || 0;
+    const hasNote = data.note && data.note.trim() !== '';
+    if (qty !== 0 || hasNote) {
+      addItem(
+        data.location,
+        selectedFood.name,
+        qty,
+        data.unit,
+        data.registered,
+        data.expiration,
+        data.note,
+      );
+    }
     setAddVisible(false);
   };
 
   const handleBatchAddSave = entries => {
-    entries.forEach((entry, idx) => {
-      const { location, quantity, unit, regDate, expDate, note } = entry;
-      const item = multiItems[idx];
-      addItem(
-        location,
-        item.name,
-        parseFloat(quantity) || 0,
-        unit,
-        regDate,
-        expDate,
-        note,
-      );
-    });
+    for (let i = 0; i < entries.length; i++) {
+      const { location, quantity, unit, regDate, expDate, note } = entries[i];
+      const item = multiItems[i];
+      cleanZeroItems(item.name);
+      const qty = parseFloat(quantity) || 0;
+      const hasNote = note && note.trim() !== '';
+      if (qty !== 0 || hasNote) {
+        addItem(location, item.name, qty, unit, regDate, expDate, note);
+      }
+    }
     setMultiAddVisible(false);
     setMultiItems([]);
   };


### PR DESCRIPTION
## Summary
- keep zero-quantity inventory items that have notes and skip adding empty entries
- ensure shopping list batch save removes only unnoted zero items and saves every selected food
- include item names in batch add modal submissions for reliable processing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f65e2e68c8324b994c48ec1c9c5cc