### PR TITLE
feat: add dark theme and modern icons

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
@@ -15,10 +15,27 @@ import UserDataScreen from './src/screens/UserDataScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Text } from 'react-native';
 import { CustomFoodsProvider } from './src/context/CustomFoodsContext';
 import { CategoriesProvider } from './src/context/CategoriesContext';
 
 const Stack = createNativeStackNavigator();
+
+Text.defaultProps = Text.defaultProps || {};
+Text.defaultProps.style = [Text.defaultProps.style, { color: '#fff' }];
+
+const AppTheme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    primary: '#bb86fc',
+    background: '#121212',
+    card: '#1f1f1f',
+    text: '#ffffff',
+    border: '#272727',
+  },
+};
 
 export default function App() {
   return (
@@ -29,9 +46,22 @@ export default function App() {
             <InventoryProvider>
               <ShoppingProvider>
                 <RecipeProvider>
-                  <NavigationContainer>
-                    <StatusBar style="auto" />
-                    <Stack.Navigator>
+                  <NavigationContainer theme={AppTheme}>
+                    <StatusBar style="light" />
+                    <Stack.Navigator
+                      screenOptions={{
+                        headerTintColor: '#fff',
+                        headerTitleStyle: { color: '#fff' },
+                        headerBackground: () => (
+                          <LinearGradient
+                            colors={['#6a00ff', '#2196f3']}
+                            style={{ flex: 1 }}
+                            start={{ x: 0, y: 0 }}
+                            end={{ x: 1, y: 0 }}
+                          />
+                        ),
+                      }}
+                    >
                     <Stack.Screen
                       name="Inventory"
                       component={InventoryScreen}

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -25,7 +25,8 @@
     "react-native-markdown-display": "^7.0.2",
     "react-native-safe-area-context": "5.4.0",
     "react-native-web": "^0.20.0",
-    "react-native-screens": "~4.11.1"
+    "react-native-screens": "~4.11.1",
+    "expo-linear-gradient": "~14.1.5"
   },
   "devDependencies": {
     "metro": "^0.82.5",

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -21,6 +21,7 @@ import { getFoodIcon } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { Ionicons } from '@expo/vector-icons';
 
 function StorageSelector({ current, onChange }) {
   const { locations } = useLocations();
@@ -117,22 +118,22 @@ export default function InventoryScreen({ navigation }) {
             }
             style={{ marginRight: 15 }}
           >
-            <Text style={{ fontSize: 18 }}>🔍</Text>
+            <Ionicons name="search" size={22} color="#fff" />
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => navigation.navigate('Recipes')}
             style={{ marginRight: 15 }}
           >
-            <Text style={{ fontSize: 18 }}>📖</Text>
+            <Ionicons name="book-outline" size={22} color="#fff" />
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => navigation.navigate('Shopping')}
             style={{ marginRight: 15 }}
           >
-            <Text style={{ fontSize: 18 }}>🛒</Text>
+            <Ionicons name="cart-outline" size={22} color="#fff" />
           </TouchableOpacity>
           <TouchableOpacity onPress={() => setMenuVisible(true)}>
-            <Text style={{ fontSize: 24, paddingHorizontal: 6, backgroundColor: '#eee', borderRadius: 4 }}>⋮</Text>
+            <Ionicons name="ellipsis-vertical" size={22} color="#fff" />
           </TouchableOpacity>
         </View>
       ),
@@ -355,7 +356,7 @@ export default function InventoryScreen({ navigation }) {
   };
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: '#121212' }}>
       <StorageSelector current={storage} onChange={setStorage} />
       <View style={{ padding: 20, flex: 1 }}>
         {searchVisible && (
@@ -401,7 +402,7 @@ export default function InventoryScreen({ navigation }) {
                           flexDirection: 'row',
                           alignItems: 'center',
                           paddingVertical: 5,
-                          backgroundColor: selected ? '#d0ebff' : undefined,
+                          backgroundColor: selected ? '#33395d' : undefined,
                           opacity: item.quantity === 0 ? 0.5 : 1,
                         }}
                         onLongPress={() => {
@@ -504,7 +505,7 @@ export default function InventoryScreen({ navigation }) {
                         >
                           <View
                             style={{
-                              backgroundColor: selected ? '#d0ebff' : '#eee',
+                              backgroundColor: selected ? '#33395d' : '#1f1f1f',
                               borderRadius: 8,
                               position: 'relative',
                               overflow: 'hidden',
@@ -516,7 +517,7 @@ export default function InventoryScreen({ navigation }) {
                                   position: 'absolute',
                                   top: 0,
                                   left: 0,
-                                  backgroundColor: '#fff',
+                                  backgroundColor: '#2e2e2e',
                                   borderRadius: 3,
                                   width: overlaySize,
                                   height: overlaySize,
@@ -567,24 +568,24 @@ export default function InventoryScreen({ navigation }) {
       </TouchableOpacity>
 
       {multiSelect && selectedItems.length > 0 && (
-        <View
-          style={{
-            position: 'absolute',
-            left: 0,
-            right: 0,
-            bottom: 0,
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            justifyContent: 'space-around',
-            backgroundColor: '#fff',
-            padding: 10,
-            borderTopWidth: 1,
-            borderColor: '#ccc',
-          }}
-        >
+          <View
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+              justifyContent: 'space-around',
+              backgroundColor: '#1f1f1f',
+              padding: 10,
+              borderTopWidth: 1,
+              borderColor: '#333',
+            }}
+          >
           <TouchableOpacity
             style={{
-              backgroundColor: '#e0e0e0',
+              backgroundColor: '#33395d',
               paddingVertical: 8,
               paddingHorizontal: 12,
               borderRadius: 6,
@@ -599,7 +600,7 @@ export default function InventoryScreen({ navigation }) {
           </TouchableOpacity>
           <TouchableOpacity
             style={{
-              backgroundColor: '#e0e0e0',
+              backgroundColor: '#33395d',
               paddingVertical: 8,
               paddingHorizontal: 12,
               borderRadius: 6,
@@ -611,7 +612,7 @@ export default function InventoryScreen({ navigation }) {
           </TouchableOpacity>
           <TouchableOpacity
             style={{
-              backgroundColor: '#e0e0e0',
+              backgroundColor: '#33395d',
               paddingVertical: 8,
               paddingHorizontal: 12,
               borderRadius: 6,
@@ -681,7 +682,7 @@ export default function InventoryScreen({ navigation }) {
                   position: 'absolute',
                   top: 40,
                   right: 10,
-                  backgroundColor: '#fff',
+                  backgroundColor: '#1f1f1f',
                   padding: 10,
                   borderRadius: 8,
                 }}
@@ -731,7 +732,7 @@ export default function InventoryScreen({ navigation }) {
             <TouchableWithoutFeedback>
               <View
                 style={{
-                  backgroundColor: '#fff',
+                  backgroundColor: '#1f1f1f',
                   padding: 20,
                   borderRadius: 8,
                   width: '80%',
@@ -814,7 +815,7 @@ export default function InventoryScreen({ navigation }) {
             <TouchableWithoutFeedback>
               <View
                 style={{
-                  backgroundColor: '#fff',
+                  backgroundColor: '#1f1f1f',
                   padding: 20,
                   borderRadius: 8,
                   width: '80%',
@@ -910,7 +911,7 @@ export default function InventoryScreen({ navigation }) {
             }}
           >
             <TouchableWithoutFeedback>
-              <View style={{ backgroundColor: '#fff', padding: 20, borderRadius: 8, maxHeight: '80%', width: '80%' }}>
+              <View style={{ backgroundColor: '#1f1f1f', padding: 20, borderRadius: 8, maxHeight: '80%', width: '80%' }}>
                 <Text style={{ marginBottom: 10 }}>
                   Añadir los siguientes {selectedItems.length} elementos a la lista de compras?
                 </Text>
@@ -961,7 +962,7 @@ export default function InventoryScreen({ navigation }) {
             }}
           >
             <TouchableWithoutFeedback>
-              <View style={{ backgroundColor: '#fff', padding: 20, borderRadius: 8 }}>
+              <View style={{ backgroundColor: '#1f1f1f', padding: 20, borderRadius: 8 }}>
                 <Text style={{ marginBottom: 10 }}>
                   {transferType === 'move' ? 'Mover a:' : 'Copiar a:'}
                 </Text>
@@ -986,7 +987,7 @@ export default function InventoryScreen({ navigation }) {
             }}
           >
             <TouchableWithoutFeedback>
-              <View style={{ backgroundColor: '#fff', padding: 20, borderRadius: 8 }}>
+              <View style={{ backgroundColor: '#1f1f1f', padding: 20, borderRadius: 8 }}>
                 <Text style={{ marginBottom: 10 }}>
                   ¿Eliminar {selectedItems.length} items?
                 </Text>

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -9,6 +9,7 @@ import {
   Modal,
   TouchableWithoutFeedback,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import {useShopping} from '../context/ShoppingContext';
 import {useInventory} from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
@@ -137,13 +138,13 @@ export default function ShoppingListScreen() {
   });
 
   return (
-    <View style={{flex:1, padding:20}}>
+    <View style={{flex:1, padding:20, backgroundColor:'#121212'}}>
       <View style={{flexDirection:'row', justifyContent:'space-between', marginBottom:10}}>
         {!selectMode ? (
           <>
             <Button title="Añadir" onPress={() => setPickerVisible(true)} />
             <TouchableOpacity onPress={() => setAutoVisible(true)}>
-              <Text style={{fontSize:24}}>⚡</Text>
+              <Ionicons name="flash-outline" size={24} color="#fff" />
             </TouchableOpacity>
           </>
         ) : (
@@ -179,16 +180,19 @@ export default function ShoppingListScreen() {
                     alignItems:'center',
                     padding:5,
                     backgroundColor: selectMode && selected.includes(index)
-                      ? '#e0f7fa'
+                      ? '#33395d'
                       : item.purchased
-                      ? '#ddd'
+                      ? '#444'
                       : 'transparent',
                   }}
                 >
                   {selectMode && (
-                    <Text style={{marginRight:10}}>
-                      {selected.includes(index) ? '☑️' : '⬜'}
-                    </Text>
+                    <Ionicons
+                      style={{marginRight:10}}
+                      name={selected.includes(index) ? 'checkbox' : 'square-outline'}
+                      size={24}
+                      color="#fff"
+                    />
                   )}
                   {item.icon && (
                     <Image
@@ -199,7 +203,7 @@ export default function ShoppingListScreen() {
                   <Text
                     style={{
                       textDecorationLine: item.purchased ? 'line-through' : 'none',
-                      color: item.purchased ? 'gray' : 'black',
+                      color: item.purchased ? '#777' : '#fff',
                     }}
                   >
                     {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
@@ -247,7 +251,7 @@ export default function ShoppingListScreen() {
             }}
           >
             <TouchableWithoutFeedback>
-              <View style={{backgroundColor:'#fff', padding:20, borderRadius:8}}>
+              <View style={{backgroundColor:'#1f1f1f', padding:20, borderRadius:8}}>
                 <Text style={{marginBottom:10}}>
                   ¿Está seguro de eliminar {selected.length} alimentos de la lista de compras?
                 </Text>
@@ -277,7 +281,7 @@ export default function ShoppingListScreen() {
             }}
           >
             <TouchableWithoutFeedback>
-              <View style={{backgroundColor:'#fff', padding:20, borderRadius:8}}>
+              <View style={{backgroundColor:'#1f1f1f', padding:20, borderRadius:8}}>
                 <Text style={{marginBottom:10}}>
                   ¿Desea añadir todos los elementos que presenten una cantidad de 0 a la lista de compras? Todos los alimentos que ya se encuentren en la lista no se agregarán.
                 </Text>


### PR DESCRIPTION
## Summary
- apply global dark theme with gradient headers
- replace emoji buttons with vector icons
- refresh inventory and shopping list styles
- add expo-linear-gradient dependency to fix bundling

## Testing
- `node -p "require.resolve('expo-linear-gradient')"`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f83956b608324bb6b65d9accfa2bd