### PR TITLE
Improve category name display

### DIFF
--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -281,7 +281,7 @@ export default function FoodPickerModal({
           {baseCategoryNames.map(cat => (
             <View key={cat} style={{ marginBottom: 15 }}>
               <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 5 }}>
-                {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                {baseCategories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
               </Text>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
                 {baseCategories[cat].items.map(name => {

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -17,6 +17,7 @@ import BatchAddItemModal from '../components/BatchAddItemModal';
 import {getFoodIcon} from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
+import { useCategories } from '../context/CategoriesContext';
 
 export default function ShoppingListScreen() {
   const {
@@ -30,6 +31,7 @@ export default function ShoppingListScreen() {
   const {inventory, addItem: addInventoryItem, removeItem: removeInventoryItem} = useInventory();
   const { getLabel } = useUnits();
   const { locations } = useLocations();
+  const { categories } = useCategories();
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);
   const [selectedFood, setSelectedFood] = useState(null);
@@ -157,7 +159,9 @@ export default function ShoppingListScreen() {
       <ScrollView>
         {Object.entries(grouped).map(([cat, items]) => (
           <View key={cat} style={{marginBottom:10}}>
-            <Text style={{fontSize:18, fontWeight:'bold', marginBottom:5}}>{cat}</Text>
+            <Text style={{fontSize:18, fontWeight:'bold', marginBottom:5}}>
+              {categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
+            </Text>
             {items.map(({item, index}) => (
               <TouchableOpacity
                 key={index}


### PR DESCRIPTION
## Summary
- Use CategoriesContext to show human-readable category titles in shopping list
- Display default category names correctly in food picker management screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fa9ea12ec832490360f85bee38bf8