### PR TITLE
style: redesign inventory item cards

### DIFF
--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -504,40 +504,64 @@ export default function InventoryScreen({ navigation }) {
                         >
                           <View
                             style={{
-                              backgroundColor: selected ? '#d0ebff' : '#eee',
-                              borderRadius: 8,
+                              backgroundColor: selected ? '#5d9eff' : '#4d4d4d',
+                              borderRadius: 12,
+                              padding: 6,
                               position: 'relative',
                               overflow: 'hidden',
+                              alignItems: 'center',
                             }}
                           >
                             {daysLeft !== null && (
                               <View
                                 style={{
                                   position: 'absolute',
-                                  top: 0,
-                                  left: 0,
+                                  top: 4,
+                                  left: 4,
                                   backgroundColor: '#fff',
-                                  borderRadius: 3,
-                                  width: overlaySize,
-                                  height: overlaySize,
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
+                                  borderRadius: 8,
+                                  paddingHorizontal: 6,
+                                  paddingVertical: 2,
                                 }}
                               >
                                 <Text style={{ fontSize: overlaySize * 0.4 }}>D-{daysLeft}</Text>
                               </View>
                             )}
-                            <View style={{ alignItems: 'center', padding: 8 }}>
+                            <View
+                              style={{
+                                backgroundColor: '#6b6b6b',
+                                borderRadius: 8,
+                                padding: 6,
+                                marginBottom: 4,
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                              }}
+                            >
                               {item.icon && (
                                 <Image
                                   source={item.icon}
-                                  style={{ width: 40, height: 40, marginBottom: 4 }}
+                                  style={{ width: 40, height: 40 }}
                                 />
                               )}
-                              <Text style={{ textAlign: 'center', fontSize: 12 }}>
-                                {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
-                              </Text>
                             </View>
+                            <Text
+                              style={{
+                                textAlign: 'center',
+                                fontSize: 12,
+                                color: '#fff',
+                              }}
+                            >
+                              {item.name}
+                            </Text>
+                            <Text
+                              style={{
+                                textAlign: 'center',
+                                fontSize: 10,
+                                color: '#ccc',
+                              }}
+                            >
+                              {item.quantity} {getLabel(item.quantity, item.unit)}
+                            </Text>
                           </View>
                         </TouchableOpacity>
                       );


### PR DESCRIPTION
## Summary
- restyle inventory grid tiles with dark background and inner icon box
- display item name, quantity and unit under icon
- keep expiration badge at top-left for easy tracking

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fb423524483248fb42ff6e4267552