### PR TITLE
Add default expiration days for custom foods

### DIFF
--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -341,6 +341,7 @@ export default function AddCustomFoodModal({ visible, onClose }) {
   const [category, setCategory] = useState(categoryNames[0]);
   const [iconUri, setIconUri] = useState(null);
   const [baseIcon, setBaseIcon] = useState(null);
+  const [expirationDays, setExpirationDays] = useState('');
   const [pickerVisible, setPickerVisible] = useState(false);
   const [manageVisible, setManageVisible] = useState(false);
   const [editingKey, setEditingKey] = useState(null);
@@ -373,6 +374,9 @@ export default function AddCustomFoodModal({ visible, onClose }) {
     setCategory(food.category);
     setIconUri(food.icon);
     setBaseIcon(food.baseIcon);
+    setExpirationDays(
+      food.expirationDays != null ? String(food.expirationDays) : ''
+    );
     setEditingKey(food.key);
     setManageVisible(false);
   };
@@ -383,12 +387,20 @@ export default function AddCustomFoodModal({ visible, onClose }) {
     setCategory(first);
     setIconUri(null);
     setBaseIcon(null);
+    setExpirationDays('');
     setEditingKey(null);
   };
 
   const save = () => {
     if (!name) return;
-    const data = { name, category, icon: iconUri, baseIcon };
+    const days = parseInt(expirationDays, 10);
+    const data = {
+      name,
+      category,
+      icon: iconUri,
+      baseIcon,
+      expirationDays: isNaN(days) ? null : days,
+    };
     if (editingKey) {
       updateCustomFood(editingKey, data);
     } else {
@@ -450,6 +462,13 @@ export default function AddCustomFoodModal({ visible, onClose }) {
               <Text>+</Text>
             </TouchableOpacity>
           </View>
+          <Text>Días de caducidad por defecto</Text>
+          <TextInput
+            style={{ borderWidth:1, marginBottom:10, padding:5 }}
+            keyboardType="numeric"
+            value={expirationDays}
+            onChangeText={setExpirationDays}
+          />
           <Text>Icono</Text>
           {(iconUri || baseIcon) && (
             <Image

--- a/MiAppNevera/src/context/CustomFoodsContext.js
+++ b/MiAppNevera/src/context/CustomFoodsContext.js
@@ -31,18 +31,42 @@ export const CustomFoodsProvider = ({ children }) => {
     });
   }, []);
 
-  const addCustomFood = useCallback(({ name, category, icon, baseIcon }) => {
-    const key = normalizeFoodName(name);
-    const newFood = { name, category, icon: icon || null, baseIcon: baseIcon || null, key };
-    persist(prev => [...prev, newFood]);
-  }, [persist]);
+  const addCustomFood = useCallback(
+    ({ name, category, icon, baseIcon, expirationDays }) => {
+      const key = normalizeFoodName(name);
+      const newFood = {
+        name,
+        category,
+        icon: icon || null,
+        baseIcon: baseIcon || null,
+        expirationDays: expirationDays ?? null,
+        key,
+      };
+      persist(prev => [...prev, newFood]);
+    },
+    [persist],
+  );
 
-  const updateCustomFood = useCallback((key, { name, category, icon, baseIcon }) => {
-    const newKey = normalizeFoodName(name);
-    persist(prev => prev.map(f =>
-      f.key === key ? { name, category, icon: icon || null, baseIcon: baseIcon || null, key: newKey } : f,
-    ));
-  }, [persist]);
+  const updateCustomFood = useCallback(
+    (key, { name, category, icon, baseIcon, expirationDays }) => {
+      const newKey = normalizeFoodName(name);
+      persist(prev =>
+        prev.map(f =>
+          f.key === key
+            ? {
+                name,
+                category,
+                icon: icon || null,
+                baseIcon: baseIcon || null,
+                expirationDays: expirationDays ?? null,
+                key: newKey,
+              }
+            : f,
+        ),
+      );
+    },
+    [persist],
+  );
 
   const removeCustomFood = useCallback(key => {
     persist(prev => prev.filter(f => f.key !== key));

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -1125,6 +1125,8 @@ export function setCustomFoodsMap(list) {
         ...item,
         key,
         baseIcon: item.baseIcon ? normalizeFoodName(item.baseIcon) : null,
+        expirationDays:
+          item.expirationDays != null ? Number(item.expirationDays) : null,
       };
     });
   }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Aplicación de inventario de alimentos escrita en React Native con soporte para web.
 
+## Funcionalidades
+- Gestión de inventario por ubicaciones (nevera, congelador, despensa).
+- Lista de compras integrada.
+- Recetario con ingredientes del inventario.
+- Categorías, ubicaciones y unidades personalizadas.
+- Creación de alimentos personalizados con iconos propios o predeterminados y días de caducidad por defecto.
+- Persistencia local mediante `AsyncStorage` para uso sin conexión.
+
 ## Estructura
 - `MiAppNevera/App.js`: punto de entrada que configura la navegación entre las pantallas.
 - `MiAppNevera/src/screens`: implementa las pantallas de inicio, categorías (nevera, congelador, despensa) y lista de compras.


### PR DESCRIPTION
## Summary
- allow custom foods to define default expiration days
- prefill expiration dates when adding custom foods to inventory
- document application features in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fd7a010a0832487c4f5792b861a69