### PR TITLE
feat: add modern gray background to main screens

### DIFF
--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -404,7 +404,7 @@ export default function InventoryScreen({ navigation }) {
   };
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: '#f0f0f0' }}>
       <StorageSelector current={storage} onChange={setStorage} />
       <View style={{ padding: 20, flex: 1 }}>
         {searchVisible && (

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -139,7 +139,7 @@ export default function ShoppingListScreen() {
   });
 
   return (
-    <View style={{flex:1, padding:20}}>
+    <View style={{flex:1, padding:20, backgroundColor:'#f0f0f0'}}>
       <View style={{flexDirection:'row', justifyContent:'space-between', marginBottom:10}}>
         {!selectMode ? (
           <>


### PR DESCRIPTION
## Summary
- use a modern gray background on the inventory screen
- apply same gray background to the shopping list

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fe0ec9aa48324b1a48e593669827a