### PR TITLE
Add explicit Expo entry point

### DIFF
--- a/MiAppNevera/index.js
+++ b/MiAppNevera/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -2,7 +2,7 @@
   "name": "MiAppNevera",
   "version": "0.0.1",
   "private": true,
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Summary
- add Expo `index.js` entry to register `App`
- point `package.json` main to the new entry file

## Testing
- `CI=1 npm start`
- `curl -s 'http://localhost:8081/index.bundle?platform=ios&dev=true&hot=false' | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9bd43b08324bdbd5e9605f9fa35