### PR TITLE
feat: add flexible theme system

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
@@ -12,15 +12,18 @@ import SettingsScreen from './src/screens/SettingsScreen';
 import UnitSettingsScreen from './src/screens/UnitSettingsScreen';
 import LocationSettingsScreen from './src/screens/LocationSettingsScreen';
 import UserDataScreen from './src/screens/UserDataScreen';
+import ThemeSettingsScreen from './src/screens/ThemeSettingsScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
 import { CustomFoodsProvider } from './src/context/CustomFoodsContext';
 import { CategoriesProvider } from './src/context/CategoriesContext';
+import { ThemeProvider, useThemeController } from './src/context/ThemeContext';
 
 const Stack = createNativeStackNavigator();
 
-export default function App() {
+function MainApp() {
+  const { themeName } = useThemeController();
   return (
     <CategoriesProvider>
       <CustomFoodsProvider>
@@ -29,8 +32,8 @@ export default function App() {
             <InventoryProvider>
               <ShoppingProvider>
                 <RecipeProvider>
-                  <NavigationContainer>
-                    <StatusBar style="auto" />
+                  <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
+                    <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
                     <Stack.Navigator>
                     <Stack.Screen
                       name="Inventory"
@@ -58,6 +61,11 @@ export default function App() {
                       options={{ title: 'Ajustes' }}
                     />
                     <Stack.Screen
+                      name="ThemeSettings"
+                      component={ThemeSettingsScreen}
+                      options={{ title: 'Tema de colores' }}
+                    />
+                    <Stack.Screen
                       name="UnitSettings"
                       component={UnitSettingsScreen}
                       options={{ title: 'Tipos de unidad' }}
@@ -81,5 +89,13 @@ export default function App() {
         </UnitsProvider>
       </CustomFoodsProvider>
     </CategoriesProvider>
+  );
+}
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <MainApp />
+    </ThemeProvider>
   );
 }

--- a/MiAppNevera/src/components/AddCategoryModal.js
+++ b/MiAppNevera/src/components/AddCategoryModal.js
@@ -1,20 +1,12 @@
 // AddCategoryModal.js – dark–premium v2.2.13
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Modal, View, Text, TextInput, TouchableOpacity, Image, StyleSheet, Platform, TouchableWithoutFeedback } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function AddCategoryModal({ visible, onClose, onSave }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const [name, setName] = useState('');
   const [iconUri, setIconUri] = useState(null);
 
@@ -93,7 +85,7 @@ export default function AddCategoryModal({ visible, onClose, onSave }) {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.35)', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 20 },
   card: {
     backgroundColor: palette.surface,

--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -3,7 +3,7 @@
 // - ScrollView con scrollbar dorada en Web y gutter estable
 // - Gestión de ingredientes/categorías con modales coherentes
 // - Confirmaciones estilizadas y avisos cuando algo está en uso
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -24,23 +24,14 @@ import { useInventory } from '../context/InventoryContext';
 import { useShopping } from '../context/ShoppingContext';
 import { useRecipes } from '../context/RecipeContext';
 import AddCategoryModal from './AddCategoryModal';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 // ========================
 // Gestor de personalizados
 // ========================
 function ManageCustomFoodsModal({ visible, onClose, onEdit }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { customFoods, removeCustomFood } = useCustomFoods();
   const { customCategories, categories, removeCategory } = useCategories();
   const { inventory } = useInventory();
@@ -315,6 +306,8 @@ function ManageCustomFoodsModal({ visible, onClose, onEdit }) {
 // Formulario principal
 // =====================
 export default function AddCustomFoodModal({ visible, onClose }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { addCustomFood, updateCustomFood } = useCustomFoods();
   const { categories, addCategory } = useCategories();
   const categoryNames = Object.keys(categories);
@@ -485,7 +478,7 @@ export default function AddCustomFoodModal({ visible, onClose }) {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   // layout
   headerRow: {
     flexDirection: 'row',

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -1,5 +1,5 @@
-// AddItemModal.js – dark–premium v2.2.6 (consistente con InventoryScreen) 
-import React, { useEffect, useState, useRef } from 'react';
+// AddItemModal.js – dark–premium v2.2.6 (consistente con InventoryScreen)
+import React, { useEffect, useState, useRef, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -20,41 +20,13 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
-
-// ===== Theme (igual que InventoryScreen v2.2.6) =====
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  frame: '#3a3429',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  accent2: '#4caf50',
-  danger: '#ff5252',
-  warn: '#ff9f43',
-};
-
-// ===== Gradients por ítem (determinísticos por nombre) =====
-const gradientOptions = [
-  { colors: ['#2a231a', '#1c1a17', '#121316'], locations: [0, 0.55, 1], start: {x: 0.1, y: 0.1}, end: {x: 0.9, y: 0.9} },   // amber
-  { colors: ['#1a212a', '#191d24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.9, y: 0.1}, end: {x: 0.1, y: 0.9} },     // steel
-  { colors: ['#261c2a', '#1e1a24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.2, y: 0.0}, end: {x: 1.0, y: 0.8} },     // violet
-  { colors: ['#1c2422', '#18201e', '#121316'], locations: [0, 0.55, 1], start: {x: 0.0, y: 0.8}, end: {x: 1.0, y: 0.2} },     // teal
-  { colors: ['#241f1a', '#1c1a19', '#121316'], locations: [0, 0.55, 1], start: {x: 0.7, y: 0.0}, end: {x: 0.0, y: 0.9} },     // copper
-  { colors: ['#281a1d', '#1f191b', '#121316'], locations: [0, 0.6, 1], start: {x: 0.0, y: 0.0}, end: {x: 1.0, y: 1.0} },     // wine
-];
-const hashString = (s) => {
-  if (!s) return 0;
-  let h = 0;
-  for (let i = 0; i < s.length; i++) { h = (h << 5) - h + s.charCodeAt(i); h |= 0; }
-  return Math.abs(h);
-};
-const gradientForKey = (key) => gradientOptions[hashString(key) % gradientOptions.length];
+import { useTheme, useThemeController } from '../context/ThemeContext';
+import { gradientForKey } from '../theme/gradients';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
+  const palette = useTheme();
+  const { themeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const today = new Date().toISOString().split('T')[0];
   const { units } = useUnits();
   const { locations } = useLocations();
@@ -93,7 +65,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
     }
   }, [visible, initialLocation, today, units, locations, foodName]);
 
-  const g = gradientForKey(foodName || 'item');
+  const g = gradientForKey(themeName, foodName || 'item');
 
   return (
     <Modal visible={visible} animationType="slide" transparent>
@@ -251,7 +223,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   sheet: {
     maxHeight: '92%',
@@ -376,3 +348,4 @@ const styles = StyleSheet.create({
   },
   saveFabText: { color: '#1b1d22', fontSize: 16, fontWeight: '600' },
 });
+

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -23,18 +23,7 @@ import FoodPickerModal from './FoodPickerModal';
 import { getFoodIcon } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import * as ImagePicker from 'expo-image-picker';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function AddRecipeModal({
   visible,
@@ -42,6 +31,8 @@ export default function AddRecipeModal({
   onClose,
   initialRecipe,
 }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { units, getLabel } = useUnits();
   const [name, setName] = useState('');
   const [image, setImage] = useState('');
@@ -430,7 +421,7 @@ const save = () => {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   headerRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -4,7 +4,7 @@
 // - Inputs de fecha gris (combina con el tema)
 // - Barra de desplazamiento sutil color dorado en web con gutter estable
 // - Modal de confirmación estilizado
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -25,41 +25,13 @@ import AddShoppingItemModal from './AddShoppingItemModal';
 import DatePicker from './DatePicker';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
-
-// ===== Theme (mismo que InventoryScreen/AddItemModal) =====
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  frame: '#3a3429',
-  border: '#2c3038',
-  accent: '#F2B56B',    // dorado
-  accent2: '#4caf50',
-  danger: '#ff5252',
-  warn: '#ff9f43',
-};
-
-// ===== Gradients por ítem (determinísticos por nombre) =====
-const gradientOptions = [
-  { colors: ['#2a231a', '#1c1a17', '#121316'], locations: [0, 0.55, 1], start: {x: 0.1, y: 0.1}, end: {x: 0.9, y: 0.9} },   // amber
-  { colors: ['#1a212a', '#191d24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.9, y: 0.1}, end: {x: 0.1, y: 0.9} },     // steel
-  { colors: ['#261c2a', '#1e1a24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.2, y: 0.0}, end: {x: 1.0, y: 0.8} },     // violet
-  { colors: ['#1c2422', '#18201e', '#121316'], locations: [0, 0.55, 1], start: {x: 0.0, y: 0.8}, end: {x: 1.0, y: 0.2} },     // teal
-  { colors: ['#241f1a', '#1c1a19', '#121316'], locations: [0, 0.55, 1], start: {x: 0.7, y: 0.0}, end: {x: 0.0, y: 0.9} },     // copper
-  { colors: ['#281a1d', '#1f191b', '#121316'], locations: [0, 0.6, 1], start: {x: 0.0, y: 0.0}, end: {x: 1.0, y: 1.0} },     // wine
-];
-const hashString = (s) => {
-  if (!s) return 0;
-  let h = 0;
-  for (let i = 0; i < s.length; i++) { h = (h << 5) - h + s.charCodeAt(i); h |= 0; }
-  return Math.abs(h);
-};
-const gradientForKey = (key) => gradientOptions[hashString(key) % gradientOptions.length];
+import { useTheme, useThemeController } from '../context/ThemeContext';
+import { gradientForKey } from '../theme/gradients';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
+  const palette = useTheme();
+  const { themeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { addItem: addShoppingItem } = useShopping();
   const { units } = useUnits();
   const { locations } = useLocations();
@@ -93,7 +65,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
     }
   }, [visible, item, units, locations]);
 
-  const g = gradientForKey(item?.name || 'item');
+  const g = gradientForKey(themeName, item?.name || 'item');
 
   const handleSave = () => {
     onSave({
@@ -299,7 +271,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   sheet: {
     maxHeight: '92%',
@@ -449,4 +421,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
 

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -1,5 +1,5 @@
 // FoodPickerModal.js – dark–premium v2.2.10 (stable, overlay-like scrollbars on web)
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import {
   Button,
   Image,
@@ -26,39 +26,8 @@ import AddCustomFoodModal from './AddCustomFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { LinearGradient } from 'expo-linear-gradient';
-
-// ===== Theme (igual que InventoryScreen/AddItemModal v2.2.6) =====
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  frame: '#3a3429',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  accent2: '#4caf50',
-  danger: '#ff5252',
-  warn: '#ff9f43',
-};
-
-// ===== Gradients por ítem (determinísticos por nombre) =====
-const gradientOptions = [
-  { colors: ['#2a231a', '#1c1a17', '#121316'], locations: [0, 0.55, 1], start: {x: 0.1, y: 0.1}, end: {x: 0.9, y: 0.9} },   // amber
-  { colors: ['#1a212a', '#191d24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.9, y: 0.1}, end: {x: 0.1, y: 0.9} },     // steel
-  { colors: ['#261c2a', '#1e1a24', '#121316'], locations: [0, 0.6, 1], start: {x: 0.2, y: 0.0}, end: {x: 1.0, y: 0.8} },     // violet
-  { colors: ['#1c2422', '#18201e', '#121316'], locations: [0, 0.55, 1], start: {x: 0.0, y: 0.8}, end: {x: 1.0, y: 0.2} },     // teal
-  { colors: ['#241f1a', '#1c1a19', '#121316'], locations: [0, 0.55, 1], start: {x: 0.7, y: 0.0}, end: {x: 0.0, y: 0.9} },     // copper
-  { colors: ['#281a1d', '#1f191b', '#121316'], locations: [0, 0.6, 1], start: {x: 0.0, y: 0.0}, end: {x: 1.0, y: 1.0} },     // wine
-];
-const hashString = (s) => {
-  if (!s) return 0;
-  let h = 0;
-  for (let i = 0; i < s.length; i++) { h = (h << 5) - h + s.charCodeAt(i); h |= 0; }
-  return Math.abs(h);
-};
-const gradientForKey = (key) => gradientOptions[hashString(key) % gradientOptions.length];
+import { useTheme, useThemeController } from '../context/ThemeContext';
+import { gradientForKey } from '../theme/gradients';
 
 export default function FoodPickerModal({
   visible,
@@ -66,6 +35,9 @@ export default function FoodPickerModal({
   onClose,
   onMultiSelect,
 }) {
+  const palette = useTheme();
+  const { themeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { categories } = useCategories();
   const categoryNames = Object.keys(categories);
   const baseCategoryNames = Object.keys(baseCategories);
@@ -211,7 +183,7 @@ export default function FoodPickerModal({
               >
                 {categoryNames.map((cat) => {
                   const active = currentCategory === cat;
-                  const g = gradientForKey(cat);
+                  const g = gradientForKey(themeName, cat);
                   return (
                     <Pressable
                       key={cat}
@@ -267,7 +239,7 @@ export default function FoodPickerModal({
             >
               {foods.map(food => {
                 const isSelected = selected.includes(food.key);
-                const g = gradientForKey(food.key);
+                const g = gradientForKey(themeName, food.key);
                 return (
                   <TouchableOpacity
                     key={food.key}
@@ -421,7 +393,7 @@ export default function FoodPickerModal({
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
   sheet: {
     flex: 1,
@@ -564,3 +536,4 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
 });
+

--- a/MiAppNevera/src/context/ThemeContext.js
+++ b/MiAppNevera/src/context/ThemeContext.js
@@ -1,0 +1,22 @@
+import React, { createContext, useContext, useState, useMemo } from 'react';
+import { Appearance } from 'react-native';
+import { themes } from '../theme';
+
+const ThemeContext = createContext({
+  theme: themes.dark,
+  themeName: 'dark',
+  setThemeName: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const scheme = Appearance.getColorScheme();
+  const [themeName, setThemeName] = useState(scheme === 'light' ? 'light' : 'dark');
+  const theme = useMemo(() => themes[themeName] || themes.dark, [themeName]);
+  const value = useMemo(() => ({ theme, themeName, setThemeName }), [theme, themeName]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext).theme;
+export const useThemeController = () => useContext(ThemeContext);
+
+export default ThemeContext;

--- a/MiAppNevera/src/screens/LocationSettingsScreen.js
+++ b/MiAppNevera/src/screens/LocationSettingsScreen.js
@@ -1,5 +1,5 @@
 // LocationSettingsScreen.js – dark–premium v2.2.13
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useMemo } from 'react';
 import {
   View,
   Text,
@@ -14,22 +14,13 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { useLocations } from '../context/LocationsContext';
 import { useInventory } from '../context/InventoryContext';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 const icons = ['🥶','❄️','🗃️','📦','🍽️','🧊','🥫','🥕','🥩','🥛'];
 
 export default function LocationSettingsScreen() {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   useLayoutEffect(() => {
     nav.setOptions?.({
@@ -39,7 +30,7 @@ export default function LocationSettingsScreen() {
       headerShadowVisible: false,
       title: 'Ubicaciones',
     });
-  }, [nav]);
+  }, [nav, palette]);
 
   const { locations, addLocation, updateLocation, removeLocation, toggleActive } = useLocations();
   const { inventory } = useInventory();
@@ -189,7 +180,7 @@ export default function LocationSettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   list: {
     ...(Platform.OS === 'web'

--- a/MiAppNevera/src/screens/RecipeBookScreen.js
+++ b/MiAppNevera/src/screens/RecipeBookScreen.js
@@ -1,24 +1,16 @@
 // RecipeBookScreen.js – dark–premium v2.2.14
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useState, useMemo } from 'react';
 import { View, Text, ScrollView, Image, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { useRecipes } from '../context/RecipeContext';
 import { useInventory } from '../context/InventoryContext';
 import AddRecipeModal from '../components/AddRecipeModal';
 import { useLocations } from '../context/LocationsContext';
 import { useNavigation } from '@react-navigation/native';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function RecipeBookScreen({ navigation }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   const { recipes, addRecipe } = useRecipes();
   const { inventory } = useInventory();
@@ -38,7 +30,7 @@ export default function RecipeBookScreen({ navigation }) {
         </TouchableOpacity>
       ),
     });
-  }, [nav]);
+  }, [nav, palette]);
 
   const hasIngredients = (recipe) => {
     return recipe.ingredients.every((ing) => {
@@ -94,7 +86,7 @@ export default function RecipeBookScreen({ navigation }) {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   headerIconBtn: {
     backgroundColor: palette.surface2,

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -21,20 +21,11 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useNavigation } from '@react-navigation/native';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  border: '#2c3038',
-  accent: '#F2B56B',
-  danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function RecipeDetailScreen({ route }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   const { index } = route.params;
   const { recipes, updateRecipe } = useRecipes();
@@ -95,7 +86,7 @@ export default function RecipeDetailScreen({ route }) {
         </View>
       ),
     });
-  }, [nav, missing, recipe]);
+  }, [nav, missing, recipe, palette]);
 
   if (!recipe) {
     return (
@@ -229,7 +220,7 @@ export default function RecipeDetailScreen({ route }) {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   scroll: {
     backgroundColor: palette.bg,
     ...(Platform.OS === 'web'

--- a/MiAppNevera/src/screens/SettingsScreen.js
+++ b/MiAppNevera/src/screens/SettingsScreen.js
@@ -1,15 +1,13 @@
 
 // SettingsScreen.js – dark–premium v2.2.12
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-
-const palette = {
-  bg: '#121316', surface: '#191b20', surface2: '#20242c', surface3: '#262b35',
-  text: '#ECEEF3', textDim: '#A8B1C0', border: '#2c3038', accent: '#F2B56B',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function SettingsScreen({ navigation }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   useLayoutEffect(() => {
     nav.setOptions?.({
@@ -18,12 +16,17 @@ export default function SettingsScreen({ navigation }) {
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [nav]);
+  }, [nav, palette]);
 
   return (
     <View style={styles.container}>
       <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}
         showsVerticalScrollIndicator={Platform.OS === 'web'}>
+        <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('ThemeSettings')}>
+          <Text style={styles.itemTitle}>Tema de colores</Text>
+          <Text style={styles.itemDesc}>Elige entre claro u oscuro.</Text>
+        </TouchableOpacity>
+
         <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('UnitSettings')}>
           <Text style={styles.itemTitle}>Tipos de unidad</Text>
           <Text style={styles.itemDesc}>Gestiona singular y plural de tus unidades.</Text>
@@ -43,7 +46,7 @@ export default function SettingsScreen({ navigation }) {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   scroll: {
     ...(Platform.OS === 'web' ? {
@@ -57,3 +60,4 @@ const styles = StyleSheet.create({
   itemTitle: { color: palette.text, fontWeight: '700', marginBottom: 4 },
   itemDesc: { color: palette.textDim },
 });
+

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -24,21 +24,11 @@ import BatchAddItemModal from '../components/BatchAddItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
-
-const palette = {
-  bg: '#121316',
-  surface: '#191b20',
-  surface2: '#20242c',
-  surface3: '#262b35',
-  text: '#ECEEF3',
-  textDim: '#A8B1C0',
-  frame: '#3a3429',
-  border: '#2c3038',
-  accent: '#F2B56B',    // dorado
-  danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function ShoppingListScreen() {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const navigation = useNavigation();
   useLayoutEffect(() => {
     navigation.setOptions?.({
@@ -47,7 +37,7 @@ export default function ShoppingListScreen() {
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [navigation]);
+  }, [navigation, palette]);
 
   const {
     list,
@@ -356,7 +346,7 @@ export default function ShoppingListScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   headerRow: {
     paddingHorizontal: 14,
@@ -480,4 +470,5 @@ const styles = StyleSheet.create({
     marginHorizontal: 6,
   },
 });
+
 

--- a/MiAppNevera/src/screens/ThemeSettingsScreen.js
+++ b/MiAppNevera/src/screens/ThemeSettingsScreen.js
@@ -1,0 +1,54 @@
+import React, { useLayoutEffect, useMemo } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, ScrollView } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTheme, useThemeController } from '../context/ThemeContext';
+
+export default function ThemeSettingsScreen() {
+  const palette = useTheme();
+  const { themeName, setThemeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  const nav = useNavigation();
+
+  useLayoutEffect(() => {
+    nav.setOptions?.({
+      headerStyle: { backgroundColor: palette.surface },
+      headerTintColor: palette.text,
+      headerTitleStyle: { color: palette.text },
+      headerShadowVisible: false,
+    });
+  }, [nav, palette]);
+
+  const themes = [
+    { key: 'dark', label: 'Dark Premium' },
+    { key: 'light', label: 'Claro' },
+  ];
+
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}
+        showsVerticalScrollIndicator={Platform.OS === 'web'}>
+        {themes.map(t => (
+          <TouchableOpacity key={t.key} style={styles.item} onPress={() => setThemeName(t.key)}>
+            <Text style={styles.itemTitle}>{t.label}</Text>
+            {themeName === t.key ? <Text style={styles.current}>Actual</Text> : null}
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const createStyles = (palette) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: palette.bg },
+  scroll: {
+    ...(Platform.OS === 'web' ? {
+      scrollbarWidth: 'thin',
+      scrollbarColor: `${palette.accent} ${palette.surface2}`,
+      scrollbarGutter: 'stable both-edges',
+      overscrollBehavior: 'contain',
+    } : {}),
+  },
+  item: { backgroundColor: palette.surface2, borderWidth: 1, borderColor: palette.border, borderRadius: 12, padding: 14, marginBottom: 12 },
+  itemTitle: { color: palette.text, fontWeight: '700' },
+  current: { color: palette.accent, marginTop: 4 },
+});

--- a/MiAppNevera/src/screens/UnitSettingsScreen.js
+++ b/MiAppNevera/src/screens/UnitSettingsScreen.js
@@ -1,16 +1,14 @@
 
 // UnitSettingsScreen.js – dark–premium v2.2.12
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useMemo } from 'react';
 import { View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useUnits } from '../context/UnitsContext';
-
-const palette = {
-  bg: '#121316', surface: '#191b20', surface2: '#20242c', surface3: '#262b35',
-  text: '#ECEEF3', textDim: '#A8B1C0', border: '#2c3038', accent: '#F2B56B', danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function UnitSettingsScreen() {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   useLayoutEffect(() => {
     nav.setOptions?.({
@@ -19,7 +17,7 @@ export default function UnitSettingsScreen() {
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [nav]);
+  }, [nav, palette]);
 
   const { units, addUnit, updateUnit, removeUnit } = useUnits();
   const [singular, setSingular] = useState('');
@@ -87,7 +85,7 @@ export default function UnitSettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   list: {
     ...(Platform.OS === 'web' ? {
@@ -111,3 +109,4 @@ const styles = StyleSheet.create({
   primaryBtn: { backgroundColor: palette.accent, borderColor: '#e2b06c', borderWidth: 1, paddingVertical: 10, borderRadius: 10, alignItems: 'center' },
   primaryBtnText: { color: '#1b1d22', fontWeight: '700' },
 });
+

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -1,6 +1,6 @@
 
 // UserDataScreen.js – dark–premium v2.2.12
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useMemo } from 'react';
 import {
   View, Text, Modal, TouchableOpacity, TouchableWithoutFeedback,
   StyleSheet, Platform, ScrollView
@@ -14,13 +14,11 @@ import { useShopping } from '../context/ShoppingContext';
 import { useRecipes } from '../context/RecipeContext';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { exportBackup, importBackup } from '../utils/backup';
-
-const palette = {
-  bg: '#121316', surface: '#191b20', surface2: '#20242c', surface3: '#262b35',
-  text: '#ECEEF3', textDim: '#A8B1C0', border: '#2c3038', accent: '#F2B56B', danger: '#e53935',
-};
+import { useTheme } from '../context/ThemeContext';
 
 export default function UserDataScreen() {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const navigation = useNavigation();
   useLayoutEffect(() => {
     navigation.setOptions?.({
@@ -29,7 +27,7 @@ export default function UserDataScreen() {
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [navigation]);
+  }, [navigation, palette]);
 
   const { resetInventory } = useInventory();
   const { resetUnits } = useUnits();
@@ -119,7 +117,7 @@ export default function UserDataScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (palette) => StyleSheet.create({
   container: { flex: 1, backgroundColor: palette.bg },
   scroll: {
     ...(Platform.OS === 'web' ? {
@@ -144,3 +142,4 @@ const styles = StyleSheet.create({
   modalBody: { color: palette.textDim, marginBottom: 12 },
   modalRow: { flexDirection: 'row' },
 });
+

--- a/MiAppNevera/src/theme/gradients.js
+++ b/MiAppNevera/src/theme/gradients.js
@@ -1,0 +1,35 @@
+const darkGradients = [
+  { colors: ['#2a231a', '#1c1a17', '#121316'], locations: [0, 0.55, 1], start: { x: 0.1, y: 0.1 }, end: { x: 0.9, y: 0.9 } },
+  { colors: ['#1a212a', '#191d24', '#121316'], locations: [0, 0.6, 1], start: { x: 0.9, y: 0.1 }, end: { x: 0.1, y: 0.9 } },
+  { colors: ['#261c2a', '#1e1a24', '#121316'], locations: [0, 0.6, 1], start: { x: 0.2, y: 0.0 }, end: { x: 1.0, y: 0.8 } },
+  { colors: ['#1c2422', '#18201e', '#121316'], locations: [0, 0.55, 1], start: { x: 0.0, y: 0.8 }, end: { x: 1.0, y: 0.2 } },
+  { colors: ['#241f1a', '#1c1a19', '#121316'], locations: [0, 0.55, 1], start: { x: 0.7, y: 0.0 }, end: { x: 0.0, y: 0.9 } },
+  { colors: ['#281a1d', '#1f191b', '#121316'], locations: [0, 0.6, 1], start: { x: 0.0, y: 0.0 }, end: { x: 1.0, y: 1.0 } },
+];
+
+const lightGradients = [
+  { colors: ['#ffffff', '#fffbd5', '#d1f3ff'], locations: [0, 0.55, 1], start: { x: 0.1, y: 0.1 }, end: { x: 0.9, y: 0.9 } },
+  { colors: ['#ffffff', '#d1f3ff', '#fffbd5'], locations: [0, 0.6, 1], start: { x: 0.9, y: 0.1 }, end: { x: 0.1, y: 0.9 } },
+  { colors: ['#fffbd5', '#ffffff', '#d1f3ff'], locations: [0, 0.6, 1], start: { x: 0.2, y: 0.0 }, end: { x: 1.0, y: 0.8 } },
+  { colors: ['#d1f3ff', '#fffbd5', '#ffffff'], locations: [0, 0.55, 1], start: { x: 0.0, y: 0.8 }, end: { x: 1.0, y: 0.2 } },
+  { colors: ['#fffbd5', '#d1f3ff', '#ffffff'], locations: [0, 0.55, 1], start: { x: 0.7, y: 0.0 }, end: { x: 0.0, y: 0.9 } },
+  { colors: ['#d1f3ff', '#ffffff', '#fffbd5'], locations: [0, 0.6, 1], start: { x: 0.0, y: 0.0 }, end: { x: 1.0, y: 1.0 } },
+];
+
+const hashString = (s = '') => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h);
+};
+
+export const gradientForKey = (themeName, key) => {
+  const options = themeName === 'light' ? lightGradients : darkGradients;
+  return options[hashString(key) % options.length];
+};
+
+export const gradients = { dark: darkGradients, light: lightGradients };
+
+export default gradientForKey;

--- a/MiAppNevera/src/theme/index.js
+++ b/MiAppNevera/src/theme/index.js
@@ -1,0 +1,33 @@
+export const dark = {
+  bg: '#121316',
+  surface: '#191b20',
+  surface2: '#20242c',
+  surface3: '#262b35',
+  text: '#ECEEF3',
+  textDim: '#A8B1C0',
+  frame: '#3a3429',
+  border: '#2c3038',
+  accent: '#F2B56B',
+  accent2: '#4caf50',
+  danger: '#ff5252',
+  warn: '#ff9f43',
+};
+
+export const light = {
+  bg: '#ffffff',
+  surface: '#f5f5f5',
+  surface2: '#eeeeee',
+  surface3: '#e0e0e0',
+  text: '#1b1d22',
+  textDim: '#4a5568',
+  frame: '#d1c7bd',
+  border: '#d1d5db',
+  accent: '#d88c34',
+  accent2: '#4caf50',
+  danger: '#e11d48',
+  warn: '#f59e0b',
+};
+
+export const themes = { dark, light };
+
+export default dark;


### PR DESCRIPTION
## Summary
- centralize color palettes in a reusable theme module
- add ThemeProvider and hook to switch between light and dark modes
- expose theme selection screen from Settings
- provide themed gradients for item cards with a white-yellow-celeste scheme in light mode
- update inventory header and location tabs to reflect the active theme

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a224da93a483249eb3955315412b13