### PR TITLE
Fix selection color in light theme

### DIFF
--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -600,7 +600,7 @@ const createStyles = (palette) => StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 10,
   },
-  rowSelected: { backgroundColor: '#2a231a' },
+  rowSelected: { backgroundColor: palette.selected },
   rowText: { color: palette.text },
   rowSub: { color: palette.textDim, fontSize: 12 },
   icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -522,7 +522,7 @@ const createStyles = (palette) => StyleSheet.create({
     paddingHorizontal: 10,
     marginBottom: 6,
   },
-  ingRowSelected: { backgroundColor: '#2a231a', borderColor: '#6a4a1a' },
+  ingRowSelected: { backgroundColor: palette.selected, borderColor: '#6a4a1a' },
   ingIcon: { width: 30, height: 30, marginRight: 8, resizeMode: 'contain' },
   ingText: { color: palette.text },
 

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -206,7 +206,7 @@ export default function RecipeDetailScreen({ route }) {
                       addItems(recipe.ingredients.map((ing) => ({ name: ing.name, quantity: ing.quantity, unit: ing.unit })));
                       setConfirmVisible(false);
                     }}
-                    style={[styles.modalBtn, { backgroundColor: '#2a231a', borderColor: '#6a4a1a' }]}
+                    style={[styles.modalBtn, { backgroundColor: palette.selected, borderColor: palette.frame }]}
                   >
                     <Text style={{ color: palette.accent, fontWeight: '700' }}>Añadir todos</Text>
                   </TouchableOpacity>

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -414,7 +414,7 @@ const createStyles = (palette) => StyleSheet.create({
     backgroundColor: palette.surface2,
   },
   rowPurchased: { backgroundColor: '#17191d' },
-  rowSelected: { backgroundColor: '#2a231a', borderLeftWidth: 3, borderLeftColor: palette.accent },
+  rowSelected: { backgroundColor: palette.selected, borderLeftWidth: 3, borderLeftColor: palette.accent },
   check: {
     width: 22, height: 22, borderRadius: 6,
     borderWidth: 1, borderColor: palette.border,

--- a/MiAppNevera/src/theme/index.js
+++ b/MiAppNevera/src/theme/index.js
@@ -11,6 +11,7 @@ export const dark = {
   accent2: '#4caf50',
   danger: '#ff5252',
   warn: '#ff9f43',
+  selected: '#2a231a',
 };
 
 export const light = {
@@ -26,6 +27,7 @@ export const light = {
   accent2: '#4caf50',
   danger: '#e11d48',
   warn: '#f59e0b',
+  selected: '#fbe8d1',
 };
 
 export const themes = { dark, light };


### PR DESCRIPTION
## Summary
- add `selected` color to theme palette
- use themed background for selected rows in shopping list and modals

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a24c7e3a9c8324a63e0aecfe60615d