### PR TITLE
chore: configure Android package and OAuth client

### DIFF
--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -8,8 +8,9 @@
       "android",
       "web"
     ],
+    "scheme": "frigoflow",
     "android": {
-      "package": "com.anonymous.miappnevera"
+      "package": "com.freigoflow.app"
     },
     "extra": {
       "eas": {

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -17,6 +17,7 @@ import { exportBackup, importBackup } from '../utils/backup';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
+import * as AuthSession from 'expo-auth-session';
 import { uploadBackupToGoogleDrive, downloadBackupFromGoogleDrive } from '../utils/googleDrive';
 import * as Updates from 'expo-updates';
 
@@ -51,9 +52,11 @@ export default function UserDataScreen() {
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [request, response, promptAsync] = Google.useAuthRequest({
-    clientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+    expoClientId: process.env.EXPO_PUBLIC_EXPO_CLIENT_ID,
+    androidClientId: process.env.EXPO_PUBLIC_ANDROID_CLIENT_ID,
+    webClientId: process.env.EXPO_PUBLIC_WEB_CLIENT_ID,
     scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
-    redirectUri: Platform.select({ web: window.location.origin, default: undefined }),
+    redirectUri: AuthSession.makeRedirectUri({ scheme: 'frigoflow' }),
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- set Android package name to `com.freigoflow.app` and add `frigoflow` scheme
- read Google OAuth client IDs from env vars and use redirect URI with the new scheme

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf7566b88324be7d061636e4b4d4