### PR TITLE
Configure Google authentication for web and Android

### DIFF
--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "MiAppNevera",
     "slug": "miappnevera",
+    "scheme": "miappnevera",
     "version": "0.0.1",
     "platforms": [
       "ios",

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -16,6 +16,7 @@ import { useCustomFoods } from '../context/CustomFoodsContext';
 import { exportBackup, importBackup } from '../utils/backup';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import * as WebBrowser from 'expo-web-browser';
+import * as AuthSession from 'expo-auth-session';
 import * as Google from 'expo-auth-session/providers/google';
 import { uploadBackupToGoogleDrive, downloadBackupFromGoogleDrive } from '../utils/googleDrive';
 import * as Updates from 'expo-updates';
@@ -51,9 +52,11 @@ export default function UserDataScreen() {
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [request, response, promptAsync] = Google.useAuthRequest({
-    clientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+    expoClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+    androidClientId: '388689708365-4g4lnv5ilksj12cghfa17flc68c5d5qk.apps.googleusercontent.com',
+    webClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
     scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
-    redirectUri: Platform.select({ web: window.location.origin, default: undefined }),
+    redirectUri: AuthSession.makeRedirectUri({ scheme: 'miappnevera' }),
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add custom URI scheme to `app.json`
- generate redirect URI with scheme for Google Drive auth
- include Android and web client IDs in Google auth request

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3de4c2efc8324a4ab06aae623fae2