### PR TITLE
Fix proxy redirect and set Expo owner

### DIFF
--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -2,6 +2,8 @@
   "expo": {
     "name": "MiAppNevera",
     "slug": "miappnevera",
+    "owner": "hope-101",
+    "scheme": "miappnevera",
     "version": "0.0.1",
     "platforms": [
       "ios",

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -16,9 +16,11 @@ import { useCustomFoods } from '../context/CustomFoodsContext';
 import { exportBackup, importBackup } from '../utils/backup';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import * as WebBrowser from 'expo-web-browser';
+import * as AuthSession from 'expo-auth-session';
 import * as Google from 'expo-auth-session/providers/google';
 import { uploadBackupToGoogleDrive, downloadBackupFromGoogleDrive } from '../utils/googleDrive';
 import * as Updates from 'expo-updates';
+import Constants from 'expo-constants';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -50,10 +52,21 @@ export default function UserDataScreen() {
   const [googleUser, setGoogleUser] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const isStandalone = Constants.appOwnership === 'standalone';
+  const useProxy = !isStandalone;
+  const owner = Constants.expoConfig?.owner ?? 'anonymous';
+  const slug = Constants.expoConfig?.slug ?? 'miappnevera';
+  const redirectUri = AuthSession.makeRedirectUri({
+    scheme: 'miappnevera',
+    useProxy,
+    projectNameForProxy: `@${owner}/${slug}`,
+  });
   const [request, response, promptAsync] = Google.useAuthRequest({
-    clientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+    expoClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+    androidClientId: '388689708365-4g4lnv5ilksj12cghfa17flc68c5d5qk.apps.googleusercontent.com',
+    webClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
     scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
-    redirectUri: Platform.select({ web: window.location.origin, default: undefined }),
+    redirectUri,
   });
 
   useEffect(() => {
@@ -190,7 +203,11 @@ export default function UserDataScreen() {
               </TouchableOpacity>
             </>
           ) : (
-            <TouchableOpacity style={styles.btn} disabled={!request} onPress={() => promptAsync()}>
+            <TouchableOpacity
+              style={styles.btn}
+              disabled={!request}
+              onPress={() => promptAsync({ useProxy, redirectUri })}
+            >
               <Text style={styles.btnText}>Conectar con Google</Text>
             </TouchableOpacity>
           )}


### PR DESCRIPTION
## Summary
- set Expo `owner` to ensure proper proxy redirect URLs
- derive redirect URI with project name and pass it to Google auth prompt

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3de4c2efc8324a4ab06aae623fae2