### PR TITLE
feat(android): enable edge-to-edge

### DIFF
--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -9,7 +9,8 @@
       "web"
     ],
     "android": {
-      "package": "com.anonymous.miappnevera"
+      "package": "com.anonymous.miappnevera",
+      "edgeToEdgeEnabled": true
     },
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- enable edge-to-edge in Android config to avoid future SDK 36 requirement

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a513c0436483249db45a4a6e49e6c9