### PR TITLE
fix: configure google auth for web and android

### DIFF
--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -50,11 +50,15 @@ export default function UserDataScreen() {
   const [googleUser, setGoogleUser] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    clientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
-    scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
-    redirectUri: Platform.select({ web: window.location.origin, default: undefined }),
-  });
+  const [request, response, promptAsync] = Google.useAuthRequest(
+    {
+      androidClientId: '388689708365-4g4lnv5ilksj12cghfa17flc68c5d5qk.apps.googleusercontent.com',
+      webClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+      scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
+      redirectUri: Platform.OS === 'web' ? window.location.origin : undefined,
+    },
+    { useProxy: Platform.OS !== 'web' }
+  );
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- use platform-specific Google OAuth client IDs
- avoid accessing `window` on native platforms when building redirect URI
- use Expo AuthSession proxy for native sign-in to prevent invalid redirects

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6163e8be48324bf94ab9f88f6b708