### PR TITLE
fix: guard Google Sign-In native module

### DIFF
--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "MiAppNevera",
     "slug": "miappnevera",
+    "scheme": "miappnevera",
     "version": "0.0.1",
     "platforms": [
       "ios",

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -23,6 +23,7 @@
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-auth-session": "^6.2.1",
+    "@react-native-google-signin/google-signin": "^15.0.0",
     "jszip": "^3.10.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/MiAppNevera/src/screens/UserDataScreen.js
+++ b/MiAppNevera/src/screens/UserDataScreen.js
@@ -3,7 +3,7 @@
 import React, { useState, useLayoutEffect, useMemo, useEffect } from 'react';
 import {
   View, Text, Modal, TouchableOpacity, TouchableWithoutFeedback,
-  StyleSheet, Platform, ScrollView, Alert
+  StyleSheet, Platform, ScrollView, Alert, NativeModules
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
@@ -20,7 +20,13 @@ import * as Google from 'expo-auth-session/providers/google';
 import { uploadBackupToGoogleDrive, downloadBackupFromGoogleDrive } from '../utils/googleDrive';
 import * as Updates from 'expo-updates';
 
-WebBrowser.maybeCompleteAuthSession();
+const isWeb = Platform.OS === 'web';
+let GoogleSignin;
+if (!isWeb && NativeModules?.RNGoogleSignin) {
+  GoogleSignin = require('@react-native-google-signin/google-signin').GoogleSignin;
+} else if (isWeb) {
+  WebBrowser.maybeCompleteAuthSession();
+}
 
 export default function UserDataScreen() {
   const palette = useTheme();
@@ -50,11 +56,27 @@ export default function UserDataScreen() {
   const [googleUser, setGoogleUser] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    clientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
-    scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
-    redirectUri: Platform.select({ web: window.location.origin, default: undefined }),
-  });
+  const [request, response, promptAsync] = Google.useAuthRequest(
+    {
+      androidClientId: '388689708365-4g4lnv5ilksj12cghfa17flc68c5d5qk.apps.googleusercontent.com',
+      webClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+      scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
+      ...(isWeb && typeof window !== 'undefined'
+        ? { redirectUri: window.location.origin }
+        : {}),
+    },
+    { useProxy: !isWeb }
+  );
+
+  useEffect(() => {
+    if (GoogleSignin?.configure) {
+      GoogleSignin.configure({
+        scopes: ['https://www.googleapis.com/auth/drive.appdata', 'profile', 'email'],
+        webClientId: '388689708365-54q3jlb6efa8dm3fkfcrbsk25pb41s27.apps.googleusercontent.com',
+        androidClientId: '388689708365-4g4lnv5ilksj12cghfa17flc68c5d5qk.apps.googleusercontent.com',
+      });
+    }
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -70,30 +92,59 @@ export default function UserDataScreen() {
       }
     })();
   }, []);
+  const handleAuthResponse = async (token) => {
+    setGoogleToken(token);
+    try {
+      const userRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const user = await userRes.json();
+      setGoogleUser(user);
+      await AsyncStorage.setItem('googleAuth', JSON.stringify({ token, user }));
+    } catch (e) {
+      console.error('Failed to fetch user info', e);
+    }
+  };
 
   useEffect(() => {
-    if (response?.type === 'success') {
-      const token = response.authentication.accessToken;
-      setGoogleToken(token);
-      (async () => {
-        try {
-          const userRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          const user = await userRes.json();
-          setGoogleUser(user);
-          await AsyncStorage.setItem('googleAuth', JSON.stringify({ token, user }));
-        } catch (e) {
-          console.error('Failed to fetch user info', e);
-        }
-      })();
+    if (isWeb && response?.type === 'success') {
+      handleAuthResponse(response.authentication.accessToken);
     }
-  }, [response]);
+  }, [response, isWeb]);
+
+  const signInNative = async () => {
+    if (GoogleSignin?.hasPlayServices) {
+      try {
+        await GoogleSignin.hasPlayServices();
+        const userInfo = await GoogleSignin.signIn();
+        const { accessToken } = await GoogleSignin.getTokens();
+        setGoogleToken(accessToken);
+        setGoogleUser(userInfo.user);
+        await AsyncStorage.setItem('googleAuth', JSON.stringify({ token: accessToken, user: userInfo.user }));
+        return;
+      } catch (e) {
+        console.error('Google sign-in failed, falling back to web flow', e);
+      }
+    }
+    const res = await promptAsync();
+    if (res?.type === 'success') {
+      await handleAuthResponse(res.authentication.accessToken);
+    } else {
+      Alert.alert('Error', 'No se pudo iniciar sesión con Google.');
+    }
+  };
 
   const handleDisconnect = async () => {
     setGoogleToken(null);
     setGoogleUser(null);
     await AsyncStorage.removeItem('googleAuth');
+    if (GoogleSignin?.signOut) {
+      try {
+        await GoogleSignin.signOut();
+      } catch (e) {
+        console.error('Google sign-out failed', e);
+      }
+    }
   };
 
   const handleUpload = async () => {
@@ -190,7 +241,11 @@ export default function UserDataScreen() {
               </TouchableOpacity>
             </>
           ) : (
-            <TouchableOpacity style={styles.btn} disabled={!request} onPress={() => promptAsync()}>
+            <TouchableOpacity
+              style={styles.btn}
+              disabled={isWeb && !request}
+              onPress={isWeb ? () => promptAsync() : signInNative}
+            >
               <Text style={styles.btnText}>Conectar con Google</Text>
             </TouchableOpacity>
           )}


### PR DESCRIPTION
## Summary
- avoid requiring `RNGoogleSignin` in Expo Go by checking native module presence
- configure and sign out of Google only when native module is available

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6163e8be48324bf94ab9f88f6b708