### PR TITLE
docs: actualizar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ Aplicación de inventario de alimentos escrita en React Native con soporte para 
 ## Funcionalidades
 - Gestión de inventario por ubicaciones (nevera, congelador, despensa).
 - Lista de compras integrada.
-- Recetario con ingredientes del inventario.
+- Recetario con imágenes, dificultad, número de personas y pasos, usando ingredientes del inventario.
 - Categorías, ubicaciones y unidades personalizadas.
 - Creación de alimentos personalizados con iconos propios o predeterminados y días de caducidad por defecto.
+- Añadir varios alimentos al inventario de una sola vez.
+- Tema claro/oscuro con persistencia.
+- Respaldo e importación de datos (ZIP) y sincronización con Google Drive mediante inicio de sesión con Google.
 - Persistencia local mediante `AsyncStorage` para uso sin conexión.
 
 ## Estructura
@@ -15,6 +18,11 @@ Aplicación de inventario de alimentos escrita en React Native con soporte para 
 - `MiAppNevera/src/screens`: implementa las pantallas de inicio, categorías (nevera, congelador, despensa) y lista de compras.
 - `MiAppNevera/src/context`: hooks de estado con persistencia en `AsyncStorage`.
 - `MiAppNevera/assets/foods.json`: estructura de inventario inicial (vacía por defecto).
+
+## Datos importantes
+- Los ID de cliente de Google para la sincronización en Drive están definidos en `MiAppNevera/src/screens/UserDataScreen.js`.
+- El `projectId` de EAS se encuentra en `MiAppNevera/app.json` (`29bdbb1e-a7ff-4f47-a1c8-178ab45939ff`).
+- Los respaldos se almacenan en Google Drive como `RefriMudanza_<fecha>.zip` y se conservan las 10 últimas revisiones.
 
 ## Desarrollo
 1. Instalar dependencias
@@ -38,6 +46,20 @@ Aplicación de inventario de alimentos escrita en React Native con soporte para 
    ```bash
    npm start
    ```
+
+## Builds con EAS
+
+Requiere `eas-cli` y una cuenta de Expo.
+
+### APK (distribución interna)
+```bash
+eas build -p android --profile preview
+```
+
+### AAB (Play Store)
+```bash
+eas build -p android --profile production
+```
 
 ## Compilar versión de producción en Windows
 


### PR DESCRIPTION
## Summary
- expand feature list in README with backup and theme options
- add key reminders and EAS build commands

## Testing
- `npm test` *(fails: Missing script "test")*
- `eas build -p android --profile preview` *(fails: requires Expo login)*
- `eas build -p android --profile production` *(fails: requires Expo login)*

------
https://chatgpt.com/codex/tasks/task_e_68a6829db12c8324874cf588aad3956b