### PR TITLE
Ajusta colores de botones eliminar segun tema

### DIFF
--- a/MiAppNevera/src/screens/LocationSettingsScreen.js
+++ b/MiAppNevera/src/screens/LocationSettingsScreen.js
@@ -219,8 +219,8 @@ const createStyles = (palette) => StyleSheet.create({
   smallBtnText: { color: palette.text },
   smallBtnAccent: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
   smallBtnAccentText: { color: '#1b1d22', fontWeight: '700' },
-  smallBtnDanger: { backgroundColor: '#2a1d1d', borderColor: '#5a2e2e' },
-  smallBtnDangerText: { color: '#ff9f9f' },
+  smallBtnDanger: { backgroundColor: palette.danger, borderColor: '#ad2c2c' },
+  smallBtnDangerText: { color: '#fff', fontWeight: '700' },
 
   editor: {
     backgroundColor: palette.surface,

--- a/MiAppNevera/src/screens/UnitSettingsScreen.js
+++ b/MiAppNevera/src/screens/UnitSettingsScreen.js
@@ -45,11 +45,11 @@ export default function UnitSettingsScreen() {
       <TouchableOpacity style={styles.smallBtn} onPress={() => startEdit(item)}>
         <Text style={styles.smallBtnText}>✏️ Editar</Text>
       </TouchableOpacity>
-      <TouchableOpacity style={[styles.smallBtn, { backgroundColor: '#2a1d1d', borderColor: '#5a2e2e', marginLeft: 8 }]} onPress={() => removeUnit(item.key)}>
-        <Text style={{ color: '#ff9f9f' }}>🗑️ Eliminar</Text>
-      </TouchableOpacity>
-    </View>
-  );
+        <TouchableOpacity style={[styles.smallBtn, styles.smallBtnDanger, { marginLeft: 8 }]} onPress={() => removeUnit(item.key)}>
+          <Text style={styles.smallBtnDangerText}>🗑️ Eliminar</Text>
+        </TouchableOpacity>
+      </View>
+    );
 
   return (
     <View style={styles.container}>
@@ -100,6 +100,8 @@ const createStyles = (palette) => StyleSheet.create({
   rowSub: { color: palette.textDim, fontSize: 12 },
   smallBtn: { backgroundColor: palette.surface3, borderColor: palette.border, borderWidth: 1, paddingVertical: 8, paddingHorizontal: 10, borderRadius: 10 },
   smallBtnText: { color: palette.text },
+  smallBtnDanger: { backgroundColor: palette.danger, borderColor: '#ad2c2c' },
+  smallBtnDangerText: { color: '#fff', fontWeight: '700' },
   editor: { backgroundColor: palette.surface, borderTopWidth: 1, borderColor: palette.border, padding: 12 },
   editorTitle: { color: palette.text, fontWeight: '700', marginBottom: 6 },
   input: { backgroundColor: palette.surface2, color: palette.text, borderColor: palette.border, borderWidth: 1, borderRadius: 10, paddingHorizontal: 10, paddingVertical: Platform.OS === 'web' ? 10 : 8, marginBottom: 8 },


### PR DESCRIPTION
## Resumen
- Usa la paleta `danger` para los botones de eliminar en Configuración de unidades
- Usa la paleta `danger` para los botones de eliminar en Configuración de ubicaciones

## Pruebas
- `npm test` (falla: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a68b1448b083249d0a0c96bfc71ffc