### PR TITLE
feat: add saved shopping lists and custom items

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -6,6 +6,7 @@ import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
 import { InventoryProvider } from './src/context/InventoryContext';
 import { ShoppingProvider } from './src/context/ShoppingContext';
+import { SavedListsProvider } from './src/context/SavedListsContext';
 import RecipeBookScreen from './src/screens/RecipeBookScreen';
 import RecipeDetailScreen from './src/screens/RecipeDetailScreen';
 import { RecipeProvider } from './src/context/RecipeContext';
@@ -14,6 +15,7 @@ import UnitSettingsScreen from './src/screens/UnitSettingsScreen';
 import LocationSettingsScreen from './src/screens/LocationSettingsScreen';
 import UserDataScreen from './src/screens/UserDataScreen';
 import ThemeSettingsScreen from './src/screens/ThemeSettingsScreen';
+import SavedListsScreen from './src/screens/SavedListsScreen';
 import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
@@ -41,10 +43,11 @@ function MainApp() {
           <LocationsProvider>
             <InventoryProvider>
               <ShoppingProvider>
-                <RecipeProvider>
-                  <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
-                    <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
-                    <Stack.Navigator>
+                <SavedListsProvider>
+                  <RecipeProvider>
+                    <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
+                      <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
+                      <Stack.Navigator>
                     <Stack.Screen
                       name="Inventory"
                       component={InventoryScreen}
@@ -54,6 +57,11 @@ function MainApp() {
                       name="Shopping"
                       component={ShoppingListScreen}
                       options={{ title: 'Compras' }}
+                    />
+                    <Stack.Screen
+                      name="SavedLists"
+                      component={SavedListsScreen}
+                      options={{ title: 'Listas guardadas' }}
                     />
                     <Stack.Screen
                       name="Recipes"
@@ -90,9 +98,10 @@ function MainApp() {
                       component={UserDataScreen}
                       options={{ title: 'Datos de usuario' }}
                     />
-                    </Stack.Navigator>
-                  </NavigationContainer>
-                </RecipeProvider>
+                      </Stack.Navigator>
+                    </NavigationContainer>
+                  </RecipeProvider>
+                </SavedListsProvider>
               </ShoppingProvider>
             </InventoryProvider>
           </LocationsProvider>

--- a/MiAppNevera/src/components/AddMiscItemModal.js
+++ b/MiAppNevera/src/components/AddMiscItemModal.js
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { useUnits } from '../context/UnitsContext';
+
+export default function AddMiscItemModal({ visible, onSave, onClose }) {
+  const { units } = useUnits();
+  const [name, setName] = useState('');
+  const [quantity, setQuantity] = useState(1);
+  const [unit, setUnit] = useState(units[0]?.key || 'units');
+
+  useEffect(() => {
+    if (visible) {
+      setName('');
+      setQuantity(1);
+      setUnit(units[0]?.key || 'units');
+    }
+  }, [visible, units]);
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={{ flex: 1, padding: 20 }}>
+        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10 }}>Añadir personalizado</Text>
+        <TextInput
+          style={{ borderWidth: 1, padding: 8, marginBottom: 10 }}
+          placeholder="Nombre"
+          value={name}
+          onChangeText={setName}
+        />
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
+          <Text style={{ marginRight: 10 }}>Cantidad:</Text>
+          <TouchableOpacity onPress={() => setQuantity(q => Math.max(0, q - 1))} style={{ borderWidth: 1, padding: 5, marginRight: 5 }}>
+            <Text>◀</Text>
+          </TouchableOpacity>
+          <TextInput
+            style={{ borderWidth: 1, padding: 5, marginRight: 5, width: 60, textAlign: 'center' }}
+            keyboardType="numeric"
+            value={quantity.toString()}
+            onChangeText={t => setQuantity(parseFloat(t.replace(/[^0-9.]/g, '')) || 0)}
+          />
+          <TouchableOpacity onPress={() => setQuantity(q => q + 1)} style={{ borderWidth: 1, padding: 5 }}>
+            <Text>▶</Text>
+          </TouchableOpacity>
+        </View>
+        <Text>Unidad</Text>
+        <View style={{ flexDirection: 'row', marginBottom: 10 }}>
+          {units.map(opt => (
+            <TouchableOpacity
+              key={opt.key}
+              style={{ padding: 8, borderWidth: 1, borderColor: '#ccc', marginRight: 10, backgroundColor: unit === opt.key ? '#ddd' : '#fff' }}
+              onPress={() => setUnit(opt.key)}
+            >
+              <Text>{opt.plural}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <TouchableOpacity onPress={onClose} style={{ padding: 10, borderWidth: 1, borderRadius: 8 }}>
+            <Text>Cancelar</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => onSave({ name, quantity: quantity || 0, unit })} style={{ padding: 10, borderWidth: 1, borderRadius: 8 }}>
+            <Text>Guardar</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/MiAppNevera/src/components/SaveShoppingListModal.js
+++ b/MiAppNevera/src/components/SaveShoppingListModal.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Modal, View, Text, TextInput, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SaveShoppingListModal({ visible, items = [], initialName = '', initialNote = '', onSave, onClose }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  const [name, setName] = useState(initialName);
+  const [note, setNote] = useState(initialNote);
+
+  useEffect(() => {
+    if (visible) {
+      setName(initialName);
+      setNote(initialNote);
+    }
+  }, [visible, initialName, initialNote]);
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <Text style={styles.title}>Guardar lista</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Nombre"
+          placeholderTextColor={palette.textDim}
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          style={[styles.input, { height: 80 }]}
+          placeholder="Nota"
+          placeholderTextColor={palette.textDim}
+          value={note}
+          onChangeText={setNote}
+          multiline
+        />
+        <ScrollView style={styles.itemsBox}>
+          {items.map((it, idx) => (
+            <Text key={idx} style={styles.itemTxt}>
+              {it.name} — {it.quantity} {it.unit}
+            </Text>
+          ))}
+        </ScrollView>
+        <View style={styles.btnRow}>
+          <TouchableOpacity onPress={onClose} style={[styles.btn, { backgroundColor: palette.surface3 }]}> 
+            <Text style={{ color: palette.text }}>Cancelar</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => onSave({ name, note })} style={[styles.btn, { backgroundColor: palette.accent }]}> 
+            <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Guardar</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = (palette) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: palette.bg, padding: 20 },
+  title: { fontSize: 18, fontWeight: '700', color: palette.text, marginBottom: 12 },
+  input: { borderWidth: 1, borderColor: palette.border, borderRadius: 8, padding: 8, color: palette.text, marginBottom: 12 },
+  itemsBox: { flex: 1, borderWidth: 1, borderColor: palette.border, borderRadius: 8, padding: 10, marginBottom: 12 },
+  itemTxt: { color: palette.text },
+  btnRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  btn: { flex: 1, alignItems: 'center', paddingVertical: 10, borderRadius: 8, borderWidth: 1, borderColor: palette.border, marginHorizontal: 6 },
+});

--- a/MiAppNevera/src/context/SavedListsContext.js
+++ b/MiAppNevera/src/context/SavedListsContext.js
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const SavedListsContext = createContext();
+
+export const SavedListsProvider = ({ children }) => {
+  const [savedLists, setSavedLists] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('savedShoppingLists');
+        if (stored) setSavedLists(JSON.parse(stored));
+      } catch (e) {
+        console.error('Failed to load saved lists', e);
+      }
+    })();
+  }, []);
+
+  const persist = useCallback(updater => {
+    setSavedLists(prev => {
+      const data = typeof updater === 'function' ? updater(prev) : updater;
+      AsyncStorage.setItem('savedShoppingLists', JSON.stringify(data)).catch(e => {
+        console.error('Failed to save lists', e);
+      });
+      return data;
+    });
+  }, []);
+
+  const addList = useCallback((name, note, items) => {
+    const id = Date.now().toString();
+    persist(prev => [...prev, { id, name, note, items }]);
+  }, [persist]);
+
+  const updateList = useCallback((id, name, note) => {
+    persist(prev => prev.map(l => l.id === id ? { ...l, name, note } : l));
+  }, [persist]);
+
+  const removeList = useCallback(id => {
+    persist(prev => prev.filter(l => l.id !== id));
+  }, [persist]);
+
+  const value = useMemo(() => ({ savedLists, addList, updateList, removeList }), [savedLists, addList, updateList, removeList]);
+
+  return (
+    <SavedListsContext.Provider value={value}>
+      {children}
+    </SavedListsContext.Provider>
+  );
+};
+
+export const useSavedLists = () => useContext(SavedListsContext);

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -61,6 +61,19 @@ export const ShoppingProvider = ({children}) => {
     persist(prev => [...prev, ...newItems]);
   }, [persist]);
 
+  // Añade un ítem sin icono y con categoría fija "varios".
+  const addCustomItem = useCallback((name, quantity = 1, unit = 'units') => {
+    const newItem = {
+      name,
+      quantity,
+      unit,
+      icon: undefined,
+      foodCategory: 'varios',
+      purchased: false,
+    };
+    persist(prev => [...prev, newItem]);
+  }, [persist]);
+
   const togglePurchased = useCallback(index => {
     persist(prev => prev.map((item, idx) =>
       idx === index ? {...item, purchased: !item.purchased} : item,
@@ -90,9 +103,19 @@ export const ShoppingProvider = ({children}) => {
     });
   }, []);
 
+  // Reemplaza la lista completa (usado al cargar listas guardadas)
+  const replaceList = useCallback(items => {
+    const mapped = items.map(it => ({
+      ...it,
+      icon: it.icon || getFoodIcon(it.name),
+      foodCategory: it.foodCategory || getFoodCategory(it.name) || 'varios',
+    }));
+    persist(mapped);
+  }, [persist]);
+
   const value = useMemo(
-    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping}),
-    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping],
+    () => ({list, addItem, addItems, addCustomItem, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList}),
+    [list, addItem, addItems, addCustomItem, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList],
   );
 
   return (

--- a/MiAppNevera/src/screens/SavedListsScreen.js
+++ b/MiAppNevera/src/screens/SavedListsScreen.js
@@ -1,0 +1,64 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+import { useSavedLists } from '../context/SavedListsContext';
+import { useShopping } from '../context/ShoppingContext';
+import SaveShoppingListModal from '../components/SaveShoppingListModal';
+import { useNavigation } from '@react-navigation/native';
+
+export default function SavedListsScreen() {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  const { savedLists, removeList, updateList } = useSavedLists();
+  const { replaceList } = useShopping();
+  const navigation = useNavigation();
+  const [editing, setEditing] = useState(null); // list object
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        {savedLists.map(list => (
+          <View key={list.id} style={styles.card}>
+            <Text style={styles.cardTitle}>{list.name}</Text>
+            {list.note ? <Text style={styles.cardNote}>{list.note}</Text> : null}
+            <View style={styles.cardActions}>
+              <TouchableOpacity onPress={() => { replaceList(list.items); navigation.navigate('Shopping'); }} style={styles.smallBtn}>
+                <Text style={styles.btnText}>Cargar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => setEditing(list)} style={styles.smallBtn}>
+                <Text style={styles.btnText}>Editar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => removeList(list.id)} style={[styles.smallBtn, styles.smallBtnDanger]}>
+                <Text style={[styles.btnText, { color: '#fff' }]}>Eliminar</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))}
+        {savedLists.length === 0 && (
+          <Text style={{ color: palette.textDim }}>No hay listas guardadas.</Text>
+        )}
+      </ScrollView>
+      {editing && (
+        <SaveShoppingListModal
+          visible={true}
+          items={editing.items}
+          initialName={editing.name}
+          initialNote={editing.note}
+          onClose={() => setEditing(null)}
+          onSave={({ name, note }) => { updateList(editing.id, name, note); setEditing(null); }}
+        />
+      )}
+    </View>
+  );
+}
+
+const createStyles = (palette) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: palette.bg },
+  card: { borderWidth: 1, borderColor: palette.border, backgroundColor: palette.surface, borderRadius: 12, padding: 12, marginBottom: 12 },
+  cardTitle: { color: palette.text, fontWeight: '700', fontSize: 16 },
+  cardNote: { color: palette.textDim, marginTop: 4 },
+  cardActions: { flexDirection: 'row', marginTop: 8 },
+  smallBtn: { marginRight: 8, backgroundColor: palette.accent, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 8 },
+  smallBtnDanger: { backgroundColor: palette.danger },
+  btnText: { color: '#1b1d22', fontWeight: '700' },
+});

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -25,6 +25,9 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
+import AddMiscItemModal from '../components/AddMiscItemModal';
+import SaveShoppingListModal from '../components/SaveShoppingListModal';
+import { useSavedLists } from '../context/SavedListsContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -43,14 +46,17 @@ export default function ShoppingListScreen() {
     list,
     addItem,
     addItems,
+    addCustomItem,
     togglePurchased,
     removeItems,
     markPurchased,
+    resetShopping,
   } = useShopping();
   const { inventory, addItem: addInventoryItem, removeItem: removeInventoryItem } = useInventory();
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  const { addList } = useSavedLists();
 
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);
@@ -60,6 +66,9 @@ export default function ShoppingListScreen() {
   const [batchVisible, setBatchVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [autoVisible, setAutoVisible] = useState(false);
+  const [miscVisible, setMiscVisible] = useState(false);
+  const [saveVisible, setSaveVisible] = useState(false);
+  const [clearVisible, setClearVisible] = useState(false);
 
   const onSelectFood = (name, icon) => {
     setSelectedFood({ name, icon });
@@ -86,6 +95,23 @@ export default function ShoppingListScreen() {
       .map(it => ({ name: it.name, quantity: 0, unit: it.unit })); // cantidad 0 según especificación
     if (newItems.length) addItems(newItems);
     setAutoVisible(false);
+  };
+
+  const handleSaveList = ({ name, note }) => {
+    addList(name, note, list);
+    setSaveVisible(false);
+  };
+
+  const handleAddMisc = ({ name, quantity, unit }) => {
+    if (name && name.trim() !== '') {
+      addCustomItem(name, quantity, unit);
+    }
+    setMiscVisible(false);
+  };
+
+  const confirmClear = () => {
+    resetShopping();
+    setClearVisible(false);
   };
 
   const toggleSelect = (index) => {
@@ -173,6 +199,18 @@ export default function ShoppingListScreen() {
           <View style={styles.headerActions}>
             <TouchableOpacity style={styles.actionBtn} onPress={() => setPickerVisible(true)}>
               <Text style={styles.actionText}>＋ Añadir</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setMiscVisible(true)}>
+              <Text style={styles.iconEmoji}>✏️</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setSaveVisible(true)}>
+              <Text style={styles.iconEmoji}>💾</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setClearVisible(true)}>
+              <Text style={styles.iconEmoji}>🗑️</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => navigation.navigate('SavedLists')}>
+              <Text style={styles.iconEmoji}>📁</Text>
             </TouchableOpacity>
             <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
               <Text style={styles.iconEmoji}>⚡</Text>
@@ -278,6 +316,17 @@ export default function ShoppingListScreen() {
         onSave={onSave}
         onClose={() => setAddVisible(false)}
       />
+      <AddMiscItemModal
+        visible={miscVisible}
+        onSave={handleAddMisc}
+        onClose={() => setMiscVisible(false)}
+      />
+      <SaveShoppingListModal
+        visible={saveVisible}
+        items={list}
+        onSave={handleSaveList}
+        onClose={() => setSaveVisible(false)}
+      />
       <BatchAddItemModal
         visible={batchVisible}
         items={selected.map(idx => ({ ...list[idx], index: idx }))}
@@ -306,6 +355,35 @@ export default function ShoppingListScreen() {
                   </TouchableOpacity>
                   <TouchableOpacity onPress={deleteSelected} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
                     <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Confirmar limpiar lista */}
+      <Modal
+        visible={clearVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setClearVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setClearVisible(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.card}>
+                <Text style={styles.cardTitle}>Limpiar lista</Text>
+                <Text style={styles.cardBody}>
+                  ¿Eliminar todos los alimentos de la lista de compras?
+                </Text>
+                <View style={styles.cardActions}>
+                  <TouchableOpacity onPress={() => setClearVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
+                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={confirmClear} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>Limpiar</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -355,7 +433,7 @@ const createStyles = (palette) => StyleSheet.create({
     borderColor: palette.border,
     backgroundColor: palette.surface,
   },
-  headerActions: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  headerActions: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap' },
   actionBtn: {
     backgroundColor: palette.accent,
     borderColor: '#e2b06c',


### PR DESCRIPTION
## Summary
- support saving, editing, and loading shopping lists
- add button to clear the current shopping list with confirmation
- allow adding custom "Varios" items and manage via new modals

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a691a77be4832494fee04cca2383bb