### PR TITLE
feat: saved shopping lists with item editing

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -4,8 +4,10 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Platform } from 'react-native';
 import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
+import SavedListsScreen from './src/screens/SavedListsScreen';
 import { InventoryProvider } from './src/context/InventoryContext';
 import { ShoppingProvider } from './src/context/ShoppingContext';
+import { SavedListsProvider } from './src/context/SavedListsContext';
 import RecipeBookScreen from './src/screens/RecipeBookScreen';
 import RecipeDetailScreen from './src/screens/RecipeDetailScreen';
 import { RecipeProvider } from './src/context/RecipeContext';
@@ -40,8 +42,9 @@ function MainApp() {
         <UnitsProvider>
           <LocationsProvider>
             <InventoryProvider>
-              <ShoppingProvider>
-                <RecipeProvider>
+              <SavedListsProvider>
+                <ShoppingProvider>
+                  <RecipeProvider>
                   <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
                     <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
                     <Stack.Navigator>
@@ -54,6 +57,11 @@ function MainApp() {
                       name="Shopping"
                       component={ShoppingListScreen}
                       options={{ title: 'Compras' }}
+                    />
+                    <Stack.Screen
+                      name="SavedLists"
+                      component={SavedListsScreen}
+                      options={{ title: 'Listas guardadas' }}
                     />
                     <Stack.Screen
                       name="Recipes"
@@ -94,7 +102,8 @@ function MainApp() {
                   </NavigationContainer>
                 </RecipeProvider>
               </ShoppingProvider>
-            </InventoryProvider>
+            </SavedListsProvider>
+          </InventoryProvider>
           </LocationsProvider>
         </UnitsProvider>
       </CustomFoodsProvider>

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -128,9 +128,9 @@ export default function FoodPickerModal({
 
   const foods = [...defaultFoods, ...customList];
 
-  // Ancho de las cards de categoría ~ como las cards de alimentos (aprox).
+  // Cards de categoría cuadradas
   const winW = Dimensions.get('window').width;
-  const catCardWidth = Math.max(160, Math.min(240, Math.floor(winW * 0.42)));
+  const catCardSize = Math.max(80, Math.min(120, Math.floor(winW * 0.25)));
 
   // ==== Scrollbar helpers (WEB): mantener gutter estable y "ocultar" con transparencia ====
   const webScrollBase = Platform.OS === 'web' ? { scrollbarWidth: 'thin', scrollbarGutter: 'stable both-edges' } : null;
@@ -147,7 +147,7 @@ export default function FoodPickerModal({
               <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
                 <Text style={styles.iconText}>←</Text>
               </TouchableOpacity>
-              <View style={{ flexDirection: 'row' }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                 <TouchableOpacity
                   onPress={() =>
                     setSearchVisible(v => {
@@ -159,8 +159,11 @@ export default function FoodPickerModal({
                 >
                   <Text style={styles.iconText}>🔍</Text>
                 </TouchableOpacity>
-                <TouchableOpacity onPress={() => setAddVisible(true)} style={[styles.iconBtn, { marginRight: 8 }]}>
-                  <Text style={styles.iconText}>＋</Text>
+                <TouchableOpacity
+                  onPress={() => setAddVisible(true)}
+                  style={[styles.createBtn, { marginRight: 8 }]}
+                >
+                  <Text style={styles.createText}>Crear Nuevo</Text>
                 </TouchableOpacity>
                 <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.iconBtn}>
                   <Text style={styles.iconText}>⋮</Text>
@@ -188,10 +191,10 @@ export default function FoodPickerModal({
                     <Pressable
                       key={cat}
                       onPress={() => setCurrentCategory(cat)}
-                      style={{ width: catCardWidth, paddingHorizontal: 6 }}
+                      style={{ paddingHorizontal: 6 }}
                     >
-                      <View style={[styles.catCard, active && styles.catCardActive]}>
-                        <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.catCardGrad}>
+                      <View style={[styles.catCard, active && styles.catCardActive, { width: catCardSize, height: catCardSize }]}>
+                        <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={[styles.catCardGrad, { flex: 1 }]}> 
                           <View style={styles.catIconBox}>
                             {categories[cat]?.icon && (
                               <Image
@@ -424,6 +427,16 @@ const createStyles = (palette) => StyleSheet.create({
     borderColor: palette.border,
   },
   iconText: { color: palette.text, fontSize: 18 },
+  createBtn: {
+    flex: 1,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.accent,
+    borderRadius: 8,
+  },
+  createText: { color: palette.bg, fontSize: 14, fontWeight: '600' },
 
   // === Categorías (cards grandes en carrusel) ===
   catBar: {

--- a/MiAppNevera/src/components/ListPreviewModal.js
+++ b/MiAppNevera/src/components/ListPreviewModal.js
@@ -1,0 +1,38 @@
+import React, { useMemo } from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+import ShoppingListPreview from './ShoppingListPreview';
+
+export default function ListPreviewModal({ visible, name, items = [], onClose }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
+            <Text style={styles.iconText}>←</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>{name || 'Lista'}</Text>
+        </View>
+        <ShoppingListPreview items={items} style={{ flex: 1 }} />
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: palette.bg },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 14,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface,
+    },
+    iconBtn: { marginRight: 12 },
+    iconText: { color: palette.text, fontSize: 18 },
+    title: { color: palette.text, fontWeight: '700', fontSize: 18 },
+  });

--- a/MiAppNevera/src/components/SaveListModal.js
+++ b/MiAppNevera/src/components/SaveListModal.js
@@ -1,0 +1,167 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Modal, View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import ShoppingListPreview from './ShoppingListPreview';
+import AddShoppingItemModal from './AddShoppingItemModal';
+import FoodPickerModal from './FoodPickerModal';
+import { getFoodCategory } from '../foodIcons';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SaveListModal({ visible, items = [], initialName = '', initialNote = '', onSave, onClose }) {
+  const [name, setName] = useState('');
+  const [note, setNote] = useState('');
+  const [localItems, setLocalItems] = useState([]);
+  const [editIdx, setEditIdx] = useState(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [adding, setAdding] = useState(null);
+  const [addVisible, setAddVisible] = useState(false);
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  useEffect(() => {
+    if (visible) {
+      setName(initialName);
+      setNote(initialNote);
+      setLocalItems(items);
+      setSelectMode(false);
+      setSelected([]);
+      setPickerVisible(false);
+      setAddVisible(false);
+      setAdding(null);
+    }
+  }, [visible, initialName, initialNote, items]);
+
+  const handleItemSave = ({ quantity, unit }) => {
+    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit } : it));
+    setEditIdx(null);
+  };
+
+  const toggleSelect = idx => {
+    setSelected(prev => {
+      const exists = prev.includes(idx);
+      const next = exists ? prev.filter(i => i !== idx) : [...prev, idx];
+      if (next.length === 0) setSelectMode(false);
+      return next;
+    });
+  };
+
+  const handleItemPress = idx => {
+    if (selectMode) {
+      toggleSelect(idx);
+    } else {
+      setEditIdx(idx);
+    }
+  };
+
+  const handleItemLongPress = idx => {
+    if (!selectMode) {
+      setSelectMode(true);
+      setSelected([idx]);
+    } else {
+      toggleSelect(idx);
+    }
+  };
+
+  const deleteSelected = () => {
+    setLocalItems(prev => prev.filter((_, i) => !selected.includes(i)));
+    setSelected([]);
+    setSelectMode(false);
+  };
+
+  const onSelectFood = (name, icon) => {
+    setAdding({ name, icon });
+    setPickerVisible(false);
+    setAddVisible(true);
+  };
+
+  const handleAddSave = ({ quantity, unit }) => {
+    if (adding) {
+      setLocalItems(prev => [
+        ...prev,
+        {
+          name: adding.name,
+          icon: adding.icon,
+          quantity,
+          unit,
+          foodCategory: getFoodCategory(adding.name),
+        },
+      ]);
+      setAdding(null);
+      setAddVisible(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <Text style={styles.title}>Guardar lista</Text>
+        <TextInput
+          placeholder="Nombre"
+          style={styles.input}
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          placeholder="Nota"
+          style={styles.input}
+          value={note}
+          onChangeText={setNote}
+        />
+        <ShoppingListPreview
+          items={localItems}
+          selected={selected}
+          onItemPress={handleItemPress}
+          onItemLongPress={handleItemLongPress}
+          style={{ flex: 1, marginBottom: 10 }}
+        />
+        <View style={styles.actions}>
+          <Button
+            title={selectMode ? 'Cancelar selección' : 'Cancelar'}
+            onPress={selectMode ? () => { setSelectMode(false); setSelected([]); } : onClose}
+          />
+          <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+          {selectMode && selected.length > 0 && (
+            <Button title="Eliminar" color="#b00" onPress={deleteSelected} />
+          )}
+          <Button title="Guardar" onPress={() => onSave({ name: name.trim(), note, items: localItems })} />
+        </View>
+        <AddShoppingItemModal
+          visible={editIdx !== null}
+          foodName={localItems[editIdx]?.name}
+          foodIcon={localItems[editIdx]?.icon}
+          initialQuantity={localItems[editIdx]?.quantity}
+          initialUnit={localItems[editIdx]?.unit}
+          onSave={handleItemSave}
+          onClose={() => setEditIdx(null)}
+        />
+        <FoodPickerModal
+          visible={pickerVisible}
+          onSelect={onSelectFood}
+          onClose={() => setPickerVisible(false)}
+        />
+        <AddShoppingItemModal
+          visible={addVisible}
+          foodName={adding?.name}
+          foodIcon={adding?.icon}
+          onSave={handleAddSave}
+          onClose={() => setAddVisible(false)}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, padding: 20, backgroundColor: palette.bg },
+    title: { fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: palette.text },
+    input: {
+      borderWidth: 1,
+      borderColor: palette.border,
+      padding: 8,
+      marginBottom: 10,
+      color: palette.text,
+    },
+    actions: { flexDirection: 'row', justifyContent: 'space-between' },
+  });

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import { ScrollView, View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { useUnits } from '../context/UnitsContext';
+import { useCategories } from '../context/CategoriesContext';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ShoppingListPreview({ items = [], onItemPress, onItemLongPress, selected = [], style }) {
+  const { getLabel } = useUnits();
+  const { categories } = useCategories();
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  const grouped = items.reduce((acc, it, index) => {
+    const cat = it.foodCategory || 'varios';
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push({ item: it, index });
+    return acc;
+  }, {});
+
+  return (
+    <ScrollView style={[styles.scroll, style]} contentContainerStyle={{ padding: 14, paddingBottom: 40 }}>
+      {Object.entries(grouped).map(([cat, arr]) => (
+        <View key={cat} style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>
+              {categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
+            </Text>
+          </View>
+          {arr.map(({ item, index }) => {
+            const isSelected = selected.includes(index);
+            return (
+              <TouchableOpacity
+                key={index}
+                onPress={() => onItemPress && onItemPress(index)}
+                onLongPress={() => onItemLongPress && onItemLongPress(index)}
+                disabled={!onItemPress && !onItemLongPress}
+              >
+                <View style={[styles.row, isSelected && styles.rowSelected]}>
+                  {item.icon && <Image source={item.icon} style={styles.icon} />}
+                  <Text style={styles.rowText} numberOfLines={2}>
+                    {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    scroll: {
+      backgroundColor: palette.bg,
+    },
+    section: {
+      marginBottom: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      borderRadius: 12,
+      overflow: 'hidden',
+    },
+    sectionHeader: {
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      backgroundColor: palette.surface3,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+    },
+    sectionTitle: { color: palette.text, fontWeight: '700' },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+    },
+    rowSelected: {
+      backgroundColor: palette.selected,
+      borderLeftWidth: 3,
+      borderLeftColor: palette.accent,
+    },
+    icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
+    rowText: { color: palette.text },
+  });

--- a/MiAppNevera/src/context/SavedListsContext.js
+++ b/MiAppNevera/src/context/SavedListsContext.js
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const SavedListsContext = createContext();
+
+export const SavedListsProvider = ({ children }) => {
+  const [savedLists, setSavedLists] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('savedLists');
+        if (stored) setSavedLists(JSON.parse(stored));
+      } catch (e) {
+        console.error('Failed to load saved lists', e);
+      }
+    })();
+  }, []);
+
+  const persist = useCallback(updater => {
+    setSavedLists(prev => {
+      const data = typeof updater === 'function' ? updater(prev) : updater;
+      AsyncStorage.setItem('savedLists', JSON.stringify(data)).catch(err => {
+        console.error('Failed to save lists', err);
+      });
+      return data;
+    });
+  }, []);
+
+  const saveList = useCallback((name, note, items, id = null) => {
+    const entry = { id: id ?? Date.now().toString(), name, note, items };
+    persist(prev => {
+      const idx = prev.findIndex(l => l.id === entry.id);
+      if (idx >= 0) {
+        const copy = [...prev];
+        copy[idx] = entry;
+        return copy;
+      }
+      return [...prev, entry];
+    });
+  }, [persist]);
+
+  const deleteList = useCallback(id => {
+    persist(prev => prev.filter(l => l.id !== id));
+  }, [persist]);
+
+  const value = useMemo(() => ({ savedLists, saveList, deleteList }), [savedLists, saveList, deleteList]);
+
+  return (
+    <SavedListsContext.Provider value={value}>
+      {children}
+    </SavedListsContext.Provider>
+  );
+};
+
+export const useSavedLists = () => useContext(SavedListsContext);
+

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -83,6 +83,16 @@ export const ShoppingProvider = ({children}) => {
     ));
   }, [persist]);
 
+  // Replace entire list (used when loading saved lists)
+  const replaceList = useCallback(items => {
+    persist(() => items.map(it => ({
+      ...it,
+      icon: it.icon || getFoodIcon(it.name),
+      foodCategory: it.foodCategory || getFoodCategory(it.name),
+      purchased: !!it.purchased,
+    })));
+  }, [persist]);
+
   const resetShopping = useCallback(() => {
     setList([]);
     AsyncStorage.removeItem('shopping').catch(e => {
@@ -91,8 +101,8 @@ export const ShoppingProvider = ({children}) => {
   }, []);
 
   const value = useMemo(
-    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping}),
-    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping],
+    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList}),
+    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList],
   );
 
   return (

--- a/MiAppNevera/src/screens/SavedListsScreen.js
+++ b/MiAppNevera/src/screens/SavedListsScreen.js
@@ -1,0 +1,159 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Modal, TouchableWithoutFeedback, StyleSheet } from 'react-native';
+import { useSavedLists } from '../context/SavedListsContext';
+import { useShopping } from '../context/ShoppingContext';
+import SaveListModal from '../components/SaveListModal';
+import ListPreviewModal from '../components/ListPreviewModal';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SavedListsScreen({ navigation }) {
+  const { savedLists, deleteList, saveList } = useSavedLists();
+  const { replaceList } = useShopping();
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  const [editing, setEditing] = useState(null);
+  const [previewing, setPreviewing] = useState(null);
+  const [confirmDel, setConfirmDel] = useState(null);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {savedLists.map(list => (
+          <View key={list.id} style={styles.card}>
+            <Text style={styles.title}>{list.name || 'Sin título'}</Text>
+            {list.note ? <Text style={styles.note}>{list.note}</Text> : null}
+            <Text style={styles.count}>{list.items?.length || 0} artículos</Text>
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.actionBtn, { backgroundColor: palette.accent }]}
+                onPress={() => {
+                  replaceList(list.items || []);
+                  navigation.navigate('Shopping');
+                }}
+              >
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cargar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.actionBtn} onPress={() => setPreviewing(list)}>
+                <Text style={styles.actionText}>Previsualizar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.actionBtn} onPress={() => setEditing(list)}>
+                <Text style={styles.actionText}>Editar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.actionBtn, { backgroundColor: palette.danger }]}
+                onPress={() => setConfirmDel(list.id)}
+              >
+                <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+
+      <SaveListModal
+        visible={!!editing}
+        items={editing?.items || []}
+        initialName={editing?.name}
+        initialNote={editing?.note}
+        onSave={({ name, note, items }) => {
+          saveList(name, note, items, editing.id);
+          setEditing(null);
+        }}
+        onClose={() => setEditing(null)}
+      />
+
+      <ListPreviewModal
+        visible={!!previewing}
+        name={previewing?.name}
+        items={previewing?.items || []}
+        onClose={() => setPreviewing(null)}
+      />
+
+      <Modal visible={!!confirmDel} transparent animationType="fade" onRequestClose={() => setConfirmDel(null)}>
+        <TouchableWithoutFeedback onPress={() => setConfirmDel(null)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.cardModal}>
+                <Text style={styles.modalTitle}>Eliminar lista</Text>
+                <Text style={styles.modalBody}>¿Eliminar esta lista guardada?</Text>
+                <View style={styles.modalActions}>
+                  <TouchableOpacity style={[styles.modalBtn, { backgroundColor: palette.surface3 }]} onPress={() => setConfirmDel(null)}>
+                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.modalBtn, { backgroundColor: palette.danger }]}
+                    onPress={() => {
+                      deleteList(confirmDel);
+                      setConfirmDel(null);
+                    }}
+                  >
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </View>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: palette.bg },
+    content: { padding: 14 },
+    card: {
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 12,
+    },
+    title: { color: palette.text, fontWeight: '700', fontSize: 16 },
+    note: { color: palette.textDim, marginVertical: 4 },
+    count: { color: palette.textDim, marginBottom: 8 },
+    actions: { flexDirection: 'row', justifyContent: 'space-between' },
+    actionBtn: {
+      flex: 1,
+      alignItems: 'center',
+      paddingVertical: 8,
+      marginHorizontal: 4,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface3,
+    },
+    actionText: { color: palette.text },
+    modalBackdrop: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0,0,0,0.35)',
+      paddingHorizontal: 20,
+    },
+    cardModal: {
+      backgroundColor: palette.surface,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
+      padding: 16,
+      width: '100%',
+      maxWidth: 420,
+    },
+    modalTitle: { color: palette.text, fontWeight: '700', fontSize: 16, marginBottom: 8 },
+    modalBody: { color: palette.textDim, marginBottom: 14 },
+    modalActions: { flexDirection: 'row', justifyContent: 'space-between' },
+    modalBtn: {
+      flex: 1,
+      alignItems: 'center',
+      paddingVertical: 10,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginHorizontal: 6,
+    },
+  });
+

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -20,11 +20,13 @@ import { useShopping } from '../context/ShoppingContext';
 import { useInventory } from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
 import AddShoppingItemModal from '../components/AddShoppingItemModal';
+import SaveListModal from '../components/SaveListModal';
 import BatchAddItemModal from '../components/BatchAddItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
+import { useSavedLists } from '../context/SavedListsContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -46,7 +48,9 @@ export default function ShoppingListScreen() {
     togglePurchased,
     removeItems,
     markPurchased,
+    resetShopping,
   } = useShopping();
+  const { saveList } = useSavedLists();
   const { inventory, addItem: addInventoryItem, removeItem: removeInventoryItem } = useInventory();
   const { getLabel } = useUnits();
   const { locations } = useLocations();
@@ -60,6 +64,8 @@ export default function ShoppingListScreen() {
   const [batchVisible, setBatchVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [autoVisible, setAutoVisible] = useState(false);
+  const [saveVisible, setSaveVisible] = useState(false);
+  const [clearVisible, setClearVisible] = useState(false);
 
   const onSelectFood = (name, icon) => {
     setSelectedFood({ name, icon });
@@ -113,6 +119,16 @@ export default function ShoppingListScreen() {
     setSelected([]);
     setSelectMode(false);
     setConfirmVisible(false);
+  };
+
+  const handleSaveCurrent = ({ name, note, items }) => {
+    saveList(name, note, items);
+    setSaveVisible(false);
+  };
+
+  const clearAll = () => {
+    resetShopping();
+    setClearVisible(false);
   };
 
   // Guardado por lotes (igual que antes)
@@ -174,9 +190,20 @@ export default function ShoppingListScreen() {
             <TouchableOpacity style={styles.actionBtn} onPress={() => setPickerVisible(true)}>
               <Text style={styles.actionText}>＋ Añadir</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
-              <Text style={styles.iconEmoji}>⚡</Text>
-            </TouchableOpacity>
+            <View style={{ flexDirection: 'row' }}>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
+                <Text style={styles.iconEmoji}>⚡</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setSaveVisible(true)}>
+                <Text style={styles.iconEmoji}>💾</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setClearVisible(true)}>
+                <Text style={styles.iconEmoji}>🗑️</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => navigation.navigate('SavedLists')}>
+                <Text style={styles.iconEmoji}>📁</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ) : (
           <View style={styles.headerActions}>
@@ -284,6 +311,12 @@ export default function ShoppingListScreen() {
         onSave={handleBatchSave}
         onClose={() => setBatchVisible(false)}
       />
+      <SaveListModal
+        visible={saveVisible}
+        items={list}
+        onSave={handleSaveCurrent}
+        onClose={() => setSaveVisible(false)}
+      />
 
       {/* Confirmar eliminación */}
       <Modal
@@ -305,6 +338,33 @@ export default function ShoppingListScreen() {
                     <Text style={{ color: palette.text }}>Cancelar</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={deleteSelected} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Clear all modal */}
+      <Modal
+        visible={clearVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setClearVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setClearVisible(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.card}>
+                <Text style={styles.cardTitle}>Limpiar lista</Text>
+                <Text style={styles.cardBody}>¿Eliminar todos los alimentos de la lista de compras?</Text>
+                <View style={styles.cardActions}>
+                  <TouchableOpacity onPress={() => setClearVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
+                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={clearAll} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
                     <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
                   </TouchableOpacity>
                 </View>


### PR DESCRIPTION
## Summary
- allow multi-select editing of saved shopping lists and add new items
- highlight selected entries in list previews
- remove personalized item support from shopping lists
- rename custom-item button to "Crear Nuevo" with centered accent styling
- match multi-select highlight color to main list and render category cards as squares

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6941a2e888324b4c62d54728d0e15