### PR TITLE
feat: saved shopping lists with item editing

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -4,8 +4,10 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Platform } from 'react-native';
 import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
+import SavedListsScreen from './src/screens/SavedListsScreen';
 import { InventoryProvider } from './src/context/InventoryContext';
 import { ShoppingProvider } from './src/context/ShoppingContext';
+import { SavedListsProvider } from './src/context/SavedListsContext';
 import RecipeBookScreen from './src/screens/RecipeBookScreen';
 import RecipeDetailScreen from './src/screens/RecipeDetailScreen';
 import { RecipeProvider } from './src/context/RecipeContext';
@@ -40,8 +42,9 @@ function MainApp() {
         <UnitsProvider>
           <LocationsProvider>
             <InventoryProvider>
-              <ShoppingProvider>
-                <RecipeProvider>
+              <SavedListsProvider>
+                <ShoppingProvider>
+                  <RecipeProvider>
                   <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
                     <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
                     <Stack.Navigator>
@@ -54,6 +57,11 @@ function MainApp() {
                       name="Shopping"
                       component={ShoppingListScreen}
                       options={{ title: 'Compras' }}
+                    />
+                    <Stack.Screen
+                      name="SavedLists"
+                      component={SavedListsScreen}
+                      options={{ title: 'Listas guardadas' }}
                     />
                     <Stack.Screen
                       name="Recipes"
@@ -94,7 +102,8 @@ function MainApp() {
                   </NavigationContainer>
                 </RecipeProvider>
               </ShoppingProvider>
-            </InventoryProvider>
+            </SavedListsProvider>
+          </InventoryProvider>
           </LocationsProvider>
         </UnitsProvider>
       </CustomFoodsProvider>

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -1,14 +1,21 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Modal,
   View,
   Text,
-  Button,
   TouchableOpacity,
   Image,
   TextInput,
+  StyleSheet,
+  Animated,
+  Pressable,
+  ScrollView,
+  Platform,
 } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useUnits } from '../context/UnitsContext';
+import { useTheme, useThemeController } from '../context/ThemeContext';
+import { gradientForKey } from '../theme/gradients';
 
 export default function AddShoppingItemModal({
   visible,
@@ -19,9 +26,28 @@ export default function AddShoppingItemModal({
   initialQuantity,
   initialUnit,
 }) {
+  const palette = useTheme();
+  const { themeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
+  const qtyScale = useRef(new Animated.Value(1)).current;
+
+  const bumpQty = () => {
+    Animated.sequence([
+      Animated.timing(qtyScale, {
+        toValue: 1.1,
+        duration: 120,
+        useNativeDriver: true,
+      }),
+      Animated.spring(qtyScale, {
+        toValue: 1,
+        friction: 4,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  };
 
   useEffect(() => {
     if (visible) {
@@ -30,70 +56,262 @@ export default function AddShoppingItemModal({
     }
   }, [visible, initialQuantity, initialUnit, units]);
 
+  const g = gradientForKey(themeName, foodName || 'item');
+
   return (
-    <Modal visible={visible} animationType="slide">
-      <View style={{flex:1, padding:20}}>
-        {foodIcon && (
-          <Image source={foodIcon} style={{width:60, height:60, alignSelf:'center', marginBottom:10}} />
-        )}
-        <Text style={{fontSize:18, fontWeight:'bold', marginBottom:10}}>
-          ¿Añadir {foodName} a la lista de compras?
-        </Text>
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            marginBottom: 10,
-          }}
-        >
-          <Text style={{marginRight: 10}}>Cantidad:</Text>
-          <TouchableOpacity
-            onPress={() => setQuantity(q => Math.max(0, q - 1))}
-            style={{borderWidth: 1, padding: 5, marginRight: 5}}
-          >
-            <Text>◀</Text>
-          </TouchableOpacity>
-          <TextInput
-            style={{borderWidth: 1, padding: 5, marginRight: 5, width: 60, textAlign: 'center'}}
-            keyboardType="numeric"
-            value={quantity.toString()}
-            onChangeText={t =>
-              setQuantity(parseFloat(t.replace(/[^0-9.]/g, '')) || 0)
-            }
-          />
-          <TouchableOpacity
-            onPress={() => setQuantity(q => q + 1)}
-            style={{borderWidth: 1, padding: 5}}
-          >
-            <Text>▶</Text>
-          </TouchableOpacity>
-        </View>
-        <Text>Unidad</Text>
-        <View style={{flexDirection:'row', marginBottom:10}}>
-          {units.map(opt => (
-            <TouchableOpacity
-              key={opt.key}
-              style={{
-                padding:8,
-                borderWidth:1,
-                borderColor:'#ccc',
-                marginRight:10,
-                backgroundColor: unit === opt.key ? '#ddd' : '#fff',
-              }}
-              onPress={() => setUnit(opt.key)}
-            >
-              <Text>{opt.plural}</Text>
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.modalBackdrop}>
+        <View style={styles.sheet}>
+          <View style={styles.headerRow}>
+            <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
+              <Text style={styles.iconText}>←</Text>
             </TouchableOpacity>
-          ))}
-        </View>
-        <View style={{flexDirection:'row', justifyContent:'space-between'}}>
-          <Button title="Volver" onPress={onClose} />
-          <Button
-            title="Guardar"
-            onPress={() => onSave({quantity: quantity || 0, unit})}
-          />
+          </View>
+
+          <LinearGradient
+            colors={g.colors}
+            locations={g.locations}
+            start={g.start}
+            end={g.end}
+            style={styles.hero}
+          >
+            <View style={styles.foodIconBox}>
+              {foodIcon && (
+                <Image
+                  source={foodIcon}
+                  style={{ width: 64, height: 64 }}
+                  resizeMode="contain"
+                />
+              )}
+            </View>
+            <Text style={styles.foodName} numberOfLines={2}>
+              {foodName}
+            </Text>
+          </LinearGradient>
+
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={{ padding: 16 }}
+          >
+            <Text style={styles.labelBold}>Cantidad</Text>
+            <View style={styles.qtyRow}>
+              <TouchableOpacity
+                onPress={() => {
+                  setQuantity((q) => Math.max(0, (q || 0) - 1));
+                  bumpQty();
+                }}
+                style={styles.qtyBtn}
+              >
+                <Text style={styles.qtyBtnText}>−</Text>
+              </TouchableOpacity>
+
+              <Animated.View style={{ transform: [{ scale: qtyScale }] }}>
+                <TextInput
+                  style={styles.qtyInput}
+                  keyboardType="numeric"
+                  value={String(quantity)}
+                  onChangeText={(t) => {
+                    const v = parseFloat(t.replace(/[^0-9.]/g, ''));
+                    setQuantity(Number.isFinite(v) ? v : 0);
+                  }}
+                />
+              </Animated.View>
+
+              <TouchableOpacity
+                onPress={() => {
+                  setQuantity((q) => (q || 0) + 1);
+                  bumpQty();
+                }}
+                style={styles.qtyBtn}
+              >
+                <Text style={styles.qtyBtnText}>＋</Text>
+              </TouchableOpacity>
+            </View>
+
+            <Text style={styles.labelBold}>Unidad</Text>
+            <View style={styles.chipWrap}>
+              {units.map((opt, idx) => (
+                <Pressable
+                  key={opt.key}
+                  onPress={() => setUnit(opt.key)}
+                  style={[
+                    styles.chip,
+                    unit === opt.key ? styles.chipSelected : null,
+                    idx % 3 === 0 && { marginLeft: 0 },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      unit === opt.key && styles.chipTextSelected,
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {opt.plural}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </ScrollView>
+
+          <View style={styles.footerRow}>
+            <TouchableOpacity style={styles.footerBtn} onPress={onClose}>
+              <Text style={styles.footerBtnText}>Cancelar</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.footerBtn, styles.footerPrimary]}
+              onPress={() => onSave({ quantity: quantity || 0, unit })}
+            >
+              <Text
+                style={[styles.footerBtnText, styles.footerPrimaryText]}
+              >
+                Guardar
+              </Text>
+            </TouchableOpacity>
+          </View>
         </View>
       </View>
     </Modal>
   );
 }
+
+const createStyles = (palette) =>
+  StyleSheet.create({
+    modalBackdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    sheet: {
+      maxHeight: '80%',
+      minHeight: '50%',
+      width: '90%',
+      backgroundColor: palette.bg,
+      borderRadius: 18,
+      borderWidth: 1,
+      borderColor: palette.border,
+      overflow: 'hidden',
+    },
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+      alignItems: 'center',
+      paddingHorizontal: 12,
+      paddingTop: 10,
+      paddingBottom: 6,
+      backgroundColor: palette.surface,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+    },
+    iconBtn: {
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      backgroundColor: palette.surface2,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    iconText: { color: palette.text, fontSize: 18 },
+    hero: {
+      padding: 14,
+      flexDirection: 'row',
+      alignItems: 'center',
+      borderBottomWidth: 1,
+      borderColor: palette.frame,
+    },
+    foodIconBox: {
+      width: 72,
+      height: 72,
+      borderRadius: 16,
+      backgroundColor: palette.surface2,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: palette.frame,
+      marginRight: 12,
+    },
+    foodName: {
+      flex: 1,
+      color: palette.accent,
+      fontSize: 18,
+      fontWeight: '400',
+    },
+    scroll: {
+      ...(Platform.OS === 'web'
+        ? {
+            scrollbarWidth: 'thin',
+            scrollbarColor: `${palette.border} transparent`,
+            scrollbarGutter: 'stable both-edges',
+            overscrollBehavior: 'contain',
+          }
+        : {}),
+    },
+    labelBold: {
+      color: palette.text,
+      fontWeight: '700',
+      marginBottom: 6,
+      marginTop: 10,
+    },
+    chipWrap: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 },
+    chip: {
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      borderRadius: 10,
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginRight: 8,
+      marginBottom: 8,
+    },
+    chipSelected: {
+      backgroundColor: palette.surface3,
+      borderColor: palette.accent,
+    },
+    chipText: { color: palette.text },
+    chipTextSelected: { color: palette.accent },
+    qtyRow: { flexDirection: 'row', alignItems: 'center' },
+    qtyBtn: {
+      backgroundColor: palette.surface3,
+      borderWidth: 1,
+      borderColor: palette.border,
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 12,
+      marginHorizontal: 4,
+    },
+    qtyBtnText: { color: palette.accent, fontSize: 18 },
+    qtyInput: {
+      width: 80,
+      textAlign: 'center',
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      color: palette.text,
+    },
+    footerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      padding: 16,
+      borderTopWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface,
+    },
+    footerBtn: {
+      flex: 1,
+      paddingVertical: 12,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      marginHorizontal: 4,
+      alignItems: 'center',
+    },
+    footerBtnText: { color: palette.text, fontSize: 16 },
+    footerPrimary: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
+    footerPrimaryText: { color: '#1b1d22', fontWeight: '600' },
+  });
+

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Platform,
+  Pressable,
+  TextInput,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useUnits } from '../context/UnitsContext';
+import { useTheme, useThemeController } from '../context/ThemeContext';
+import { gradientForKey } from '../theme/gradients';
+
+export default function BatchAddShoppingModal({ visible, items = [], onSave, onClose }) {
+  const palette = useTheme();
+  const { themeName } = useThemeController();
+  const styles = useMemo(() => createStyles(palette, themeName), [palette, themeName]);
+  const { units, getLabel } = useUnits();
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    if (visible) {
+      setData(
+        items.map(() => ({
+          quantity: '1',
+          unit: units[0]?.key || 'units',
+        })),
+      );
+    }
+  }, [visible, items, units]);
+
+  const updateField = (index, field, value) => {
+    setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
+  };
+
+  const saveAll = () => {
+    onSave(
+      items.map((item, idx) => ({
+        name: item.name,
+        quantity: data[idx]?.quantity || '1',
+        unit: data[idx]?.unit || units[0]?.key || 'units',
+      })),
+    );
+  };
+
+  const g = gradientForKey(themeName, 'batch');
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.modalBackdrop}>
+        <View style={styles.sheet}>
+          <View style={styles.headerRow}>
+            <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
+              <Text style={styles.iconText}>←</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={saveAll} style={styles.iconBtnAccent}>
+              <Text style={styles.iconTextOnAccent}>Guardar</Text>
+            </TouchableOpacity>
+          </View>
+
+          <LinearGradient
+            colors={g.colors}
+            locations={g.locations}
+            start={g.start}
+            end={g.end}
+            style={styles.hero}
+          >
+            <Text style={styles.heroTitle}>Añadir {items.length} alimento(s)</Text>
+          </LinearGradient>
+
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
+            showsVerticalScrollIndicator={Platform.OS === 'web'}
+          >
+            {items.map((item, idx) => {
+              const gi = gradientForKey(themeName, item.name);
+              const qty = parseFloat(data[idx]?.quantity) || 0;
+              return (
+                <View key={idx} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <LinearGradient
+                      colors={gi.colors}
+                      locations={gi.locations}
+                      start={gi.start}
+                      end={gi.end}
+                      style={styles.cardRibbon}
+                    >
+                      {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
+                      <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">
+                        {item.name}
+                      </Text>
+                    </LinearGradient>
+                    <Text style={styles.cardMeta}>
+                      {qty} {getLabel(qty, data[idx]?.unit)}
+                    </Text>
+                  </View>
+
+                  <Text style={styles.labelBold}>Cantidad</Text>
+                  <View style={styles.qtyRow}>
+                    <TouchableOpacity
+                      onPress={() =>
+                        updateField(idx, 'quantity', String(Math.max(0, qty - 1)))
+                      }
+                      style={styles.qtyBtn}
+                    >
+                      <Text style={styles.qtyBtnText}>−</Text>
+                    </TouchableOpacity>
+                    <TextInput
+                      style={styles.qtyInput}
+                      keyboardType="numeric"
+                      value={String(data[idx]?.quantity)}
+                      onChangeText={t => updateField(idx, 'quantity', t)}
+                    />
+                    <TouchableOpacity
+                      onPress={() =>
+                        updateField(idx, 'quantity', String(qty + 1))
+                      }
+                      style={styles.qtyBtn}
+                    >
+                      <Text style={styles.qtyBtnText}>＋</Text>
+                    </TouchableOpacity>
+                  </View>
+
+                  <Text style={styles.labelBold}>Unidad</Text>
+                  <View style={styles.chipWrap}>
+                    {units.map(opt => (
+                      <Pressable
+                        key={opt.key}
+                        onPress={() => updateField(idx, 'unit', opt.key)}
+                        style={[
+                          styles.chip,
+                          data[idx]?.unit === opt.key && styles.chipSelected,
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.chipText,
+                            data[idx]?.unit === opt.key && styles.chipTextSelected,
+                          ]}
+                          numberOfLines={1}
+                        >
+                          {opt.plural}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              );
+            })}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(palette, themeName) {
+  return StyleSheet.create({
+    modalBackdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    sheet: {
+      maxHeight: '80%',
+      width: '90%',
+      backgroundColor: palette.bg,
+      borderRadius: 18,
+      borderWidth: 1,
+      borderColor: palette.border,
+      overflow: 'hidden',
+    },
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: 12,
+      paddingTop: 10,
+      paddingBottom: 6,
+      backgroundColor: palette.surface,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+    },
+    iconBtn: {
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      backgroundColor: palette.surface2,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: palette.border,
+    },
+    iconBtnAccent: {
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      backgroundColor: palette.accent,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: '#e2b06c',
+    },
+    iconText: { color: palette.text, fontSize: 18 },
+    iconTextOnAccent: {
+      color: themeName === 'light' ? '#1b1d22' : palette.bg,
+      fontWeight: '700',
+    },
+    hero: {
+      padding: 14,
+      borderBottomWidth: 1,
+      borderColor: palette.frame,
+    },
+    heroTitle: { color: palette.accent, fontSize: 18, fontWeight: '400' },
+    scroll: {
+      ...(Platform.OS === 'web'
+        ? {
+            scrollbarWidth: 'thin',
+            scrollbarColor: `${palette.border} transparent`,
+            scrollbarGutter: 'stable both-edges',
+            overscrollBehavior: 'contain',
+          }
+        : {}),
+    },
+    card: {
+      backgroundColor: palette.surface2,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
+      padding: 12,
+      marginBottom: 12,
+    },
+    cardHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 8,
+    },
+    cardRibbon: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      alignSelf: 'flex-start',
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: palette.frame || palette.border,
+    },
+    ribbonIcon: { width: 32, height: 32, marginRight: 10, resizeMode: 'contain' },
+    ribbonTitle: { color: palette.text, fontWeight: '800', fontSize: 18 },
+    cardMeta: { color: palette.textDim },
+    labelBold: { color: palette.text, fontWeight: '700', marginBottom: 6, marginTop: 10 },
+    qtyRow: { flexDirection: 'row', alignItems: 'center' },
+    qtyBtn: {
+      backgroundColor: palette.surface3,
+      borderWidth: 1,
+      borderColor: palette.border,
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 12,
+      marginHorizontal: 4,
+    },
+    qtyBtnText: { color: palette.accent, fontSize: 18 },
+    qtyInput: {
+      width: 80,
+      textAlign: 'center',
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      color: palette.text,
+    },
+    chipWrap: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 },
+    chip: {
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      borderRadius: 10,
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginRight: 8,
+      marginBottom: 8,
+    },
+    chipSelected: { backgroundColor: palette.surface3, borderColor: palette.accent },
+    chipText: { color: palette.text },
+    chipTextSelected: { color: palette.accent },
+  });
+}

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -128,9 +128,9 @@ export default function FoodPickerModal({
 
   const foods = [...defaultFoods, ...customList];
 
-  // Ancho de las cards de categoría ~ como las cards de alimentos (aprox).
+  // Cards de categoría cuadradas
   const winW = Dimensions.get('window').width;
-  const catCardWidth = Math.max(160, Math.min(240, Math.floor(winW * 0.42)));
+  const catCardSize = Math.max(80, Math.min(120, Math.floor(winW * 0.25)));
 
   // ==== Scrollbar helpers (WEB): mantener gutter estable y "ocultar" con transparencia ====
   const webScrollBase = Platform.OS === 'web' ? { scrollbarWidth: 'thin', scrollbarGutter: 'stable both-edges' } : null;
@@ -147,7 +147,7 @@ export default function FoodPickerModal({
               <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
                 <Text style={styles.iconText}>←</Text>
               </TouchableOpacity>
-              <View style={{ flexDirection: 'row' }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                 <TouchableOpacity
                   onPress={() =>
                     setSearchVisible(v => {
@@ -159,8 +159,11 @@ export default function FoodPickerModal({
                 >
                   <Text style={styles.iconText}>🔍</Text>
                 </TouchableOpacity>
-                <TouchableOpacity onPress={() => setAddVisible(true)} style={[styles.iconBtn, { marginRight: 8 }]}>
-                  <Text style={styles.iconText}>＋</Text>
+                <TouchableOpacity
+                  onPress={() => setAddVisible(true)}
+                  style={[styles.createBtn, { marginRight: 8 }]}
+                >
+                  <Text style={styles.createText}>Crear Nuevo</Text>
                 </TouchableOpacity>
                 <TouchableOpacity onPress={() => setMenuVisible(true)} style={styles.iconBtn}>
                   <Text style={styles.iconText}>⋮</Text>
@@ -188,10 +191,10 @@ export default function FoodPickerModal({
                     <Pressable
                       key={cat}
                       onPress={() => setCurrentCategory(cat)}
-                      style={{ width: catCardWidth, paddingHorizontal: 6 }}
+                      style={{ paddingHorizontal: 6 }}
                     >
-                      <View style={[styles.catCard, active && styles.catCardActive]}>
-                        <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.catCardGrad}>
+                      <View style={[styles.catCard, active && styles.catCardActive, { width: catCardSize, height: catCardSize }]}>
+                        <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={[styles.catCardGrad, { flex: 1 }]}> 
                           <View style={styles.catIconBox}>
                             {categories[cat]?.icon && (
                               <Image
@@ -372,7 +375,9 @@ export default function FoodPickerModal({
                               resizeMode="contain"
                             />
                           </View>
-                          <Text style={{ textAlign: 'center', marginTop: 5, color: palette.text }} numberOfLines={2}>{name}</Text>
+                          <Text style={{ textAlign: 'center', marginTop: 5, color: palette.text }} numberOfLines={2}>
+                            {getFoodInfo(name)?.name || name}
+                          </Text>
                         </Pressable>
                       );
                     })}
@@ -416,14 +421,28 @@ const createStyles = (palette) => StyleSheet.create({
     borderColor: palette.border,
   },
   iconBtn: {
+    height: 40,
     paddingHorizontal: 10,
-    paddingVertical: 6,
     backgroundColor: palette.surface2,
     borderRadius: 8,
     borderWidth: 1,
     borderColor: palette.border,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   iconText: { color: palette.text, fontSize: 18 },
+  createBtn: {
+    flex: 1,
+    height: 40,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.accent,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#e2b06c',
+  },
+  createText: { color: palette.bg, fontSize: 16, fontWeight: '600' },
 
   // === Categorías (cards grandes en carrusel) ===
   catBar: {

--- a/MiAppNevera/src/components/ListPreviewModal.js
+++ b/MiAppNevera/src/components/ListPreviewModal.js
@@ -1,0 +1,38 @@
+import React, { useMemo } from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+import ShoppingListPreview from './ShoppingListPreview';
+
+export default function ListPreviewModal({ visible, name, items = [], onClose }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
+            <Text style={styles.iconText}>←</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>{name || 'Lista'}</Text>
+        </View>
+        <ShoppingListPreview items={items} style={{ flex: 1 }} />
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: palette.bg },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 14,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface,
+    },
+    iconBtn: { marginRight: 12 },
+    iconText: { color: palette.text, fontSize: 18 },
+    title: { color: palette.text, fontWeight: '700', fontSize: 18 },
+  });

--- a/MiAppNevera/src/components/SaveListModal.js
+++ b/MiAppNevera/src/components/SaveListModal.js
@@ -1,0 +1,167 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Modal, View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import ShoppingListPreview from './ShoppingListPreview';
+import AddShoppingItemModal from './AddShoppingItemModal';
+import FoodPickerModal from './FoodPickerModal';
+import { getFoodCategory } from '../foodIcons';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SaveListModal({ visible, items = [], initialName = '', initialNote = '', onSave, onClose }) {
+  const [name, setName] = useState('');
+  const [note, setNote] = useState('');
+  const [localItems, setLocalItems] = useState([]);
+  const [editIdx, setEditIdx] = useState(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [adding, setAdding] = useState(null);
+  const [addVisible, setAddVisible] = useState(false);
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  useEffect(() => {
+    if (visible) {
+      setName(initialName);
+      setNote(initialNote);
+      setLocalItems(items);
+      setSelectMode(false);
+      setSelected([]);
+      setPickerVisible(false);
+      setAddVisible(false);
+      setAdding(null);
+    }
+  }, [visible, initialName, initialNote, items]);
+
+  const handleItemSave = ({ quantity, unit }) => {
+    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit } : it));
+    setEditIdx(null);
+  };
+
+  const toggleSelect = idx => {
+    setSelected(prev => {
+      const exists = prev.includes(idx);
+      const next = exists ? prev.filter(i => i !== idx) : [...prev, idx];
+      if (next.length === 0) setSelectMode(false);
+      return next;
+    });
+  };
+
+  const handleItemPress = idx => {
+    if (selectMode) {
+      toggleSelect(idx);
+    } else {
+      setEditIdx(idx);
+    }
+  };
+
+  const handleItemLongPress = idx => {
+    if (!selectMode) {
+      setSelectMode(true);
+      setSelected([idx]);
+    } else {
+      toggleSelect(idx);
+    }
+  };
+
+  const deleteSelected = () => {
+    setLocalItems(prev => prev.filter((_, i) => !selected.includes(i)));
+    setSelected([]);
+    setSelectMode(false);
+  };
+
+  const onSelectFood = (name, icon) => {
+    setAdding({ name, icon });
+    setPickerVisible(false);
+    setAddVisible(true);
+  };
+
+  const handleAddSave = ({ quantity, unit }) => {
+    if (adding) {
+      setLocalItems(prev => [
+        ...prev,
+        {
+          name: adding.name,
+          icon: adding.icon,
+          quantity,
+          unit,
+          foodCategory: getFoodCategory(adding.name),
+        },
+      ]);
+      setAdding(null);
+      setAddVisible(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <Text style={styles.title}>Guardar lista</Text>
+        <TextInput
+          placeholder="Nombre"
+          style={styles.input}
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          placeholder="Nota"
+          style={styles.input}
+          value={note}
+          onChangeText={setNote}
+        />
+        <ShoppingListPreview
+          items={localItems}
+          selected={selected}
+          onItemPress={handleItemPress}
+          onItemLongPress={handleItemLongPress}
+          style={{ flex: 1, marginBottom: 10 }}
+        />
+        <View style={styles.actions}>
+          <Button
+            title={selectMode ? 'Cancelar selección' : 'Cancelar'}
+            onPress={selectMode ? () => { setSelectMode(false); setSelected([]); } : onClose}
+          />
+          <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+          {selectMode && selected.length > 0 && (
+            <Button title="Eliminar" color="#b00" onPress={deleteSelected} />
+          )}
+          <Button title="Guardar" onPress={() => onSave({ name: name.trim(), note, items: localItems })} />
+        </View>
+        <AddShoppingItemModal
+          visible={editIdx !== null}
+          foodName={localItems[editIdx]?.name}
+          foodIcon={localItems[editIdx]?.icon}
+          initialQuantity={localItems[editIdx]?.quantity}
+          initialUnit={localItems[editIdx]?.unit}
+          onSave={handleItemSave}
+          onClose={() => setEditIdx(null)}
+        />
+        <FoodPickerModal
+          visible={pickerVisible}
+          onSelect={onSelectFood}
+          onClose={() => setPickerVisible(false)}
+        />
+        <AddShoppingItemModal
+          visible={addVisible}
+          foodName={adding?.name}
+          foodIcon={adding?.icon}
+          onSave={handleAddSave}
+          onClose={() => setAddVisible(false)}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, padding: 20, backgroundColor: palette.bg },
+    title: { fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: palette.text },
+    input: {
+      borderWidth: 1,
+      borderColor: palette.border,
+      padding: 8,
+      marginBottom: 10,
+      color: palette.text,
+    },
+    actions: { flexDirection: 'row', justifyContent: 'space-between' },
+  });

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import { ScrollView, View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { useUnits } from '../context/UnitsContext';
+import { useCategories } from '../context/CategoriesContext';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ShoppingListPreview({ items = [], onItemPress, onItemLongPress, selected = [], style }) {
+  const { getLabel } = useUnits();
+  const { categories } = useCategories();
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  const grouped = items.reduce((acc, it, index) => {
+    const cat = it.foodCategory || 'varios';
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push({ item: it, index });
+    return acc;
+  }, {});
+
+  return (
+    <ScrollView style={[styles.scroll, style]} contentContainerStyle={{ padding: 14, paddingBottom: 40 }}>
+      {Object.entries(grouped).map(([cat, arr]) => (
+        <View key={cat} style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>
+              {categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
+            </Text>
+          </View>
+          {arr.map(({ item, index }) => {
+            const isSelected = selected.includes(index);
+            return (
+              <TouchableOpacity
+                key={index}
+                onPress={() => onItemPress && onItemPress(index)}
+                onLongPress={() => onItemLongPress && onItemLongPress(index)}
+                disabled={!onItemPress && !onItemLongPress}
+              >
+                <View style={[styles.row, isSelected && styles.rowSelected]}>
+                  {item.icon && <Image source={item.icon} style={styles.icon} />}
+                  <Text style={styles.rowText} numberOfLines={2}>
+                    {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    scroll: {
+      backgroundColor: palette.bg,
+    },
+    section: {
+      marginBottom: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      borderRadius: 12,
+      overflow: 'hidden',
+    },
+    sectionHeader: {
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      backgroundColor: palette.surface3,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+    },
+    sectionTitle: { color: palette.text, fontWeight: '700' },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      borderBottomWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+    },
+    rowSelected: {
+      backgroundColor: palette.selected,
+      borderLeftWidth: 3,
+      borderLeftColor: palette.accent,
+    },
+    icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
+    rowText: { color: palette.text },
+  });

--- a/MiAppNevera/src/context/SavedListsContext.js
+++ b/MiAppNevera/src/context/SavedListsContext.js
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const SavedListsContext = createContext();
+
+export const SavedListsProvider = ({ children }) => {
+  const [savedLists, setSavedLists] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('savedLists');
+        if (stored) setSavedLists(JSON.parse(stored));
+      } catch (e) {
+        console.error('Failed to load saved lists', e);
+      }
+    })();
+  }, []);
+
+  const persist = useCallback(updater => {
+    setSavedLists(prev => {
+      const data = typeof updater === 'function' ? updater(prev) : updater;
+      AsyncStorage.setItem('savedLists', JSON.stringify(data)).catch(err => {
+        console.error('Failed to save lists', err);
+      });
+      return data;
+    });
+  }, []);
+
+  const saveList = useCallback((name, note, items, id = null) => {
+    const entry = { id: id ?? Date.now().toString(), name, note, items };
+    persist(prev => {
+      const idx = prev.findIndex(l => l.id === entry.id);
+      if (idx >= 0) {
+        const copy = [...prev];
+        copy[idx] = entry;
+        return copy;
+      }
+      return [...prev, entry];
+    });
+  }, [persist]);
+
+  const deleteList = useCallback(id => {
+    persist(prev => prev.filter(l => l.id !== id));
+  }, [persist]);
+
+  const value = useMemo(() => ({ savedLists, saveList, deleteList }), [savedLists, saveList, deleteList]);
+
+  return (
+    <SavedListsContext.Provider value={value}>
+      {children}
+    </SavedListsContext.Provider>
+  );
+};
+
+export const useSavedLists = () => useContext(SavedListsContext);
+

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -83,6 +83,16 @@ export const ShoppingProvider = ({children}) => {
     ));
   }, [persist]);
 
+  // Replace entire list (used when loading saved lists)
+  const replaceList = useCallback(items => {
+    persist(() => items.map(it => ({
+      ...it,
+      icon: it.icon || getFoodIcon(it.name),
+      foodCategory: it.foodCategory || getFoodCategory(it.name),
+      purchased: !!it.purchased,
+    })));
+  }, [persist]);
+
   const resetShopping = useCallback(() => {
     setList([]);
     AsyncStorage.removeItem('shopping').catch(e => {
@@ -91,8 +101,8 @@ export const ShoppingProvider = ({children}) => {
   }, []);
 
   const value = useMemo(
-    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping}),
-    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping],
+    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList}),
+    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList],
   );
 
   return (

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -118,6 +118,24 @@ export default function InventoryScreen({ navigation }) {
   const numColumns = Math.max(1, Math.floor(screenWidth / 120));
   const itemWidth = `${100 / numColumns}%`;
 
+  const currentLoc = locations.find(l => l.key === storage);
+  const isEmpty = (inventory[storage]?.length || 0) === 0;
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        emptyWrap: { alignItems: 'center', justifyContent: 'center', paddingVertical: 50 },
+        emptyBtn: {
+          backgroundColor: palette.accent,
+          borderColor: '#e2b06c',
+          borderWidth: 1,
+          paddingHorizontal: 14,
+          paddingVertical: 10,
+          borderRadius: 10,
+        },
+      }),
+    [palette],
+  );
+
   const cleanZeroItems = name => {
     locations.forEach(loc => {
       for (let i = inventory[loc.key].length - 1; i >= 0; i--) {
@@ -375,7 +393,17 @@ export default function InventoryScreen({ navigation }) {
           onScrollBeginDrag={showScrollbar}
           onMomentumScrollBegin={showScrollbar}
         >
-          {groupOrder.map(cat => {
+          {isEmpty ? (
+            <View style={styles.emptyWrap}>
+              <Text style={{ color: palette.textDim, marginBottom: 8 }}>
+                {`Su "${currentLoc?.name}" se encuentra vacío`}
+              </Text>
+              <TouchableOpacity onPress={() => setPickerVisible(true)} style={styles.emptyBtn}>
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Añadir alimento</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            groupOrder.map(cat => {
             const items = grouped[cat];
             if (!items || items.length === 0) return null;
             return (
@@ -483,7 +511,8 @@ export default function InventoryScreen({ navigation }) {
                 )}
               </View>
             );
-          })}
+          })
+          )}
         </Animated.ScrollView>
 
         {/* Scrollbar overlay */}

--- a/MiAppNevera/src/screens/SavedListsScreen.js
+++ b/MiAppNevera/src/screens/SavedListsScreen.js
@@ -1,0 +1,159 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Modal, TouchableWithoutFeedback, StyleSheet } from 'react-native';
+import { useSavedLists } from '../context/SavedListsContext';
+import { useShopping } from '../context/ShoppingContext';
+import SaveListModal from '../components/SaveListModal';
+import ListPreviewModal from '../components/ListPreviewModal';
+import { useTheme } from '../context/ThemeContext';
+
+export default function SavedListsScreen({ navigation }) {
+  const { savedLists, deleteList, saveList } = useSavedLists();
+  const { replaceList } = useShopping();
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+
+  const [editing, setEditing] = useState(null);
+  const [previewing, setPreviewing] = useState(null);
+  const [confirmDel, setConfirmDel] = useState(null);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {savedLists.map(list => (
+          <View key={list.id} style={styles.card}>
+            <Text style={styles.title}>{list.name || 'Sin título'}</Text>
+            {list.note ? <Text style={styles.note}>{list.note}</Text> : null}
+            <Text style={styles.count}>{list.items?.length || 0} artículos</Text>
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.actionBtn, { backgroundColor: palette.accent }]}
+                onPress={() => {
+                  replaceList(list.items || []);
+                  navigation.navigate('Shopping');
+                }}
+              >
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cargar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.actionBtn} onPress={() => setPreviewing(list)}>
+                <Text style={styles.actionText}>Previsualizar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.actionBtn} onPress={() => setEditing(list)}>
+                <Text style={styles.actionText}>Editar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.actionBtn, { backgroundColor: palette.danger }]}
+                onPress={() => setConfirmDel(list.id)}
+              >
+                <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+
+      <SaveListModal
+        visible={!!editing}
+        items={editing?.items || []}
+        initialName={editing?.name}
+        initialNote={editing?.note}
+        onSave={({ name, note, items }) => {
+          saveList(name, note, items, editing.id);
+          setEditing(null);
+        }}
+        onClose={() => setEditing(null)}
+      />
+
+      <ListPreviewModal
+        visible={!!previewing}
+        name={previewing?.name}
+        items={previewing?.items || []}
+        onClose={() => setPreviewing(null)}
+      />
+
+      <Modal visible={!!confirmDel} transparent animationType="fade" onRequestClose={() => setConfirmDel(null)}>
+        <TouchableWithoutFeedback onPress={() => setConfirmDel(null)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.cardModal}>
+                <Text style={styles.modalTitle}>Eliminar lista</Text>
+                <Text style={styles.modalBody}>¿Eliminar esta lista guardada?</Text>
+                <View style={styles.modalActions}>
+                  <TouchableOpacity style={[styles.modalBtn, { backgroundColor: palette.surface3 }]} onPress={() => setConfirmDel(null)}>
+                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.modalBtn, { backgroundColor: palette.danger }]}
+                    onPress={() => {
+                      deleteList(confirmDel);
+                      setConfirmDel(null);
+                    }}
+                  >
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </View>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    container: { flex: 1, backgroundColor: palette.bg },
+    content: { padding: 14 },
+    card: {
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 12,
+    },
+    title: { color: palette.text, fontWeight: '700', fontSize: 16 },
+    note: { color: palette.textDim, marginVertical: 4 },
+    count: { color: palette.textDim, marginBottom: 8 },
+    actions: { flexDirection: 'row', justifyContent: 'space-between' },
+    actionBtn: {
+      flex: 1,
+      alignItems: 'center',
+      paddingVertical: 8,
+      marginHorizontal: 4,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface3,
+    },
+    actionText: { color: palette.text },
+    modalBackdrop: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0,0,0,0.35)',
+      paddingHorizontal: 20,
+    },
+    cardModal: {
+      backgroundColor: palette.surface,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: palette.border,
+      padding: 16,
+      width: '100%',
+      maxWidth: 420,
+    },
+    modalTitle: { color: palette.text, fontWeight: '700', fontSize: 16, marginBottom: 8 },
+    modalBody: { color: palette.textDim, marginBottom: 14 },
+    modalActions: { flexDirection: 'row', justifyContent: 'space-between' },
+    modalBtn: {
+      flex: 1,
+      alignItems: 'center',
+      paddingVertical: 10,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginHorizontal: 6,
+    },
+  });
+

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -20,11 +20,15 @@ import { useShopping } from '../context/ShoppingContext';
 import { useInventory } from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
 import AddShoppingItemModal from '../components/AddShoppingItemModal';
+import SaveListModal from '../components/SaveListModal';
+import BatchAddShoppingModal from '../components/BatchAddShoppingModal';
 import BatchAddItemModal from '../components/BatchAddItemModal';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
+import { useSavedLists } from '../context/SavedListsContext';
+import { getFoodIcon } from '../foodIcons';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -46,7 +50,9 @@ export default function ShoppingListScreen() {
     togglePurchased,
     removeItems,
     markPurchased,
+    resetShopping,
   } = useShopping();
+  const { saveList } = useSavedLists();
   const { inventory, addItem: addInventoryItem, removeItem: removeInventoryItem } = useInventory();
   const { getLabel } = useUnits();
   const { locations } = useLocations();
@@ -55,16 +61,27 @@ export default function ShoppingListScreen() {
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);
   const [selectedFood, setSelectedFood] = useState(null);
+  const [multiItems, setMultiItems] = useState([]);
+  const [multiAddVisible, setMultiAddVisible] = useState(false);
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState([]);
   const [batchVisible, setBatchVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [autoVisible, setAutoVisible] = useState(false);
+  const [saveVisible, setSaveVisible] = useState(false);
+  const [clearVisible, setClearVisible] = useState(false);
 
   const onSelectFood = (name, icon) => {
     setSelectedFood({ name, icon });
     setPickerVisible(false);
     setAddVisible(true);
+  };
+
+  const onMultiSelectFoods = names => {
+    const items = names.map(name => ({ name, icon: getFoodIcon(name) }));
+    setMultiItems(items);
+    setPickerVisible(false);
+    setMultiAddVisible(true);
   };
 
   const onSave = ({ quantity, unit }) => {
@@ -73,6 +90,18 @@ export default function ShoppingListScreen() {
       setSelectedFood(null);
       setAddVisible(false);
     }
+  };
+
+  const handleMultiAddSave = entries => {
+    addItems(
+      entries.map(e => ({
+        name: e.name,
+        quantity: parseFloat(e.quantity) || 0,
+        unit: e.unit,
+      })),
+    );
+    setMultiAddVisible(false);
+    setMultiItems([]);
   };
 
   // AutoAdd: añade a la lista todos los alimentos del inventario con cantidad 0 (placeholders)
@@ -113,6 +142,16 @@ export default function ShoppingListScreen() {
     setSelected([]);
     setSelectMode(false);
     setConfirmVisible(false);
+  };
+
+  const handleSaveCurrent = ({ name, note, items }) => {
+    saveList(name, note, items);
+    setSaveVisible(false);
+  };
+
+  const clearAll = () => {
+    resetShopping();
+    setClearVisible(false);
   };
 
   // Guardado por lotes (igual que antes)
@@ -174,20 +213,37 @@ export default function ShoppingListScreen() {
             <TouchableOpacity style={styles.actionBtn} onPress={() => setPickerVisible(true)}>
               <Text style={styles.actionText}>＋ Añadir</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
-              <Text style={styles.iconEmoji}>⚡</Text>
-            </TouchableOpacity>
+            <View style={{ flexDirection: 'row' }}>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
+                <Text style={styles.iconEmoji}>⚡</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setSaveVisible(true)}>
+                <Text style={styles.iconEmoji}>💾</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setClearVisible(true)}>
+                <Text style={styles.iconEmoji}>🗑️</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => navigation.navigate('SavedLists')}>
+                <Text style={styles.iconEmoji}>📁</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ) : (
           <View style={styles.headerActions}>
             <TouchableOpacity style={styles.actionBtn} onPress={selectAll}>
               <Text style={styles.actionText}>Seleccionar todo</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]} onPress={() => setBatchVisible(true)}>
+            <TouchableOpacity
+              style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]}
+              onPress={() => setBatchVisible(true)}
+            >
               <Text style={[styles.actionText, { color: palette.accent }]}>Guardar</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionBtn, { backgroundColor: '#2a1d1d', borderColor: '#5a2e2e' }]} onPress={() => setConfirmVisible(true)}>
-              <Text style={[styles.actionText, { color: '#ff9f9f' }]}>Eliminar</Text>
+            <TouchableOpacity
+              style={[styles.actionBtn, { backgroundColor: palette.danger, borderColor: '#ad2c2c' }]}
+              onPress={() => setConfirmVisible(true)}
+            >
+              <Text style={[styles.actionText, { color: '#fff' }]}>Eliminar</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -269,6 +325,7 @@ export default function ShoppingListScreen() {
       <FoodPickerModal
         visible={pickerVisible}
         onSelect={onSelectFood}
+        onMultiSelect={onMultiSelectFoods}
         onClose={() => setPickerVisible(false)}
       />
       <AddShoppingItemModal
@@ -278,11 +335,23 @@ export default function ShoppingListScreen() {
         onSave={onSave}
         onClose={() => setAddVisible(false)}
       />
+      <BatchAddShoppingModal
+        visible={multiAddVisible}
+        items={multiItems}
+        onSave={handleMultiAddSave}
+        onClose={() => setMultiAddVisible(false)}
+      />
       <BatchAddItemModal
         visible={batchVisible}
         items={selected.map(idx => ({ ...list[idx], index: idx }))}
         onSave={handleBatchSave}
         onClose={() => setBatchVisible(false)}
+      />
+      <SaveListModal
+        visible={saveVisible}
+        items={list}
+        onSave={handleSaveCurrent}
+        onClose={() => setSaveVisible(false)}
       />
 
       {/* Confirmar eliminación */}
@@ -305,6 +374,33 @@ export default function ShoppingListScreen() {
                     <Text style={{ color: palette.text }}>Cancelar</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={deleteSelected} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Clear all modal */}
+      <Modal
+        visible={clearVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setClearVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setClearVisible(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={styles.card}>
+                <Text style={styles.cardTitle}>Limpiar lista</Text>
+                <Text style={styles.cardBody}>¿Eliminar todos los alimentos de la lista de compras?</Text>
+                <View style={styles.cardActions}>
+                  <TouchableOpacity onPress={() => setClearVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
+                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={clearAll} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
                     <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
                   </TouchableOpacity>
                 </View>


### PR DESCRIPTION
## Summary
- allow multi-select editing of saved shopping lists and add new items
- highlight selected entries in list previews
- remove personalized item support from shopping lists
- rename custom-item button to "Crear Nuevo" with centered accent styling
- match multi-select highlight color to main list and render category cards as squares
- palette-align shopping list delete button
- show formatted names in default food manager
- add saved list management with custom items and list clearing
- fix create-food button height and show empty-location prompts
- theme the add-to-shopping modal with gradient header and palette-aligned controls
- expand add-item modal to occupy half the screen for better visual balance
- center the add-item modal so its window floats in the middle of the screen
- enable batch additions to the shopping list via a new modal

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6941a2e888324b4c62d54728d0e15