### PR TITLE
feat: allow shopping items to track price

### DIFF
--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -25,6 +25,8 @@ export default function AddShoppingItemModal({
   onClose,
   initialQuantity,
   initialUnit,
+  initialUnitPrice,
+  initialTotalPrice,
 }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
@@ -32,6 +34,10 @@ export default function AddShoppingItemModal({
   const { units } = useUnits();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
+  const [unitPrice, setUnitPrice] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [unitPriceText, setUnitPriceText] = useState('');
+  const [totalPriceText, setTotalPriceText] = useState('');
   const qtyScale = useRef(new Animated.Value(1)).current;
 
   const bumpQty = () => {
@@ -53,8 +59,14 @@ export default function AddShoppingItemModal({
     if (visible) {
       setQuantity(initialQuantity ?? 1);
       setUnit(initialUnit || units[0]?.key || 'units');
+      const u = initialUnitPrice ?? 0;
+      const t = initialTotalPrice ?? 0;
+      setUnitPrice(u);
+      setTotalPrice(t);
+      setUnitPriceText(u ? String(u) : '');
+      setTotalPriceText(t ? String(t) : '');
     }
-  }, [visible, initialQuantity, initialUnit, units]);
+  }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 
@@ -97,7 +109,19 @@ export default function AddShoppingItemModal({
             <View style={styles.qtyRow}>
               <TouchableOpacity
                 onPress={() => {
-                  setQuantity((q) => Math.max(0, (q || 0) - 1));
+                  setQuantity((q) => {
+                    const next = Math.max(0, (q || 0) - 1);
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = next ? totalPrice / next : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
                   bumpQty();
                 }}
                 style={styles.qtyBtn}
@@ -112,14 +136,36 @@ export default function AddShoppingItemModal({
                   value={String(quantity)}
                   onChangeText={(t) => {
                     const v = parseFloat(t.replace(/[^0-9.]/g, ''));
-                    setQuantity(Number.isFinite(v) ? v : 0);
+                    const q = Number.isFinite(v) ? v : 0;
+                    setQuantity(q);
+                    if (unitPrice) {
+                      const tot = unitPrice * q;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = q ? totalPrice / q : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
                   }}
                 />
               </Animated.View>
 
               <TouchableOpacity
                 onPress={() => {
-                  setQuantity((q) => (q || 0) + 1);
+                  setQuantity((q) => {
+                    const next = (q || 0) + 1;
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = totalPrice / next;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
                   bumpQty();
                 }}
                 style={styles.qtyBtn}
@@ -152,6 +198,57 @@ export default function AddShoppingItemModal({
                 </Pressable>
               ))}
             </View>
+
+            <Text style={styles.labelBold}>Precio</Text>
+            <View style={styles.priceRow}>
+              <TextInput
+                style={[styles.priceInput, { marginRight: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo unitario"
+                placeholderTextColor={palette.textDim}
+                value={unitPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setUnitPriceText(sanitized);
+                  const u = parseFloat(sanitized);
+                  if (!isNaN(u)) {
+                    setUnitPrice(u);
+                    const tot = u * (quantity || 0);
+                    setTotalPrice(tot);
+                    setTotalPriceText(tot ? tot.toFixed(2) : '');
+                  } else {
+                    setUnitPrice(0);
+                    setTotalPrice(0);
+                    setTotalPriceText('');
+                  }
+                }}
+              />
+              <Text style={styles.priceDivider}>/</Text>
+              <TextInput
+                style={[styles.priceInput, { marginLeft: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo total"
+                placeholderTextColor={palette.textDim}
+                value={totalPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setTotalPriceText(sanitized);
+                  const tot = parseFloat(sanitized);
+                  if (!isNaN(tot)) {
+                    setTotalPrice(tot);
+                    const u = (quantity || 0) ? tot / (quantity || 0) : 0;
+                    setUnitPrice(u);
+                    setUnitPriceText(u ? u.toFixed(2) : '');
+                  } else {
+                    setTotalPrice(0);
+                    setUnitPrice(0);
+                    setUnitPriceText('');
+                  }
+                }}
+              />
+            </View>
           </ScrollView>
 
           <View style={styles.footerRow}>
@@ -160,7 +257,14 @@ export default function AddShoppingItemModal({
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.footerBtn, styles.footerPrimary]}
-              onPress={() => onSave({ quantity: quantity || 0, unit })}
+              onPress={() =>
+                onSave({
+                  quantity: quantity || 0,
+                  unit,
+                  unitPrice: unitPrice || 0,
+                  totalPrice: totalPrice || 0,
+                })
+              }
             >
               <Text
                 style={[styles.footerBtnText, styles.footerPrimaryText]}
@@ -292,6 +396,19 @@ const createStyles = (palette) =>
       paddingHorizontal: 10,
       color: palette.text,
     },
+    priceRow: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
+    priceInput: {
+      flex: 1,
+      textAlign: 'center',
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      color: palette.text,
+    },
+    priceDivider: { color: palette.text, paddingHorizontal: 4 },
     footerRow: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -235,8 +235,8 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
         foodName={item?.name}
         foodIcon={item?.icon}
         initialUnit={item?.unit}
-        onSave={({ quantity: q, unit: u }) => {
-          addShoppingItem(item?.name, q || 0, u);
+        onSave={({ quantity: q, unit: u, unitPrice, totalPrice }) => {
+          addShoppingItem(item?.name, q || 0, u, unitPrice, totalPrice);
           Alert.alert('Añadido', `${item?.name} añadido a la lista de compras`);
           setShoppingVisible(false);
         }}

--- a/MiAppNevera/src/components/SaveListModal.js
+++ b/MiAppNevera/src/components/SaveListModal.js
@@ -32,8 +32,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
     }
   }, [visible, initialName, initialNote, items]);
 
-  const handleItemSave = ({ quantity, unit }) => {
-    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit } : it));
+  const handleItemSave = ({ quantity, unit, unitPrice, totalPrice }) => {
+    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit, unitPrice, totalPrice } : it));
     setEditIdx(null);
   };
 
@@ -75,7 +75,7 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
     setAddVisible(true);
   };
 
-  const handleAddSave = ({ quantity, unit }) => {
+  const handleAddSave = ({ quantity, unit, unitPrice, totalPrice }) => {
     if (adding) {
       setLocalItems(prev => [
         ...prev,
@@ -84,6 +84,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
           icon: adding.icon,
           quantity,
           unit,
+          unitPrice,
+          totalPrice,
           foodCategory: getFoodCategory(adding.name),
         },
       ]);
@@ -132,6 +134,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
           foodIcon={localItems[editIdx]?.icon}
           initialQuantity={localItems[editIdx]?.quantity}
           initialUnit={localItems[editIdx]?.unit}
+          initialUnitPrice={localItems[editIdx]?.unitPrice}
+          initialTotalPrice={localItems[editIdx]?.totalPrice}
           onSave={handleItemSave}
           onClose={() => setEditIdx(null)}
         />

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -38,8 +38,13 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
                 <View style={[styles.row, isSelected && styles.rowSelected]}>
                   {item.icon && <Image source={item.icon} style={styles.icon} />}
                   <Text style={styles.rowText} numberOfLines={2}>
-                    {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
+                    {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
                   </Text>
+                  {item.totalPrice > 0 && (
+                    <Text style={styles.priceBadge}>
+                      {`S/${item.totalPrice.toFixed(2)}`}
+                    </Text>
+                  )}
                 </View>
               </TouchableOpacity>
             );
@@ -86,5 +91,6 @@ const createStyles = palette =>
       borderLeftColor: palette.accent,
     },
     icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
-    rowText: { color: palette.text },
+    rowText: { color: palette.text, flex: 1 },
+    priceBadge: { color: palette.accent, fontWeight: '700', marginLeft: 8 },
   });

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -18,6 +18,8 @@ export const ShoppingProvider = ({children}) => {
             ...item,
             icon: item.icon || getFoodIcon(item.name),
             foodCategory: item.foodCategory || getFoodCategory(item.name),
+            unitPrice: item.unitPrice || 0,
+            totalPrice: item.totalPrice || 0,
           }));
           setList(parsed);
         }
@@ -37,11 +39,15 @@ export const ShoppingProvider = ({children}) => {
     });
   }, []);
 
-  const addItem = useCallback((name, quantity = 1, unit = 'units') => {
+  const addItem = useCallback((name, quantity = 1, unit = 'units', unitPrice = 0, totalPrice = 0) => {
+    const uPrice = unitPrice || (quantity ? totalPrice / quantity : 0);
+    const tPrice = totalPrice || uPrice * quantity;
     const newItem = {
       name,
       quantity,
       unit,
+      unitPrice: uPrice,
+      totalPrice: tPrice,
       icon: getFoodIcon(name),
       foodCategory: getFoodCategory(name),
       purchased: false,
@@ -50,14 +56,20 @@ export const ShoppingProvider = ({children}) => {
   }, [persist]);
 
   const addItems = useCallback(items => {
-    const newItems = items.map(({name, quantity = 1, unit = 'units'}) => ({
-      name,
-      quantity,
-      unit,
-      icon: getFoodIcon(name),
-      foodCategory: getFoodCategory(name),
-      purchased: false,
-    }));
+    const newItems = items.map(({name, quantity = 1, unit = 'units', unitPrice = 0, totalPrice = 0}) => {
+      const uPrice = unitPrice || (quantity ? totalPrice / quantity : 0);
+      const tPrice = totalPrice || uPrice * quantity;
+      return {
+        name,
+        quantity,
+        unit,
+        unitPrice: uPrice,
+        totalPrice: tPrice,
+        icon: getFoodIcon(name),
+        foodCategory: getFoodCategory(name),
+        purchased: false,
+      };
+    });
     persist(prev => [...prev, ...newItems]);
   }, [persist]);
 
@@ -89,6 +101,8 @@ export const ShoppingProvider = ({children}) => {
       ...it,
       icon: it.icon || getFoodIcon(it.name),
       foodCategory: it.foodCategory || getFoodCategory(it.name),
+      unitPrice: it.unitPrice || 0,
+      totalPrice: it.totalPrice || 0,
       purchased: !!it.purchased,
     })));
   }, [persist]);

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -84,9 +84,9 @@ export default function ShoppingListScreen() {
     setMultiAddVisible(true);
   };
 
-  const onSave = ({ quantity, unit }) => {
+  const onSave = ({ quantity, unit, unitPrice, totalPrice }) => {
     if (selectedFood) {
-      addItem(selectedFood.name, quantity, unit);
+      addItem(selectedFood.name, quantity, unit, unitPrice, totalPrice);
       setSelectedFood(null);
       setAddVisible(false);
     }
@@ -309,9 +309,14 @@ export default function ShoppingListScreen() {
                           ]}
                           numberOfLines={2}
                         >
-                          {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
+                          {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
                         </Text>
                       </View>
+                      {item.totalPrice > 0 && (
+                        <Text style={styles.priceBadge}>
+                          {`S/${item.totalPrice.toFixed(2)}`}
+                        </Text>
+                      )}
                     </View>
                   </TouchableOpacity>
                 );
@@ -521,6 +526,7 @@ const createStyles = (palette) => StyleSheet.create({
   checkOn: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
   icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
   rowText: { color: palette.text },
+  priceBadge: { color: palette.accent, fontWeight: '700', marginLeft: 8 },
 
   emptyWrap: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- add unit and total price fields to shopping list items and persist them
- allow entering unit or total cost when adding items with automatic calculation
- display item pricing across shopping list and saved list previews
- show total cost in Soles to the right of each item
- permit decimal prices by using a decimal pad input

## Testing
- `npm test` *(fails: Missing script "test" in MiAppNevera)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c4cac2c88324a27d712de59bd6e6