### PR TITLE
feat: show shopping list total and category breakdown

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -33,7 +33,8 @@
     "react-native-web": "^0.20.0",
     "react-native-screens": "~4.11.1",
     "expo-updates": "~0.28.17",
-    "expo-linear-gradient": "~14.1.5"
+    "expo-linear-gradient": "~14.1.5",
+    "react-native-svg": "^15.3.0"
   },
   "devDependencies": {
     "metro": "^0.82.5",

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -25,6 +25,8 @@ export default function AddShoppingItemModal({
   onClose,
   initialQuantity,
   initialUnit,
+  initialUnitPrice,
+  initialTotalPrice,
 }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
@@ -32,6 +34,10 @@ export default function AddShoppingItemModal({
   const { units } = useUnits();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
+  const [unitPrice, setUnitPrice] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [unitPriceText, setUnitPriceText] = useState('');
+  const [totalPriceText, setTotalPriceText] = useState('');
   const qtyScale = useRef(new Animated.Value(1)).current;
 
   const bumpQty = () => {
@@ -53,8 +59,14 @@ export default function AddShoppingItemModal({
     if (visible) {
       setQuantity(initialQuantity ?? 1);
       setUnit(initialUnit || units[0]?.key || 'units');
+      const u = initialUnitPrice ?? 0;
+      const t = initialTotalPrice ?? 0;
+      setUnitPrice(u);
+      setTotalPrice(t);
+      setUnitPriceText(u ? String(u) : '');
+      setTotalPriceText(t ? String(t) : '');
     }
-  }, [visible, initialQuantity, initialUnit, units]);
+  }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 
@@ -97,7 +109,19 @@ export default function AddShoppingItemModal({
             <View style={styles.qtyRow}>
               <TouchableOpacity
                 onPress={() => {
-                  setQuantity((q) => Math.max(0, (q || 0) - 1));
+                  setQuantity((q) => {
+                    const next = Math.max(0, (q || 0) - 1);
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = next ? totalPrice / next : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
                   bumpQty();
                 }}
                 style={styles.qtyBtn}
@@ -112,14 +136,36 @@ export default function AddShoppingItemModal({
                   value={String(quantity)}
                   onChangeText={(t) => {
                     const v = parseFloat(t.replace(/[^0-9.]/g, ''));
-                    setQuantity(Number.isFinite(v) ? v : 0);
+                    const q = Number.isFinite(v) ? v : 0;
+                    setQuantity(q);
+                    if (unitPrice) {
+                      const tot = unitPrice * q;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = q ? totalPrice / q : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
                   }}
                 />
               </Animated.View>
 
               <TouchableOpacity
                 onPress={() => {
-                  setQuantity((q) => (q || 0) + 1);
+                  setQuantity((q) => {
+                    const next = (q || 0) + 1;
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = totalPrice / next;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
                   bumpQty();
                 }}
                 style={styles.qtyBtn}
@@ -152,6 +198,57 @@ export default function AddShoppingItemModal({
                 </Pressable>
               ))}
             </View>
+
+            <Text style={styles.labelBold}>Precio</Text>
+            <View style={styles.priceRow}>
+              <TextInput
+                style={[styles.priceInput, { marginRight: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo unitario"
+                placeholderTextColor={palette.textDim}
+                value={unitPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setUnitPriceText(sanitized);
+                  const u = parseFloat(sanitized);
+                  if (!isNaN(u)) {
+                    setUnitPrice(u);
+                    const tot = u * (quantity || 0);
+                    setTotalPrice(tot);
+                    setTotalPriceText(tot ? tot.toFixed(2) : '');
+                  } else {
+                    setUnitPrice(0);
+                    setTotalPrice(0);
+                    setTotalPriceText('');
+                  }
+                }}
+              />
+              <Text style={styles.priceDivider}>/</Text>
+              <TextInput
+                style={[styles.priceInput, { marginLeft: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo total"
+                placeholderTextColor={palette.textDim}
+                value={totalPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setTotalPriceText(sanitized);
+                  const tot = parseFloat(sanitized);
+                  if (!isNaN(tot)) {
+                    setTotalPrice(tot);
+                    const u = (quantity || 0) ? tot / (quantity || 0) : 0;
+                    setUnitPrice(u);
+                    setUnitPriceText(u ? u.toFixed(2) : '');
+                  } else {
+                    setTotalPrice(0);
+                    setUnitPrice(0);
+                    setUnitPriceText('');
+                  }
+                }}
+              />
+            </View>
           </ScrollView>
 
           <View style={styles.footerRow}>
@@ -160,7 +257,14 @@ export default function AddShoppingItemModal({
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.footerBtn, styles.footerPrimary]}
-              onPress={() => onSave({ quantity: quantity || 0, unit })}
+              onPress={() =>
+                onSave({
+                  quantity: quantity || 0,
+                  unit,
+                  unitPrice: unitPrice || 0,
+                  totalPrice: totalPrice || 0,
+                })
+              }
             >
               <Text
                 style={[styles.footerBtnText, styles.footerPrimaryText]}
@@ -292,6 +396,19 @@ const createStyles = (palette) =>
       paddingHorizontal: 10,
       color: palette.text,
     },
+    priceRow: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
+    priceInput: {
+      flex: 1,
+      textAlign: 'center',
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      color: palette.text,
+    },
+    priceDivider: { color: palette.text, paddingHorizontal: 4 },
     footerRow: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -29,21 +29,25 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
         items.map(() => ({
           quantity: '1',
           unit: units[0]?.key || 'units',
+          unitPriceText: '',
+          totalPriceText: '',
         })),
       );
     }
   }, [visible, items, units]);
 
-  const updateField = (index, field, value) => {
-    setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
+  const updateItem = (index, changes) => {
+    setData(prev => prev.map((d, i) => (i === index ? { ...d, ...changes } : d)));
   };
 
   const saveAll = () => {
     onSave(
       items.map((item, idx) => ({
         name: item.name,
-        quantity: data[idx]?.quantity || '1',
+        quantity: parseFloat(data[idx]?.quantity) || 0,
         unit: data[idx]?.unit || units[0]?.key || 'units',
+        unitPrice: parseFloat(data[idx]?.unitPriceText) || 0,
+        totalPrice: parseFloat(data[idx]?.totalPriceText) || 0,
       })),
     );
   };
@@ -80,7 +84,8 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
           >
             {items.map((item, idx) => {
               const gi = gradientForKey(themeName, item.name);
-              const qty = parseFloat(data[idx]?.quantity) || 0;
+              const entry = data[idx] || {};
+              const qty = parseFloat(entry.quantity) || 0;
               return (
                 <View key={idx} style={styles.card}>
                   <View style={styles.cardHeader}>
@@ -97,7 +102,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                       </Text>
                     </LinearGradient>
                     <Text style={styles.cardMeta}>
-                      {qty} {getLabel(qty, data[idx]?.unit)}
+                      {qty} {getLabel(qty, entry.unit)}
                     </Text>
                   </View>
 
@@ -105,7 +110,29 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                   <View style={styles.qtyRow}>
                     <TouchableOpacity
                       onPress={() =>
-                        updateField(idx, 'quantity', String(Math.max(0, qty - 1)))
+                        setData(prev =>
+                          prev.map((d, i) => {
+                            if (i !== idx) return d;
+                            const nextQty = Math.max(0, (parseFloat(d.quantity) || 0) - 1);
+                            let unitPriceText = d.unitPriceText;
+                            let totalPriceText = d.totalPriceText;
+                            if (unitPriceText) {
+                              const u = parseFloat(unitPriceText) || 0;
+                              const tot = u * nextQty;
+                              totalPriceText = tot ? tot.toFixed(2) : '';
+                            } else if (totalPriceText) {
+                              const t = parseFloat(totalPriceText) || 0;
+                              const u = nextQty ? t / nextQty : 0;
+                              unitPriceText = u ? u.toFixed(2) : '';
+                            }
+                            return {
+                              ...d,
+                              quantity: String(nextQty),
+                              unitPriceText,
+                              totalPriceText,
+                            };
+                          }),
+                        )
                       }
                       style={styles.qtyBtn}
                     >
@@ -114,12 +141,59 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                     <TextInput
                       style={styles.qtyInput}
                       keyboardType="numeric"
-                      value={String(data[idx]?.quantity)}
-                      onChangeText={t => updateField(idx, 'quantity', t)}
+                      value={String(entry.quantity)}
+                      onChangeText={t =>
+                        setData(prev =>
+                          prev.map((d, i) => {
+                            if (i !== idx) return d;
+                            const sanitized = t.replace(/[^0-9.]/g, '');
+                            const q = parseFloat(sanitized) || 0;
+                            let unitPriceText = d.unitPriceText;
+                            let totalPriceText = d.totalPriceText;
+                            if (unitPriceText) {
+                              const u = parseFloat(unitPriceText) || 0;
+                              const tot = u * q;
+                              totalPriceText = tot ? tot.toFixed(2) : '';
+                            } else if (totalPriceText) {
+                              const tot = parseFloat(totalPriceText) || 0;
+                              const u = q ? tot / q : 0;
+                              unitPriceText = u ? u.toFixed(2) : '';
+                            }
+                            return {
+                              ...d,
+                              quantity: sanitized,
+                              unitPriceText,
+                              totalPriceText,
+                            };
+                          }),
+                        )
+                      }
                     />
                     <TouchableOpacity
                       onPress={() =>
-                        updateField(idx, 'quantity', String(qty + 1))
+                        setData(prev =>
+                          prev.map((d, i) => {
+                            if (i !== idx) return d;
+                            const nextQty = (parseFloat(d.quantity) || 0) + 1;
+                            let unitPriceText = d.unitPriceText;
+                            let totalPriceText = d.totalPriceText;
+                            if (unitPriceText) {
+                              const u = parseFloat(unitPriceText) || 0;
+                              const tot = u * nextQty;
+                              totalPriceText = tot ? tot.toFixed(2) : '';
+                            } else if (totalPriceText) {
+                              const t = parseFloat(totalPriceText) || 0;
+                              const u = nextQty ? t / nextQty : 0;
+                              unitPriceText = u ? u.toFixed(2) : '';
+                            }
+                            return {
+                              ...d,
+                              quantity: String(nextQty),
+                              unitPriceText,
+                              totalPriceText,
+                            };
+                          }),
+                        )
                       }
                       style={styles.qtyBtn}
                     >
@@ -132,16 +206,16 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                     {units.map(opt => (
                       <Pressable
                         key={opt.key}
-                        onPress={() => updateField(idx, 'unit', opt.key)}
+                        onPress={() => updateItem(idx, { unit: opt.key })}
                         style={[
                           styles.chip,
-                          data[idx]?.unit === opt.key && styles.chipSelected,
+                          entry.unit === opt.key && styles.chipSelected,
                         ]}
                       >
                         <Text
                           style={[
                             styles.chipText,
-                            data[idx]?.unit === opt.key && styles.chipTextSelected,
+                            entry.unit === opt.key && styles.chipTextSelected,
                           ]}
                           numberOfLines={1}
                         >
@@ -149,6 +223,47 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                         </Text>
                       </Pressable>
                     ))}
+                  </View>
+
+                  <Text style={styles.labelBold}>Precio</Text>
+                  <View style={styles.priceRow}>
+                    <TextInput
+                      style={[styles.priceInput, { marginRight: 4 }]}
+                      keyboardType="decimal-pad"
+                      inputMode="decimal"
+                      placeholder="Costo unitario"
+                      placeholderTextColor={palette.textDim}
+                      value={entry.unitPriceText || ''}
+                      onChangeText={t => {
+                        const sanitized = t.replace(/[^0-9.]/g, '');
+                        const q = parseFloat(entry.quantity) || 0;
+                        const u = parseFloat(sanitized);
+                        const tot = !isNaN(u) && q ? u * q : 0;
+                        updateItem(idx, {
+                          unitPriceText: sanitized,
+                          totalPriceText: tot ? tot.toFixed(2) : '',
+                        });
+                      }}
+                    />
+                    <Text style={styles.priceDivider}>/</Text>
+                    <TextInput
+                      style={[styles.priceInput, { marginLeft: 4 }]}
+                      keyboardType="decimal-pad"
+                      inputMode="decimal"
+                      placeholder="Costo total"
+                      placeholderTextColor={palette.textDim}
+                      value={entry.totalPriceText || ''}
+                      onChangeText={t => {
+                        const sanitized = t.replace(/[^0-9.]/g, '');
+                        const q = parseFloat(entry.quantity) || 0;
+                        const tot = parseFloat(sanitized);
+                        const u = !isNaN(tot) && q ? tot / q : 0;
+                        updateItem(idx, {
+                          totalPriceText: sanitized,
+                          unitPriceText: u ? u.toFixed(2) : '',
+                        });
+                      }}
+                    />
                   </View>
                 </View>
               );
@@ -288,5 +403,18 @@ function createStyles(palette, themeName) {
     chipSelected: { backgroundColor: palette.surface3, borderColor: palette.accent },
     chipText: { color: palette.text },
     chipTextSelected: { color: palette.accent },
+    priceRow: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
+    priceInput: {
+      flex: 1,
+      textAlign: 'center',
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      borderRadius: 10,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      color: palette.text,
+    },
+    priceDivider: { color: palette.text, paddingHorizontal: 4 },
   });
 }

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -235,8 +235,8 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
         foodName={item?.name}
         foodIcon={item?.icon}
         initialUnit={item?.unit}
-        onSave={({ quantity: q, unit: u }) => {
-          addShoppingItem(item?.name, q || 0, u);
+        onSave={({ quantity: q, unit: u, unitPrice, totalPrice }) => {
+          addShoppingItem(item?.name, q || 0, u, unitPrice, totalPrice);
           Alert.alert('Añadido', `${item?.name} añadido a la lista de compras`);
           setShoppingVisible(false);
         }}

--- a/MiAppNevera/src/components/SaveListModal.js
+++ b/MiAppNevera/src/components/SaveListModal.js
@@ -32,8 +32,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
     }
   }, [visible, initialName, initialNote, items]);
 
-  const handleItemSave = ({ quantity, unit }) => {
-    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit } : it));
+  const handleItemSave = ({ quantity, unit, unitPrice, totalPrice }) => {
+    setLocalItems(prev => prev.map((it, idx) => idx === editIdx ? { ...it, quantity, unit, unitPrice, totalPrice } : it));
     setEditIdx(null);
   };
 
@@ -75,7 +75,7 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
     setAddVisible(true);
   };
 
-  const handleAddSave = ({ quantity, unit }) => {
+  const handleAddSave = ({ quantity, unit, unitPrice, totalPrice }) => {
     if (adding) {
       setLocalItems(prev => [
         ...prev,
@@ -84,6 +84,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
           icon: adding.icon,
           quantity,
           unit,
+          unitPrice,
+          totalPrice,
           foodCategory: getFoodCategory(adding.name),
         },
       ]);
@@ -132,6 +134,8 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
           foodIcon={localItems[editIdx]?.icon}
           initialQuantity={localItems[editIdx]?.quantity}
           initialUnit={localItems[editIdx]?.unit}
+          initialUnitPrice={localItems[editIdx]?.unitPrice}
+          initialTotalPrice={localItems[editIdx]?.totalPrice}
           onSave={handleItemSave}
           onClose={() => setEditIdx(null)}
         />

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -38,8 +38,13 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
                 <View style={[styles.row, isSelected && styles.rowSelected]}>
                   {item.icon && <Image source={item.icon} style={styles.icon} />}
                   <Text style={styles.rowText} numberOfLines={2}>
-                    {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
+                    {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
                   </Text>
+                  {item.totalPrice > 0 && (
+                    <Text style={styles.priceBadge}>
+                      {`S/${item.totalPrice.toFixed(2)}`}
+                    </Text>
+                  )}
                 </View>
               </TouchableOpacity>
             );
@@ -86,5 +91,6 @@ const createStyles = palette =>
       borderLeftColor: palette.accent,
     },
     icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
-    rowText: { color: palette.text },
+    rowText: { color: palette.text, flex: 1 },
+    priceBadge: { color: palette.accent, fontWeight: '700', marginLeft: 8 },
   });

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -18,6 +18,8 @@ export const ShoppingProvider = ({children}) => {
             ...item,
             icon: item.icon || getFoodIcon(item.name),
             foodCategory: item.foodCategory || getFoodCategory(item.name),
+            unitPrice: item.unitPrice || 0,
+            totalPrice: item.totalPrice || 0,
           }));
           setList(parsed);
         }
@@ -37,11 +39,15 @@ export const ShoppingProvider = ({children}) => {
     });
   }, []);
 
-  const addItem = useCallback((name, quantity = 1, unit = 'units') => {
+  const addItem = useCallback((name, quantity = 1, unit = 'units', unitPrice = 0, totalPrice = 0) => {
+    const uPrice = unitPrice || (quantity ? totalPrice / quantity : 0);
+    const tPrice = totalPrice || uPrice * quantity;
     const newItem = {
       name,
       quantity,
       unit,
+      unitPrice: uPrice,
+      totalPrice: tPrice,
       icon: getFoodIcon(name),
       foodCategory: getFoodCategory(name),
       purchased: false,
@@ -50,15 +56,29 @@ export const ShoppingProvider = ({children}) => {
   }, [persist]);
 
   const addItems = useCallback(items => {
-    const newItems = items.map(({name, quantity = 1, unit = 'units'}) => ({
-      name,
-      quantity,
-      unit,
-      icon: getFoodIcon(name),
-      foodCategory: getFoodCategory(name),
-      purchased: false,
-    }));
+    const newItems = items.map(({name, quantity = 1, unit = 'units', unitPrice = 0, totalPrice = 0}) => {
+      const uPrice = unitPrice || (quantity ? totalPrice / quantity : 0);
+      const tPrice = totalPrice || uPrice * quantity;
+      return {
+        name,
+        quantity,
+        unit,
+        unitPrice: uPrice,
+        totalPrice: tPrice,
+        icon: getFoodIcon(name),
+        foodCategory: getFoodCategory(name),
+        purchased: false,
+      };
+    });
     persist(prev => [...prev, ...newItems]);
+  }, [persist]);
+
+  const editItem = useCallback((index, quantity = 1, unit = 'units', unitPrice = 0, totalPrice = 0) => {
+    const uPrice = unitPrice || (quantity ? totalPrice / quantity : 0);
+    const tPrice = totalPrice || uPrice * quantity;
+    persist(prev => prev.map((item, idx) =>
+      idx === index ? { ...item, quantity, unit, unitPrice: uPrice, totalPrice: tPrice } : item,
+    ));
   }, [persist]);
 
   const togglePurchased = useCallback(index => {
@@ -89,6 +109,8 @@ export const ShoppingProvider = ({children}) => {
       ...it,
       icon: it.icon || getFoodIcon(it.name),
       foodCategory: it.foodCategory || getFoodCategory(it.name),
+      unitPrice: it.unitPrice || 0,
+      totalPrice: it.totalPrice || 0,
       purchased: !!it.purchased,
     })));
   }, [persist]);
@@ -101,8 +123,8 @@ export const ShoppingProvider = ({children}) => {
   }, []);
 
   const value = useMemo(
-    () => ({list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList}),
-    [list, addItem, addItems, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList],
+    () => ({list, addItem, addItems, editItem, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList}),
+    [list, addItem, addItems, editItem, togglePurchased, removeItem, removeItems, markPurchased, resetShopping, replaceList],
   );
 
   return (

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -15,6 +15,7 @@ import {
   StyleSheet,
   Platform,
 } from 'react-native';
+import Svg, { Path, Circle, Text as SvgText } from 'react-native-svg';
 import { useNavigation } from '@react-navigation/native';
 import { useShopping } from '../context/ShoppingContext';
 import { useInventory } from '../context/InventoryContext';
@@ -29,6 +30,44 @@ import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
 import { useSavedLists } from '../context/SavedListsContext';
 import { getFoodIcon } from '../foodIcons';
+
+const PieChart = ({ data, size = 180, innerRadius = 60, background }) => {
+  const radius = size / 2;
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+  let acc = 0;
+  return (
+    <Svg width={size} height={size}>
+      {data.map(d => {
+        const start = (acc / total) * 2 * Math.PI;
+        const end = ((acc + d.value) / total) * 2 * Math.PI;
+        const large = end - start > Math.PI ? 1 : 0;
+        const x1 = radius + radius * Math.sin(start);
+        const y1 = radius - radius * Math.cos(start);
+        const x2 = radius + radius * Math.sin(end);
+        const y2 = radius - radius * Math.cos(end);
+        const path = `M${radius} ${radius} L${x1} ${y1} A${radius} ${radius} 0 ${large} 1 ${x2} ${y2} Z`;
+        const mid = (start + end) / 2;
+        const tx = radius + (radius * 0.6) * Math.sin(mid);
+        const ty = radius - (radius * 0.6) * Math.cos(mid);
+        const pct = total ? (d.value / total) * 100 : 0;
+        acc += d.value;
+        return (
+          <React.Fragment key={d.key}>
+            <Path d={path} fill={d.color} />
+            {pct >= 5 && (
+              <SvgText x={tx} y={ty} fill="#fff" fontSize={12} textAnchor="middle">
+                {`${pct.toFixed(0)}%`}
+              </SvgText>
+            )}
+          </React.Fragment>
+        );
+      })}
+      {innerRadius > 0 && (
+        <Circle cx={radius} cy={radius} r={innerRadius} fill={background || '#fff'} />
+      )}
+    </Svg>
+  );
+};
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -47,6 +86,7 @@ export default function ShoppingListScreen() {
     list,
     addItem,
     addItems,
+    editItem,
     togglePurchased,
     removeItems,
     markPurchased,
@@ -70,6 +110,8 @@ export default function ShoppingListScreen() {
   const [autoVisible, setAutoVisible] = useState(false);
   const [saveVisible, setSaveVisible] = useState(false);
   const [clearVisible, setClearVisible] = useState(false);
+  const [editIdx, setEditIdx] = useState(null);
+  const [detailsVisible, setDetailsVisible] = useState(false);
 
   const onSelectFood = (name, icon) => {
     setSelectedFood({ name, icon });
@@ -84,9 +126,9 @@ export default function ShoppingListScreen() {
     setMultiAddVisible(true);
   };
 
-  const onSave = ({ quantity, unit }) => {
+  const onSave = ({ quantity, unit, unitPrice, totalPrice }) => {
     if (selectedFood) {
-      addItem(selectedFood.name, quantity, unit);
+      addItem(selectedFood.name, quantity, unit, unitPrice, totalPrice);
       setSelectedFood(null);
       setAddVisible(false);
     }
@@ -98,6 +140,8 @@ export default function ShoppingListScreen() {
         name: e.name,
         quantity: parseFloat(e.quantity) || 0,
         unit: e.unit,
+        unitPrice: parseFloat(e.unitPrice) || 0,
+        totalPrice: parseFloat(e.totalPrice) || 0,
       })),
     );
     setMultiAddVisible(false);
@@ -202,6 +246,42 @@ export default function ShoppingListScreen() {
     return g;
   }, [list]);
 
+  const totalCost = useMemo(
+    () => list.reduce((sum, it) => sum + (it.totalPrice || 0), 0),
+    [list],
+  );
+
+  const costByCategory = useMemo(() => {
+    const totals = {};
+    list.forEach(it => {
+      const cat = it.foodCategory || 'otros';
+      const price = it.totalPrice || 0;
+      if (price > 0) totals[cat] = (totals[cat] || 0) + price;
+    });
+    return totals;
+  }, [list]);
+
+  const chartData = useMemo(() => {
+    const paletteColors = [
+      '#4e79a7',
+      '#f28e2b',
+      '#e15759',
+      '#76b7b2',
+      '#59a14f',
+      '#edc949',
+      '#af7aa1',
+      '#ff9da7',
+      '#9c755f',
+      '#bab0ab',
+    ];
+    return Object.entries(costByCategory).map(([key, value], idx) => ({
+      key,
+      value,
+      color: paletteColors[idx % paletteColors.length],
+      percent: totalCost ? (value / totalCost) * 100 : 0,
+    }));
+  }, [costByCategory, totalCost]);
+
   const empty = list.length === 0;
 
   return (
@@ -233,6 +313,14 @@ export default function ShoppingListScreen() {
             <TouchableOpacity style={styles.actionBtn} onPress={selectAll}>
               <Text style={styles.actionText}>Seleccionar todo</Text>
             </TouchableOpacity>
+            {selected.length === 1 && (
+              <TouchableOpacity
+                style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]}
+                onPress={() => setEditIdx(selected[0])}
+              >
+                <Text style={[styles.actionText, { color: palette.accent }]}>Editar</Text>
+              </TouchableOpacity>
+            )}
             <TouchableOpacity
               style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]}
               onPress={() => setBatchVisible(true)}
@@ -263,61 +351,79 @@ export default function ShoppingListScreen() {
             </TouchableOpacity>
           </View>
         ) : (
-          Object.entries(grouped).map(([cat, items]) => (
-            <View key={cat} style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>
-                  {categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </Text>
-              </View>
-              {items.map(({ item, index }) => {
-                const isSel = selectMode && selected.includes(index);
-                const purchased = !!item.purchased;
-                return (
-                  <TouchableOpacity
-                    key={index}
-                    onPress={() => (selectMode ? toggleSelect(index) : togglePurchased(index))}
-                    onLongPress={() => {
-                      if (!selectMode) {
-                        setSelectMode(true);
-                        setSelected([index]);
-                      } else {
-                        toggleSelect(index);
-                      }
-                    }}
-                  >
-                    <View
-                      style={[
-                        styles.row,
-                        purchased && styles.rowPurchased,
-                        isSel && styles.rowSelected,
-                      ]}
+          <>
+            {Object.entries(grouped).map(([cat, items]) => (
+              <View key={cat} style={styles.section}>
+                <View style={styles.sectionHeader}>
+                  <Text style={styles.sectionTitle}>
+                    {categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
+                  </Text>
+                </View>
+                {items.map(({ item, index }) => {
+                  const isSel = selectMode && selected.includes(index);
+                  const purchased = !!item.purchased;
+                  return (
+                    <TouchableOpacity
+                      key={index}
+                      onPress={() => (selectMode ? toggleSelect(index) : togglePurchased(index))}
+                      onLongPress={() => {
+                        if (!selectMode) {
+                          setSelectMode(true);
+                          setSelected([index]);
+                        } else {
+                          toggleSelect(index);
+                        }
+                      }}
                     >
-                      {selectMode && (
-                        <View style={[styles.check, isSel && styles.checkOn]}>
-                          <Text style={{ color: isSel ? '#1b1d22' : palette.textDim }}>
-                            {isSel ? '✓' : ''}
+                      <View
+                        style={[
+                          styles.row,
+                          purchased && styles.rowPurchased,
+                          isSel && styles.rowSelected,
+                        ]}
+                      >
+                        {selectMode && (
+                          <View style={[styles.check, isSel && styles.checkOn]}>
+                            <Text style={{ color: isSel ? '#1b1d22' : palette.textDim }}>
+                              {isSel ? '✓' : ''}
+                            </Text>
+                          </View>
+                        )}
+                        {item.icon && <Image source={item.icon} style={styles.icon} />}
+                        <View style={{ flex: 1 }}>
+                          <Text
+                            style={[
+                              styles.rowText,
+                              purchased && { textDecorationLine: 'line-through', color: palette.textDim },
+                            ]}
+                            numberOfLines={2}
+                          >
+                            {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
                           </Text>
                         </View>
-                      )}
-                      {item.icon && <Image source={item.icon} style={styles.icon} />}
-                      <View style={{ flex: 1 }}>
-                        <Text
-                          style={[
-                            styles.rowText,
-                            purchased && { textDecorationLine: 'line-through', color: palette.textDim },
-                          ]}
-                          numberOfLines={2}
-                        >
-                          {item.name} — {item.quantity} {getLabel(item.quantity, item.unit)}
-                        </Text>
+                        {item.totalPrice > 0 && (
+                          <Text style={styles.priceBadge}>
+                            {`S/${item.totalPrice.toFixed(2)}`}
+                          </Text>
+                        )}
                       </View>
-                    </View>
-                  </TouchableOpacity>
-                );
-              })}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            ))}
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <Text style={styles.sectionTitle}>Detalles de lista de compra</Text>
+              </View>
+              <View style={styles.detailsRow}>
+                <TouchableOpacity style={styles.actionBtn} onPress={() => setDetailsVisible(true)}>
+                  <Text style={styles.actionText}>Más detalles</Text>
+                </TouchableOpacity>
+                <Text style={styles.totalText}>{`Costo Total: S/${totalCost.toFixed(2)}`}</Text>
+              </View>
             </View>
-          ))
+          </>
         )}
       </ScrollView>
 
@@ -334,6 +440,22 @@ export default function ShoppingListScreen() {
         foodIcon={selectedFood?.icon}
         onSave={onSave}
         onClose={() => setAddVisible(false)}
+      />
+      <AddShoppingItemModal
+        visible={editIdx !== null}
+        foodName={list[editIdx]?.name}
+        foodIcon={list[editIdx]?.icon}
+        initialQuantity={list[editIdx]?.quantity}
+        initialUnit={list[editIdx]?.unit}
+        initialUnitPrice={list[editIdx]?.unitPrice}
+        initialTotalPrice={list[editIdx]?.totalPrice}
+        onSave={({ quantity, unit, unitPrice, totalPrice }) => {
+          editItem(editIdx, quantity, unit, unitPrice, totalPrice);
+          setEditIdx(null);
+          setSelected([]);
+          setSelectMode(false);
+        }}
+        onClose={() => setEditIdx(null)}
       />
       <BatchAddShoppingModal
         visible={multiAddVisible}
@@ -353,6 +475,42 @@ export default function ShoppingListScreen() {
         onSave={handleSaveCurrent}
         onClose={() => setSaveVisible(false)}
       />
+
+      <Modal
+        visible={detailsVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDetailsVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setDetailsVisible(false)}>
+          <View style={styles.modalBackdrop}>
+            <TouchableWithoutFeedback>
+              <View style={[styles.card, { alignItems: 'center' }]}>
+                <Text style={styles.cardTitle}>Distribución de costos</Text>
+                {totalCost > 0 ? (
+                  <>
+                    <PieChart data={chartData} size={200} innerRadius={70} background={palette.surface} />
+                    <View style={{ marginTop: 16, alignSelf: 'stretch' }}>
+                      {chartData.map(d => (
+                        <View key={d.key} style={styles.legendRow}>
+                          <View style={[styles.legendColor, { backgroundColor: d.color }]} />
+                          <Text style={[styles.legendLabel, { flex: 1 }]}> 
+                            {categories[d.key]?.name || d.key}
+                          </Text>
+                          <Text style={styles.legendValue}>{`S/${d.value.toFixed(2)}`}</Text>
+                          <Text style={styles.legendPercent}>{`${d.percent.toFixed(0)}%`}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  </>
+                ) : (
+                  <Text style={{ color: palette.textDim }}>Sin datos de costo</Text>
+                )}
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
 
       {/* Confirmar eliminación */}
       <Modal
@@ -521,6 +679,21 @@ const createStyles = (palette) => StyleSheet.create({
   checkOn: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
   icon: { width: 30, height: 30, marginRight: 10, resizeMode: 'contain' },
   rowText: { color: palette.text },
+  priceBadge: { color: palette.accent, fontWeight: '700', marginLeft: 8 },
+
+  detailsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  totalText: { color: palette.text, fontWeight: '700' },
+  legendRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 6 },
+  legendColor: { width: 12, height: 12, borderRadius: 2, marginRight: 8 },
+  legendLabel: { color: palette.text },
+  legendValue: { color: palette.text, marginLeft: 8 },
+  legendPercent: { color: palette.textDim, marginLeft: 8 },
 
   emptyWrap: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- show cumulative shopping list cost and button for details
- display pie chart of category expenses with legend and percentages
- compute cost totals by category and add react-native-svg dependency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7c4cac2c88324a27d712de59bd6e6