### PR TITLE
feat: edit default foods and propagate custom settings

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -20,6 +20,7 @@ import { UnitsProvider } from './src/context/UnitsContext';
 import { LocationsProvider } from './src/context/LocationsContext';
 import { StatusBar } from 'expo-status-bar';
 import { CustomFoodsProvider } from './src/context/CustomFoodsContext';
+import { DefaultFoodsProvider } from './src/context/DefaultFoodsContext';
 import { CategoriesProvider } from './src/context/CategoriesContext';
 import { ThemeProvider, useThemeController } from './src/context/ThemeContext';
 
@@ -37,14 +38,15 @@ function MainApp() {
     }
   }, []);
   return (
-    <CategoriesProvider>
-      <CustomFoodsProvider>
-        <UnitsProvider>
-          <LocationsProvider>
-            <InventoryProvider>
-              <SavedListsProvider>
-                <ShoppingProvider>
-                  <RecipeProvider>
+      <CategoriesProvider>
+        <DefaultFoodsProvider>
+        <CustomFoodsProvider>
+          <UnitsProvider>
+            <LocationsProvider>
+              <InventoryProvider>
+                <SavedListsProvider>
+                  <ShoppingProvider>
+                    <RecipeProvider>
                   <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
                     <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
                     <Stack.Navigator>
@@ -103,11 +105,12 @@ function MainApp() {
                 </RecipeProvider>
               </ShoppingProvider>
             </SavedListsProvider>
-          </InventoryProvider>
-          </LocationsProvider>
-        </UnitsProvider>
-      </CustomFoodsProvider>
-    </CategoriesProvider>
+            </InventoryProvider>
+            </LocationsProvider>
+          </UnitsProvider>
+        </CustomFoodsProvider>
+        </DefaultFoodsProvider>
+      </CategoriesProvider>
   );
 }
 

--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -25,6 +25,7 @@ import { useShopping } from '../context/ShoppingContext';
 import { useRecipes } from '../context/RecipeContext';
 import AddCategoryModal from './AddCategoryModal';
 import { useTheme } from '../context/ThemeContext';
+import { useUnits } from '../context/UnitsContext';
 
 // ========================
 // Gestor de personalizados
@@ -310,12 +311,15 @@ export default function AddCustomFoodModal({ visible, onClose }) {
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { addCustomFood, updateCustomFood } = useCustomFoods();
   const { categories, addCategory } = useCategories();
+  const { units } = useUnits();
   const categoryNames = Object.keys(categories);
   const [name, setName] = useState('');
   const [category, setCategory] = useState(categoryNames[0]);
   const [iconUri, setIconUri] = useState(null);
   const [baseIcon, setBaseIcon] = useState(null);
   const [expirationDays, setExpirationDays] = useState('');
+  const [defaultUnit, setDefaultUnit] = useState(units[0]?.key || 'units');
+  const [defaultPrice, setDefaultPrice] = useState('');
   const [pickerVisible, setPickerVisible] = useState(false);
   const [manageVisible, setManageVisible] = useState(false);
   const [editingKey, setEditingKey] = useState(null);
@@ -346,6 +350,8 @@ export default function AddCustomFoodModal({ visible, onClose }) {
     setIconUri(food.icon);
     setBaseIcon(food.baseIcon);
     setExpirationDays(food.expirationDays != null ? String(food.expirationDays) : '');
+    setDefaultUnit(food.defaultUnit || units[0]?.key || 'units');
+    setDefaultPrice(food.defaultPrice != null ? String(food.defaultPrice) : '');
     setEditingKey(food.key);
     setManageVisible(false);
   };
@@ -357,6 +363,8 @@ export default function AddCustomFoodModal({ visible, onClose }) {
     setIconUri(null);
     setBaseIcon(null);
     setExpirationDays('');
+    setDefaultUnit(units[0]?.key || 'units');
+    setDefaultPrice('');
     setEditingKey(null);
   };
 
@@ -370,6 +378,8 @@ export default function AddCustomFoodModal({ visible, onClose }) {
       icon: iconUri,
       baseIcon,
       expirationDays: isNaN(days) ? null : days,
+      defaultUnit,
+      defaultPrice: defaultPrice === '' ? null : Number(defaultPrice),
     };
     if (editingKey) {
       updateCustomFood(editingKey, data);
@@ -434,7 +444,40 @@ export default function AddCustomFoodModal({ visible, onClose }) {
             style={styles.input}
             keyboardType="numeric"
             value={expirationDays}
-            onChangeText={setExpirationDays}
+            onChangeText={t => setExpirationDays(t.replace(/[^0-9]/g, ''))}
+            placeholder="Opcional"
+            placeholderTextColor={palette.textDim}
+          />
+
+          <Text style={styles.label}>Unidad por defecto</Text>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+            {units.map(u => (
+              <TouchableOpacity
+                key={u.key}
+                onPress={() => setDefaultUnit(u.key)}
+                style={[styles.chip, defaultUnit === u.key && styles.chipOn]}
+              >
+                <Text style={[styles.chipTxt, defaultUnit === u.key && styles.chipTxtOn]}>
+                  {u.singular}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={styles.label}>Precio unitario por defecto</Text>
+          <TextInput
+            style={styles.input}
+            value={defaultPrice}
+            onChangeText={t => {
+              let sanitized = t.replace(/[^0-9.]/g, '');
+              const parts = sanitized.split('.');
+              if (parts.length > 2) {
+                sanitized = parts[0] + '.' + parts.slice(1).join('');
+              }
+              setDefaultPrice(sanitized);
+            }}
+            keyboardType="decimal-pad"
+            inputMode="decimal"
             placeholder="Opcional"
             placeholderTextColor={palette.textDim}
           />

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -36,6 +36,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const [regDate, setRegDate] = useState(today);
   const [expDate, setExpDate] = useState('');
   const [note, setNote] = useState('');
+  const [label, setLabel] = useState(foodName);
   const { addItem: addShoppingItem } = useShopping();
 
   // Animación suave al cambiar cantidad
@@ -51,19 +52,20 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
     if (visible) {
       setLocation(initialLocation);
       setQuantity(1);
-      setUnit(units[0]?.key || 'units');
-      setRegDate(today);
-      const info = getFoodInfo(foodName);
-      if (info?.expirationDays != null) {
-        const d = new Date();
-        d.setDate(d.getDate() + info.expirationDays);
-        setExpDate(d.toISOString().split('T')[0]);
-      } else {
-        setExpDate('');
+        const info = getFoodInfo(foodName);
+        setUnit(info?.defaultUnit || units[0]?.key || 'units');
+        setRegDate(today);
+        if (info?.expirationDays != null) {
+          const d = new Date();
+          d.setDate(d.getDate() + info.expirationDays);
+          setExpDate(d.toISOString().split('T')[0]);
+        } else {
+          setExpDate('');
+        }
+        setNote('');
+        setLabel(info?.name || foodName);
       }
-      setNote('');
-    }
-  }, [visible, initialLocation, today, units, locations, foodName]);
+    }, [visible, initialLocation, today, units, locations, foodName]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 
@@ -92,7 +94,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             <View style={styles.foodIconBox}>
               {foodIcon && <Image source={foodIcon} style={{ width: 64, height: 64 }} resizeMode="contain" />}
             </View>
-            <Text style={styles.foodName} numberOfLines={2}>{foodName}</Text>
+              <Text style={styles.foodName} numberOfLines={2}>{label}</Text>
           </LinearGradient>
 
           <ScrollView

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -16,6 +16,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
+import { getFoodInfo } from '../foodIcons';
 
 export default function AddShoppingItemModal({
   visible,
@@ -38,6 +39,7 @@ export default function AddShoppingItemModal({
   const [totalPrice, setTotalPrice] = useState(0);
   const [unitPriceText, setUnitPriceText] = useState('');
   const [totalPriceText, setTotalPriceText] = useState('');
+  const [label, setLabel] = useState(foodName);
   const qtyScale = useRef(new Animated.Value(1)).current;
 
   const bumpQty = () => {
@@ -56,17 +58,19 @@ export default function AddShoppingItemModal({
   };
 
   useEffect(() => {
-    if (visible) {
-      setQuantity(initialQuantity ?? 1);
-      setUnit(initialUnit || units[0]?.key || 'units');
-      const u = initialUnitPrice ?? 0;
-      const t = initialTotalPrice ?? 0;
-      setUnitPrice(u);
-      setTotalPrice(t);
-      setUnitPriceText(u ? String(u) : '');
-      setTotalPriceText(t ? String(t) : '');
-    }
-  }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units]);
+      if (visible) {
+        const info = getFoodInfo(foodName);
+        setLabel(info?.name || foodName);
+        setQuantity(initialQuantity ?? 1);
+        setUnit(initialUnit || units[0]?.key || 'units');
+        const u = initialUnitPrice ?? 0;
+        const t = initialTotalPrice ?? 0;
+        setUnitPrice(u);
+        setTotalPrice(t);
+        setUnitPriceText(u ? String(u) : '');
+        setTotalPriceText(t ? String(t) : '');
+      }
+    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 
@@ -96,9 +100,9 @@ export default function AddShoppingItemModal({
                 />
               )}
             </View>
-            <Text style={styles.foodName} numberOfLines={2}>
-              {foodName}
-            </Text>
+              <Text style={styles.foodName} numberOfLines={2}>
+                {label}
+              </Text>
           </LinearGradient>
 
           <ScrollView

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -42,14 +42,14 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
             d.setDate(d.getDate() + info.expirationDays);
             exp = d.toISOString().split('T')[0];
           }
-          return {
-            location: locations[0]?.key || 'fridge',
-            quantity: '1',
-            unit: units[0]?.key || 'units',
-            regDate: today,
-            expDate: exp,
-            note: '',
-          };
+            return {
+              location: locations[0]?.key || 'fridge',
+              quantity: '1',
+              unit: info?.defaultUnit || units[0]?.key || 'units',
+              regDate: today,
+              expDate: exp,
+              note: '',
+            };
         }),
       );
     }

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -15,6 +15,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
+import { getFoodInfo } from '../foodIcons';
 
 export default function BatchAddShoppingModal({ visible, items = [], onSave, onClose }) {
   const palette = useTheme();
@@ -26,11 +27,11 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
   useEffect(() => {
     if (visible) {
       setData(
-        items.map(() => ({
+        items.map(item => ({
           quantity: '1',
-          unit: units[0]?.key || 'units',
-          unitPriceText: '',
-          totalPriceText: '',
+          unit: item.defaultUnit || units[0]?.key || 'units',
+          unitPriceText: item.defaultPrice ? String(item.defaultPrice) : '',
+          totalPriceText: item.defaultPrice ? String(item.defaultPrice) : '',
         })),
       );
     }
@@ -82,29 +83,31 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
             contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
             showsVerticalScrollIndicator={Platform.OS === 'web'}
           >
-            {items.map((item, idx) => {
-              const gi = gradientForKey(themeName, item.name);
-              const entry = data[idx] || {};
-              const qty = parseFloat(entry.quantity) || 0;
-              return (
-                <View key={idx} style={styles.card}>
-                  <View style={styles.cardHeader}>
-                    <LinearGradient
-                      colors={gi.colors}
-                      locations={gi.locations}
-                      start={gi.start}
-                      end={gi.end}
-                      style={styles.cardRibbon}
-                    >
-                      {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
-                      <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">
-                        {item.name}
+              {items.map((item, idx) => {
+                const gi = gradientForKey(themeName, item.name);
+                const entry = data[idx] || {};
+                const qty = parseFloat(entry.quantity) || 0;
+                const info = getFoodInfo(item.name);
+                const label = info?.name || item.name;
+                return (
+                  <View key={idx} style={styles.card}>
+                    <View style={styles.cardHeader}>
+                      <LinearGradient
+                        colors={gi.colors}
+                        locations={gi.locations}
+                        start={gi.start}
+                        end={gi.end}
+                        style={styles.cardRibbon}
+                      >
+                        {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
+                        <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">
+                          {label}
+                        </Text>
+                      </LinearGradient>
+                      <Text style={styles.cardMeta}>
+                        {qty} {getLabel(qty, entry.unit)}
                       </Text>
-                    </LinearGradient>
-                    <Text style={styles.cardMeta}>
-                      {qty} {getLabel(qty, entry.unit)}
-                    </Text>
-                  </View>
+                    </View>
 
                   <Text style={styles.labelBold}>Cantidad</Text>
                   <View style={styles.qtyRow}>

--- a/MiAppNevera/src/components/EditDefaultFoodModal.js
+++ b/MiAppNevera/src/components/EditDefaultFoodModal.js
@@ -1,0 +1,175 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+import { useUnits } from '../context/UnitsContext';
+import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
+
+export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
+  const palette = useTheme();
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  const { units } = useUnits();
+  const { updateOverride } = useDefaultFoods();
+  const [name, setName] = useState('');
+  const [days, setDays] = useState('');
+  const [unit, setUnit] = useState(units[0]?.key || 'units');
+  const [price, setPrice] = useState('');
+
+  useEffect(() => {
+    if (visible && foodKey) {
+      const info = getFoodInfo(foodKey);
+      setName(info?.name || foodKey);
+      setDays(info?.expirationDays != null ? String(info.expirationDays) : '');
+      setUnit(info?.defaultUnit || units[0]?.key || 'units');
+      setPrice(info?.defaultPrice != null ? String(info.defaultPrice) : '');
+    }
+  }, [visible, foodKey, units]);
+
+  const handleSave = () => {
+    updateOverride(foodKey, {
+      name,
+      expirationDays: days === '' ? null : Number(days),
+      defaultUnit: unit,
+      defaultPrice: price === '' ? null : Number(price),
+    });
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.modalBackdrop}>
+        <View style={styles.sheet}>
+          <Text style={styles.title}>Editar alimento</Text>
+          <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}>
+            <Text style={styles.label}>Nombre</Text>
+            <TextInput value={name} onChangeText={setName} style={styles.input} />
+            <Text style={styles.label}>Días de caducidad</Text>
+            <TextInput
+              value={days}
+              onChangeText={t => setDays(t.replace(/[^0-9]/g, ''))}
+              keyboardType="numeric"
+              style={styles.input}
+            />
+            <Text style={styles.label}>Unidad por defecto</Text>
+            <View style={styles.chipWrap}>
+              {units.map(u => (
+                <Pressable
+                  key={u.key}
+                  onPress={() => setUnit(u.key)}
+                  style={[styles.chip, unit === u.key && styles.chipOn]}
+                >
+                  <Text style={[styles.chipTxt, unit === u.key && styles.chipTxtOn]}>
+                    {u.singular}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            <Text style={styles.label}>Precio unitario</Text>
+            <TextInput
+              value={price}
+              onChangeText={t => {
+                let sanitized = t.replace(/[^0-9.]/g, '');
+                const parts = sanitized.split('.');
+                if (parts.length > 2) {
+                  sanitized = parts[0] + '.' + parts.slice(1).join('');
+                }
+                setPrice(sanitized);
+              }}
+              keyboardType="decimal-pad"
+              inputMode="decimal"
+              style={styles.input}
+            />
+          </ScrollView>
+          <View style={styles.footer}>
+            <TouchableOpacity onPress={onClose} style={styles.btn}>
+              <Text style={styles.btnTxt}>Cancelar</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleSave} style={[styles.btn, styles.btnPrimary]}>
+              <Text style={styles.btnPrimaryTxt}>Guardar</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = palette =>
+  StyleSheet.create({
+    modalBackdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    sheet: {
+      backgroundColor: palette.bg,
+      borderRadius: 18,
+      borderWidth: 1,
+      borderColor: palette.border,
+      width: '90%',
+      maxHeight: '80%',
+      minHeight: '50%',
+      overflow: 'hidden',
+    },
+    title: {
+      textAlign: 'center',
+      color: palette.accent,
+      fontWeight: '700',
+      fontSize: 16,
+      marginTop: 12,
+    },
+    scroll: { flex: 1 },
+    label: { color: palette.text, marginTop: 12, marginBottom: 4 },
+    input: {
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      borderRadius: 10,
+      paddingHorizontal: 10,
+      paddingVertical: 8,
+      color: palette.text,
+    },
+    chipWrap: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 },
+    chip: {
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      borderRadius: 10,
+      backgroundColor: palette.surface2,
+      borderWidth: 1,
+      borderColor: palette.border,
+      marginRight: 8,
+      marginBottom: 8,
+    },
+    chipOn: { backgroundColor: palette.surface3, borderColor: palette.accent },
+    chipTxt: { color: palette.text },
+    chipTxtOn: { color: palette.accent },
+    footer: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      padding: 12,
+      borderTopWidth: 1,
+      borderColor: palette.border,
+    },
+    btn: {
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: palette.surface2,
+      marginLeft: 8,
+    },
+    btnTxt: { color: palette.text },
+    btnPrimary: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
+    btnPrimaryTxt: { color: '#1b1d22', fontWeight: '700' },
+  });

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -23,8 +23,10 @@ import foodIcons, {
   normalizeFoodName,
 } from '../foodIcons';
 import AddCustomFoodModal from './AddCustomFoodModal';
+import EditDefaultFoodModal from './EditDefaultFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
@@ -50,7 +52,9 @@ export default function FoodPickerModal({
   const [manageVisible, setManageVisible] = useState(false);
   const [hiddenFoods, setHiddenFoods] = useState([]);
   const { customFoods } = useCustomFoods();
+  const { overrides } = useDefaultFoods();
   const [addVisible, setAddVisible] = useState(false);
+  const [editKey, setEditKey] = useState(null);
 
   // === Estados para "ocultar" scrollbars sin mover layout (web) ===
   const [hoverCat, setHoverCat] = useState(false);
@@ -83,6 +87,9 @@ export default function FoodPickerModal({
     AsyncStorage.setItem('hiddenFoods', JSON.stringify(hiddenFoods));
   }, [hiddenFoods]);
 
+  // Re-render when default food overrides change
+  useEffect(() => {}, [overrides]);
+
   const toggleSelect = key => {
     setSelected(prev =>
       prev.includes(key) ? prev.filter(n => n !== key) : [...prev, key],
@@ -91,8 +98,7 @@ export default function FoodPickerModal({
 
   const handleSave = () => {
     if (onMultiSelect && selected.length) {
-      const names = selected.map(k => customFoodMap[k]?.name || getFoodInfo(k)?.name || k);
-      onMultiSelect(names);
+      onMultiSelect(selected);
     }
     setSelectMode(false);
     setSelected([]);
@@ -250,7 +256,7 @@ export default function FoodPickerModal({
                     onPress={() =>
                       selectMode
                         ? toggleSelect(food.key)
-                        : onSelect(food.label, food.icon)
+                        : onSelect(food.key, food.icon)
                     }
                     onLongPress={() => {
                       if (!selectMode) {
@@ -359,6 +365,7 @@ export default function FoodPickerModal({
                                 : [...prev, name],
                             )
                           }
+                          onLongPress={() => setEditKey(name)}
                         >
                           <View
                             style={{
@@ -394,6 +401,11 @@ export default function FoodPickerModal({
 
       {/* Añadir personalizado */}
       <AddCustomFoodModal visible={addVisible} onClose={() => setAddVisible(false)} />
+      <EditDefaultFoodModal
+        visible={!!editKey}
+        foodKey={editKey}
+        onClose={() => setEditKey(null)}
+      />
     </>
   );
 }

--- a/MiAppNevera/src/context/CustomFoodsContext.js
+++ b/MiAppNevera/src/context/CustomFoodsContext.js
@@ -32,7 +32,7 @@ export const CustomFoodsProvider = ({ children }) => {
   }, []);
 
   const addCustomFood = useCallback(
-    ({ name, category, icon, baseIcon, expirationDays }) => {
+    ({ name, category, icon, baseIcon, expirationDays, defaultUnit, defaultPrice }) => {
       const key = normalizeFoodName(name);
       const newFood = {
         name,
@@ -40,6 +40,8 @@ export const CustomFoodsProvider = ({ children }) => {
         icon: icon || null,
         baseIcon: baseIcon || null,
         expirationDays: expirationDays ?? null,
+        defaultUnit: defaultUnit || null,
+        defaultPrice: defaultPrice ?? null,
         key,
       };
       persist(prev => [...prev, newFood]);
@@ -48,7 +50,7 @@ export const CustomFoodsProvider = ({ children }) => {
   );
 
   const updateCustomFood = useCallback(
-    (key, { name, category, icon, baseIcon, expirationDays }) => {
+    (key, { name, category, icon, baseIcon, expirationDays, defaultUnit, defaultPrice }) => {
       const newKey = normalizeFoodName(name);
       persist(prev =>
         prev.map(f =>
@@ -59,6 +61,8 @@ export const CustomFoodsProvider = ({ children }) => {
                 icon: icon || null,
                 baseIcon: baseIcon || null,
                 expirationDays: expirationDays ?? null,
+                defaultUnit: defaultUnit || null,
+                defaultPrice: defaultPrice ?? null,
                 key: newKey,
               }
             : f,

--- a/MiAppNevera/src/context/DefaultFoodsContext.js
+++ b/MiAppNevera/src/context/DefaultFoodsContext.js
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { setDefaultFoodsMap } from '../foodIcons';
+
+const DefaultFoodsContext = createContext();
+
+export const DefaultFoodsProvider = ({ children }) => {
+  const [overrides, setOverrides] = useState([]);
+
+  useEffect(() => {
+    AsyncStorage.getItem('defaultFoodOverrides').then(stored => {
+      const parsed = stored ? JSON.parse(stored) : [];
+      setOverrides(parsed);
+      setDefaultFoodsMap(parsed);
+    });
+  }, []);
+
+  const persist = useCallback(updater => {
+    setOverrides(prev => {
+      const data = typeof updater === 'function' ? updater(prev) : updater;
+      AsyncStorage.setItem('defaultFoodOverrides', JSON.stringify(data)).catch(e => {
+        console.error('Failed to save default food overrides', e);
+      });
+      setDefaultFoodsMap(data);
+      return data;
+    });
+  }, []);
+
+  const updateOverride = useCallback((key, data) => {
+    persist(prev => {
+      const filtered = prev.filter(f => f.key !== key);
+      return [...filtered, { key, ...data }];
+    });
+  }, [persist]);
+
+  const value = useMemo(() => ({ overrides, updateOverride }), [overrides, updateOverride]);
+
+  return (
+    <DefaultFoodsContext.Provider value={value}>
+      {children}
+    </DefaultFoodsContext.Provider>
+  );
+};
+
+export const useDefaultFoods = () => useContext(DefaultFoodsContext);

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -1,7 +1,8 @@
 import React, {createContext, useContext, useEffect, useState, useCallback, useMemo} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import foods from '../../assets/foods.json';
-import {getFoodIcon, getFoodCategory} from '../foodIcons';
+import {getFoodIcon, getFoodCategory, getFoodInfo} from '../foodIcons';
+import { useDefaultFoods } from './DefaultFoodsContext';
 import { useLocations } from './LocationsContext';
 import { useCustomFoods } from './CustomFoodsContext';
 
@@ -10,6 +11,7 @@ const InventoryContext = createContext();
 export const InventoryProvider = ({children}) => {
   const { locations } = useLocations();
   const { customFoods } = useCustomFoods();
+  const { overrides } = useDefaultFoods();
 
   const buildEmpty = useCallback(() => {
     const obj = {};
@@ -48,6 +50,24 @@ export const InventoryProvider = ({children}) => {
       }
     })();
   }, [locations, customFoods]);
+
+  useEffect(() => {
+    // refresh names/icons when default overrides change
+    setInventory(prev => {
+      const updated = {};
+      Object.keys(prev).forEach(cat => {
+        updated[cat] = prev[cat].map(item => {
+          const info = getFoodInfo(item.name);
+          return {
+            ...item,
+            name: info?.name || item.name,
+            icon: getFoodIcon(item.name),
+          };
+        });
+      });
+      return updated;
+    });
+  }, [overrides]);
 
   useEffect(() => {
     setInventory(prev => {

--- a/MiAppNevera/src/context/ShoppingContext.js
+++ b/MiAppNevera/src/context/ShoppingContext.js
@@ -1,13 +1,15 @@
 import React, {createContext, useContext, useEffect, useState, useCallback, useMemo} from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {getFoodIcon, getFoodCategory} from '../foodIcons';
+import {getFoodIcon, getFoodCategory, getFoodInfo} from '../foodIcons';
 import { useCustomFoods } from './CustomFoodsContext';
+import { useDefaultFoods } from './DefaultFoodsContext';
 
 const ShoppingContext = createContext();
 
 export const ShoppingProvider = ({children}) => {
   const [list, setList] = useState([]);
   const { customFoods } = useCustomFoods();
+  const { overrides } = useDefaultFoods();
 
   useEffect(() => {
     (async () => {
@@ -28,6 +30,20 @@ export const ShoppingProvider = ({children}) => {
       }
     })();
   }, [customFoods]);
+
+  useEffect(() => {
+    // update names when default overrides change
+    setList(prev =>
+      prev.map(item => {
+        const info = getFoodInfo(item.name);
+        return {
+          ...item,
+          name: info?.name || item.name,
+          icon: getFoodIcon(item.name),
+        };
+      }),
+    );
+  }, [overrides]);
 
   const persist = useCallback(updater => {
     setList(prev => {

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -1115,6 +1115,7 @@ export const categories = {
 };
 
 let customFoodsMap = {};
+let defaultOverridesMap = {};
 
 export function setCustomFoodsMap(list) {
   customFoodsMap = {};
@@ -1127,6 +1128,25 @@ export function setCustomFoodsMap(list) {
         baseIcon: item.baseIcon ? normalizeFoodName(item.baseIcon) : null,
         expirationDays:
           item.expirationDays != null ? Number(item.expirationDays) : null,
+        defaultUnit: item.defaultUnit || null,
+        defaultPrice: item.defaultPrice != null ? Number(item.defaultPrice) : null,
+      };
+    });
+  }
+}
+
+export function setDefaultFoodsMap(list) {
+  defaultOverridesMap = {};
+  if (Array.isArray(list)) {
+    list.forEach(item => {
+      if (!item || !item.key) return;
+      defaultOverridesMap[item.key] = {
+        name: item.name,
+        expirationDays:
+          item.expirationDays != null ? Number(item.expirationDays) : null,
+        defaultUnit: item.defaultUnit || null,
+        defaultPrice:
+          item.defaultPrice != null ? Number(item.defaultPrice) : null,
       };
     });
   }
@@ -1146,6 +1166,9 @@ export function getFoodInfo(name) {
         ? getFoodIcon(info.baseIcon)
         : undefined;
     return { ...info, icon };
+  }
+  if (defaultOverridesMap[key]) {
+    return { ...foodData[key], ...defaultOverridesMap[key], key };
   }
   return foodData[key];
 }

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -22,7 +22,7 @@ import FoodPickerModal from '../components/FoodPickerModal';
 import AddItemModal from '../components/AddItemModal';
 import EditItemModal from '../components/EditItemModal';
 import BatchAddItemModal from '../components/BatchAddItemModal';
-import { getFoodIcon } from '../foodIcons';
+import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
@@ -255,14 +255,25 @@ export default function InventoryScreen({ navigation }) {
     groupOrder = ['all'];
   }
 
-  const onSelectFood = (name, icon) => { setSelectedFood({ name, icon }); setPickerVisible(false); setAddVisible(true); };
-  const onMultiSelectFoods = names => { const items = names.map(name => ({ name, icon: getFoodIcon(name) })); setMultiItems(items); setPickerVisible(false); setMultiAddVisible(true); };
+  const onSelectFood = (key, icon) => {
+    const info = getFoodInfo(key);
+    setSelectedFood({ key, name: info?.name || key, icon });
+    setPickerVisible(false);
+    setAddVisible(true);
+  };
+  const onMultiSelectFoods = keys => {
+    const items = keys.map(k => ({ name: k, icon: getFoodIcon(k) }));
+    setMultiItems(items);
+    setPickerVisible(false);
+    setMultiAddVisible(true);
+  };
 
   const onSave = data => {
-    cleanZeroItems(selectedFood.name);
+    cleanZeroItems(selectedFood.key);
     const qty = parseFloat(data.quantity) || 0;
     const hasNote = data.note && data.note.trim() !== '';
-    if (qty !== 0 || hasNote) addItem(data.location, selectedFood.name, qty, data.unit, data.registered, data.expiration, data.note);
+    if (qty !== 0 || hasNote)
+      addItem(data.location, selectedFood.key, qty, data.unit, data.registered, data.expiration, data.note);
     setAddVisible(false);
   };
 
@@ -659,7 +670,7 @@ export default function InventoryScreen({ navigation }) {
 
       {/* Modales de negocio */}
       <FoodPickerModal visible={pickerVisible} onSelect={onSelectFood} onMultiSelect={onMultiSelectFoods} onClose={() => setPickerVisible(false)} />
-      <AddItemModal visible={addVisible} foodName={selectedFood?.name} foodIcon={selectedFood?.icon} initialLocation={storage} onSave={onSave} onClose={() => setAddVisible(false)} />
+        <AddItemModal visible={addVisible} foodName={selectedFood?.key} foodIcon={selectedFood?.icon} initialLocation={storage} onSave={onSave} onClose={() => setAddVisible(false)} />
       <BatchAddItemModal visible={multiAddVisible} items={multiItems} onSave={handleBatchAddSave} onClose={() => setMultiAddVisible(false)} />
       <EditItemModal
         visible={!!editingItem}

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -28,7 +28,7 @@ import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
 import { useSavedLists } from '../context/SavedListsContext';
-import { getFoodIcon } from '../foodIcons';
+import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import CostPieChart from '../components/CostPieChart';
 
 export default function ShoppingListScreen() {
@@ -75,26 +75,42 @@ export default function ShoppingListScreen() {
   const [editIdx, setEditIdx] = useState(null);
   const [detailsVisible, setDetailsVisible] = useState(false);
 
-  const onSelectFood = (name, icon) => {
-    setSelectedFood({ name, icon });
-    setPickerVisible(false);
-    setAddVisible(true);
-  };
+    const onSelectFood = (key, icon) => {
+      const info = getFoodInfo(key);
+      setSelectedFood({
+        key,
+        name: info?.name || key,
+        icon,
+        unit: info?.defaultUnit,
+        unitPrice: info?.defaultPrice,
+        totalPrice: info?.defaultPrice,
+      });
+      setPickerVisible(false);
+      setAddVisible(true);
+    };
 
-  const onMultiSelectFoods = names => {
-    const items = names.map(name => ({ name, icon: getFoodIcon(name) }));
-    setMultiItems(items);
-    setPickerVisible(false);
-    setMultiAddVisible(true);
-  };
+    const onMultiSelectFoods = keys => {
+      const items = keys.map(k => {
+        const info = getFoodInfo(k);
+        return {
+          name: k,
+          icon: getFoodIcon(k),
+          defaultUnit: info?.defaultUnit,
+          defaultPrice: info?.defaultPrice,
+        };
+      });
+      setMultiItems(items);
+      setPickerVisible(false);
+      setMultiAddVisible(true);
+    };
 
-  const onSave = ({ quantity, unit, unitPrice, totalPrice }) => {
-    if (selectedFood) {
-      addItem(selectedFood.name, quantity, unit, unitPrice, totalPrice);
-      setSelectedFood(null);
-      setAddVisible(false);
-    }
-  };
+    const onSave = ({ quantity, unit, unitPrice, totalPrice }) => {
+      if (selectedFood) {
+        addItem(selectedFood.key, quantity, unit, unitPrice, totalPrice);
+        setSelectedFood(null);
+        setAddVisible(false);
+      }
+    };
 
   const handleMultiAddSave = entries => {
     addItems(
@@ -398,10 +414,13 @@ export default function ShoppingListScreen() {
       />
       <AddShoppingItemModal
         visible={addVisible}
-        foodName={selectedFood?.name}
+        foodName={selectedFood?.key}
         foodIcon={selectedFood?.icon}
         onSave={onSave}
         onClose={() => setAddVisible(false)}
+        initialUnit={selectedFood?.unit}
+        initialUnitPrice={selectedFood?.unitPrice}
+        initialTotalPrice={selectedFood?.totalPrice}
       />
       <AddShoppingItemModal
         visible={editIdx !== null}


### PR DESCRIPTION
## Summary
- add DefaultFoodsContext and modal to edit built-in foods
- support updating name, expiration, unit and price for default foods
- pre-fill shopping and inventory entries with custom defaults
- center default food editor dialog and validate numeric inputs
- allow defining default unit, price and expiration when creating custom foods
- ensure renamed default foods persist after page refresh

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7e216b1bc8324afc4cf0d9ed94d7d