### PR TITLE
fix: persist default food name overrides

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -20,6 +20,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -30,6 +31,8 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const today = new Date().toISOString().split('T')[0];
   const { units } = useUnits();
   const { locations } = useLocations();
+  // subscribe to default food overrides so edits persist after refresh
+  const { overrides } = useDefaultFoods();
   const [location, setLocation] = useState(initialLocation);
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
@@ -65,7 +68,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
         setNote('');
         setLabel(info?.name || foodName);
       }
-    }, [visible, initialLocation, today, units, locations, foodName]);
+    }, [visible, initialLocation, today, units, locations, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -17,6 +17,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function AddShoppingItemModal({
   visible,
@@ -33,6 +34,8 @@ export default function AddShoppingItemModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
+  // subscribe to default food overrides so edits persist
+  const { overrides } = useDefaultFoods();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
   const [unitPrice, setUnitPrice] = useState(0);
@@ -70,7 +73,7 @@ export default function AddShoppingItemModal({
         setUnitPriceText(u ? String(u) : '');
         setTotalPriceText(t ? String(t) : '');
       }
-    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName]);
+    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -18,6 +18,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -29,6 +30,8 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
   const today = new Date().toISOString().split('T')[0];
   const { units, getLabel } = useUnits();
   const { locations } = useLocations();
+  // subscribe to default food overrides so batch defaults update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -53,7 +56,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
         }),
       );
     }
-  }, [visible, items, today, units, locations]);
+  }, [visible, items, today, units, locations, overrides]);
 
   const updateField = (index, field, value) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -16,12 +16,15 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function BatchAddShoppingModal({ visible, items = [], onSave, onClose }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette, themeName), [palette, themeName]);
   const { units, getLabel } = useUnits();
+  // subscribe to default food overrides so batch names update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -35,7 +38,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
         })),
       );
     }
-  }, [visible, items, units]);
+  }, [visible, items, units, overrides]);
 
   const updateItem = (index, changes) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, ...changes } : d)));

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -26,6 +26,7 @@ import AddCustomFoodModal from './AddCustomFoodModal';
 import EditDefaultFoodModal from './EditDefaultFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
@@ -40,6 +41,8 @@ export default function FoodPickerModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { categories } = useCategories();
+  // subscribe to default food overrides so default names update after refresh
+  const { overrides } = useDefaultFoods();
   const categoryNames = Object.keys(categories);
   const baseCategoryNames = Object.keys(baseCategories);
   const [currentCategory, setCurrentCategory] = useState(categoryNames[0] || '');

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -26,6 +26,7 @@ import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -98,6 +99,8 @@ export default function InventoryScreen({ navigation }) {
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  // subscribe to default food overrides so inventory names update after refresh
+  const { overrides } = useDefaultFoods();
   const [storage, setStorage] = useState(locations[0]?.key || 'fridge');
 
   useEffect(() => {

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -30,6 +30,7 @@ import { useTheme } from '../context/ThemeContext';
 import { useSavedLists } from '../context/SavedListsContext';
 import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import CostPieChart from '../components/CostPieChart';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -59,6 +60,8 @@ export default function ShoppingListScreen() {
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  // subscribe to default food overrides so shopping names update after refresh
+  const { overrides } = useDefaultFoods();
 
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);


### PR DESCRIPTION
## Summary
- subscribe food selection and item modals to default food overrides so admin renames persist after refresh

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8a2d37f608324895c0ca2eac2e4bd