### PR TITLE
fix: persist default food name overrides

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -20,6 +20,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -30,6 +31,8 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const today = new Date().toISOString().split('T')[0];
   const { units } = useUnits();
   const { locations } = useLocations();
+  // subscribe to default food overrides so edits persist after refresh
+  const { overrides } = useDefaultFoods();
   const [location, setLocation] = useState(initialLocation);
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
@@ -65,7 +68,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
         setNote('');
         setLabel(info?.name || foodName);
       }
-    }, [visible, initialLocation, today, units, locations, foodName]);
+    }, [visible, initialLocation, today, units, locations, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -17,6 +17,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function AddShoppingItemModal({
   visible,
@@ -33,6 +34,8 @@ export default function AddShoppingItemModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
+  // subscribe to default food overrides so edits persist
+  const { overrides } = useDefaultFoods();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
   const [unitPrice, setUnitPrice] = useState(0);
@@ -70,7 +73,7 @@ export default function AddShoppingItemModal({
         setUnitPriceText(u ? String(u) : '');
         setTotalPriceText(t ? String(t) : '');
       }
-    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName]);
+    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -18,6 +18,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -29,6 +30,8 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
   const today = new Date().toISOString().split('T')[0];
   const { units, getLabel } = useUnits();
   const { locations } = useLocations();
+  // subscribe to default food overrides so batch defaults update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -53,7 +56,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
         }),
       );
     }
-  }, [visible, items, today, units, locations]);
+  }, [visible, items, today, units, locations, overrides]);
 
   const updateField = (index, field, value) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
@@ -98,17 +101,20 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
             contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
             showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
           >
-            {items.map((item, idx) => (
-              <View key={idx} style={styles.card}>
-                <View style={styles.cardHeader}>
-                  <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.cardRibbon}>
-                  {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
-                  <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">{item.name}</Text>
-                </LinearGradient>
-                <Text style={styles.cardMeta}>
-                    {data[idx]?.quantity || 0} {getLabel(parseFloat(data[idx]?.quantity) || 0, data[idx]?.unit)}
-                  </Text>
-                </View>
+            {items.map((item, idx) => {
+              const info = getFoodInfo(item.name);
+              const label = info?.name || item.name;
+              return (
+                <View key={idx} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.cardRibbon}>
+                    {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
+                    <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">{label}</Text>
+                  </LinearGradient>
+                  <Text style={styles.cardMeta}>
+                      {data[idx]?.quantity || 0} {getLabel(parseFloat(data[idx]?.quantity) || 0, data[idx]?.unit)}
+                    </Text>
+                  </View>
 
                 {/* Ubicación */}
                 <Text style={styles.labelBold}>Ubicación</Text>

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -16,12 +16,15 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function BatchAddShoppingModal({ visible, items = [], onSave, onClose }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette, themeName), [palette, themeName]);
   const { units, getLabel } = useUnits();
+  // subscribe to default food overrides so batch names update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -35,7 +38,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
         })),
       );
     }
-  }, [visible, items, units]);
+  }, [visible, items, units, overrides]);
 
   const updateItem = (index, changes) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, ...changes } : d)));

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -26,6 +26,7 @@ import AddCustomFoodModal from './AddCustomFoodModal';
 import EditDefaultFoodModal from './EditDefaultFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
@@ -40,6 +41,8 @@ export default function FoodPickerModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { categories } = useCategories();
+  // subscribe to default food overrides so default names update after refresh
+  const { overrides } = useDefaultFoods();
   const categoryNames = Object.keys(categories);
   const baseCategoryNames = Object.keys(baseCategories);
   const [currentCategory, setCurrentCategory] = useState(categoryNames[0] || '');

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -12,6 +12,8 @@ import {
 import { useUnits } from '../context/UnitsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
+import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import CostPieChart from './CostPieChart';
 
 export default function ShoppingListPreview({ items = [], onItemPress, onItemLongPress, selected = [], style }) {
@@ -19,6 +21,8 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
   const { categories } = useCategories();
   const palette = useTheme();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  // subscribe to default food overrides so preview names update
+  const { overrides } = useDefaultFoods();
 
   const [detailsVisible, setDetailsVisible] = useState(false);
 
@@ -77,6 +81,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
             </View>
             {arr.map(({ item, index }) => {
               const isSelected = selected.includes(index);
+              const label = getFoodInfo(item.name)?.name || item.name;
               return (
                 <TouchableOpacity
                   key={index}
@@ -87,7 +92,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
                   <View style={[styles.row, isSelected && styles.rowSelected]}>
                     {item.icon && <Image source={item.icon} style={styles.icon} />}
                     <Text style={styles.rowText} numberOfLines={2}>
-                      {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
+                      {label} - {item.quantity} {getLabel(item.quantity, item.unit)}
                     </Text>
                     {item.totalPrice > 0 && (
                       <Text style={styles.priceBadge}>

--- a/MiAppNevera/src/screens/CategoryScreen.js
+++ b/MiAppNevera/src/screens/CategoryScreen.js
@@ -3,11 +3,15 @@ import { Button, Image, ScrollView, Text, TextInput, View } from 'react-native';
 import { useInventory } from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
 import { useCategories } from '../context/CategoriesContext';
+import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function CategoryScreen({ route }) {
   const { category } = route.params;
   const { inventory, addItem, updateQuantity, removeItem } = useInventory();
   const { categories } = useCategories();
+  // subscribe to default food overrides so category list updates names
+  const { overrides } = useDefaultFoods();
   const [quantity, setQuantity] = useState(1);
   const [search, setSearch] = useState('');
   const [pickerVisible, setPickerVisible] = useState(false);
@@ -45,41 +49,45 @@ export default function CategoryScreen({ route }) {
       />
       <ScrollView>
         {inventory[category]
-          ?.filter(item =>
-            item.name.toLowerCase().includes(search.toLowerCase()),
-          )
-          .map((item, idx) => (
-            <View
-              key={idx}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                padding: 5,
-                opacity: item.quantity === 0 ? 0.5 : 1,
-              }}
-            >
-              {item.icon && (
-                <Image
-                  source={item.icon}
-                  style={{ width: 32, height: 32, marginRight: 10 }}
+          ?.filter(item => {
+            const label = getFoodInfo(item.name)?.name || item.name;
+            return label.toLowerCase().includes(search.toLowerCase());
+          })
+          .map((item, idx) => {
+            const label = getFoodInfo(item.name)?.name || item.name;
+            return (
+              <View
+                key={idx}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  padding: 5,
+                  opacity: item.quantity === 0 ? 0.5 : 1,
+                }}
+              >
+                {item.icon && (
+                  <Image
+                    source={item.icon}
+                    style={{ width: 32, height: 32, marginRight: 10 }}
+                  />
+                )}
+                <Text style={{ flex: 1 }}>{label}</Text>
+                <Button
+                  title="-"
+                  onPress={() => updateQuantity(category, idx, -1)}
                 />
-              )}
-              <Text style={{ flex: 1 }}>{item.name}</Text>
-              <Button
-                title="-"
-                onPress={() => updateQuantity(category, idx, -1)}
-              />
-              <Text style={{ marginHorizontal: 10 }}>{item.quantity}</Text>
-              <Button
-                title="+"
-                onPress={() => updateQuantity(category, idx, 1)}
-              />
-              <Button
-                title="Eliminar"
-                onPress={() => removeItem(category, idx)}
-              />
-            </View>
-          ))}
+                <Text style={{ marginHorizontal: 10 }}>{item.quantity}</Text>
+                <Button
+                  title="+"
+                  onPress={() => updateQuantity(category, idx, 1)}
+                />
+                <Button
+                  title="Eliminar"
+                  onPress={() => removeItem(category, idx)}
+                />
+              </View>
+            );
+          })}
       </ScrollView>
     </View>
   );

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -26,6 +26,7 @@ import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -98,6 +99,8 @@ export default function InventoryScreen({ navigation }) {
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  // subscribe to default food overrides so inventory names update after refresh
+  const { overrides } = useDefaultFoods();
   const [storage, setStorage] = useState(locations[0]?.key || 'fridge');
 
   useEffect(() => {
@@ -437,6 +440,7 @@ export default function InventoryScreen({ navigation }) {
                     const daysLeft = item.expiration ? Math.ceil((new Date(item.expiration) - new Date()) / (1000 * 60 * 60 * 24)) : null;
                     const meta = getExpiryMeta(palette, daysLeft);
                     const g = gradientForKey(themeName, item.name || key);
+                    const label = getFoodInfo(item.name)?.name || item.name;
 
                     return (
                       <TouchableOpacity
@@ -454,7 +458,7 @@ export default function InventoryScreen({ navigation }) {
                             <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center', paddingRight: 6 }}>
                               {/* Nombre + badge pegado a la izquierda */}
                               <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center', minWidth: 0 }}>
-                                <Text style={{ color: palette.foodName, fontSize: 15, fontWeight: '400', flexShrink: 1 }} numberOfLines={2}>{item.name}</Text>
+                                <Text style={{ color: palette.foodName, fontSize: 15, fontWeight: '400', flexShrink: 1 }} numberOfLines={2}>{label}</Text>
                                 {meta && (
                                   <View style={{ marginLeft: 10, backgroundColor: meta.bg, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 8 }}>
                                     <Text style={{ color: meta.text, fontSize: 12, fontWeight: '700' }}>{meta.label}</Text>
@@ -489,6 +493,7 @@ export default function InventoryScreen({ navigation }) {
                       const daysLeft = item.expiration ? Math.ceil((new Date(item.expiration) - new Date()) / (1000 * 60 * 60 * 24)) : null;
                       const meta = getExpiryMeta(palette, daysLeft);
                       const g = gradientForKey(themeName, item.name || key);
+                      const label = getFoodInfo(item.name)?.name || item.name;
 
                       return (
                         <TouchableOpacity
@@ -508,7 +513,7 @@ export default function InventoryScreen({ navigation }) {
                                 {item.icon && (<Image source={item.icon} style={{ width: 54, height: 54 }} resizeMode="contain" />)}
                               </View>
                               <Text style={{ textAlign: 'center', color: palette.foodName, fontSize: 12, fontWeight: '400' }} numberOfLines={2}>
-                                {item.name}
+                                {label}
                               </Text>
                               <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
                                 {item.quantity} {getLabel(item.quantity, item.unit)}
@@ -710,7 +715,7 @@ export default function InventoryScreen({ navigation }) {
                         />
                       )}
                       <Text style={{ color: palette.text }}>
-                        {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
+                        {getFoodInfo(item.name)?.name || item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
                       </Text>
                     </View>
                   ))}

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -30,6 +30,7 @@ import { useTheme } from '../context/ThemeContext';
 import { useSavedLists } from '../context/SavedListsContext';
 import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import CostPieChart from '../components/CostPieChart';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -59,6 +60,8 @@ export default function ShoppingListScreen() {
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  // subscribe to default food overrides so shopping names update after refresh
+  const { overrides } = useDefaultFoods();
 
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);
@@ -340,6 +343,7 @@ export default function ShoppingListScreen() {
                 {items.map(({ item, index }) => {
                   const isSel = selectMode && selected.includes(index);
                   const purchased = !!item.purchased;
+                  const label = getFoodInfo(item.name)?.name || item.name;
                   return (
                     <TouchableOpacity
                       key={index}
@@ -376,7 +380,7 @@ export default function ShoppingListScreen() {
                             ]}
                             numberOfLines={2}
                           >
-                            {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
+                            {label} - {item.quantity} {getLabel(item.quantity, item.unit)}
                           </Text>
                         </View>
                         {item.totalPrice > 0 && (


### PR DESCRIPTION
## Summary
- resolve default food names with `getFoodInfo` across inventory, shopping list, batch add and preview screens so admin renames keep proper casing
- refresh category view filtering/display using overridden names

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8a2d37f608324895c0ca2eac2e4bd