### PR TITLE
feat: allow pricing inventory items

### DIFF
--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -17,6 +17,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function AddShoppingItemModal({
   visible,
@@ -33,6 +34,8 @@ export default function AddShoppingItemModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
+  // subscribe to default food overrides so edits persist
+  const { overrides } = useDefaultFoods();
   const [quantity, setQuantity] = useState(1);
   const [unit, setUnit] = useState(units[0]?.key || 'units');
   const [unitPrice, setUnitPrice] = useState(0);
@@ -70,7 +73,7 @@ export default function AddShoppingItemModal({
         setUnitPriceText(u ? String(u) : '');
         setTotalPriceText(t ? String(t) : '');
       }
-    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName]);
+    }, [visible, initialQuantity, initialUnit, initialUnitPrice, initialTotalPrice, units, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -18,6 +18,7 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 
@@ -29,6 +30,8 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
   const today = new Date().toISOString().split('T')[0];
   const { units, getLabel } = useUnits();
   const { locations } = useLocations();
+  // subscribe to default food overrides so batch defaults update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -42,18 +45,19 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
             d.setDate(d.getDate() + info.expirationDays);
             exp = d.toISOString().split('T')[0];
           }
-            return {
-              location: locations[0]?.key || 'fridge',
-              quantity: '1',
-              unit: info?.defaultUnit || units[0]?.key || 'units',
-              regDate: today,
-              expDate: exp,
-              note: '',
-            };
+          return {
+            location: locations[0]?.key || 'fridge',
+            quantity: '1',
+            unit: info?.defaultUnit || units[0]?.key || 'units',
+            regDate: today,
+            expDate: exp,
+            note: '',
+            price: info?.defaultPrice != null ? String(info.defaultPrice) : '',
+          };
         }),
       );
     }
-  }, [visible, items, today, units, locations]);
+  }, [visible, items, today, units, locations, overrides]);
 
   const updateField = (index, field, value) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
@@ -63,6 +67,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
     onSave(
       data.map((d, idx) => ({
         ...d,
+        price: parseFloat(d.price) || 0,
         index: items[idx].index,
         name: items[idx].name,
       })),
@@ -98,17 +103,20 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
             contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
             showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
           >
-            {items.map((item, idx) => (
-              <View key={idx} style={styles.card}>
-                <View style={styles.cardHeader}>
-                  <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.cardRibbon}>
-                  {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
-                  <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">{item.name}</Text>
-                </LinearGradient>
-                <Text style={styles.cardMeta}>
-                    {data[idx]?.quantity || 0} {getLabel(parseFloat(data[idx]?.quantity) || 0, data[idx]?.unit)}
-                  </Text>
-                </View>
+            {items.map((item, idx) => {
+              const info = getFoodInfo(item.name);
+              const label = info?.name || item.name;
+              return (
+                <View key={idx} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.cardRibbon}>
+                    {item.icon && <Image source={item.icon} style={styles.ribbonIcon} />}
+                    <Text style={styles.ribbonTitle} numberOfLines={1} ellipsizeMode="tail">{label}</Text>
+                  </LinearGradient>
+                  <Text style={styles.cardMeta}>
+                      {data[idx]?.quantity || 0} {getLabel(parseFloat(data[idx]?.quantity) || 0, data[idx]?.unit)}
+                    </Text>
+                  </View>
 
                 {/* Ubicación */}
                 <Text style={styles.labelBold}>Ubicación</Text>
@@ -184,6 +192,30 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                   ))}
                 </View>
 
+                {/* Precio */}
+                <Text style={styles.labelBold}>Precio unitario</Text>
+                <TextInput
+                  style={styles.priceInput}
+                  value={data[idx]?.price}
+                  onChangeText={t => {
+                    let sanitized = t.replace(/[^0-9.]/g, '');
+                    const parts = sanitized.split('.');
+                    if (parts.length > 2) {
+                      sanitized = parts[0] + '.' + parts.slice(1).join('');
+                    }
+                    updateField(idx, 'price', sanitized);
+                  }}
+                  keyboardType="decimal-pad"
+                  inputMode="decimal"
+                  placeholder="Opcional"
+                  placeholderTextColor={palette.textDim}
+                />
+                {parseFloat(data[idx]?.price) > 0 && parseFloat(data[idx]?.quantity) > 0 && (
+                  <Text style={styles.totalPriceText}>
+                    {`Total: S/${(parseFloat(data[idx].price) * parseFloat(data[idx].quantity)).toFixed(2)}`}
+                  </Text>
+                )}
+
                 {/* Fechas */}
                 <View style={{ marginTop: 6 }}>
                   <Text style={styles.labelBold}>Fecha de registro</Text>
@@ -213,7 +245,8 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                   placeholderTextColor={palette.textDim}
                 />
               </View>
-            ))}
+            );
+          })}
           </ScrollView>
 
         </View>
@@ -338,6 +371,17 @@ const createStyles = (palette, themeName) => StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
   },
+  priceInput: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    backgroundColor: palette.surface2,
+    color: palette.text,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    marginBottom: 4,
+  },
+  totalPriceText: { color: palette.accent, fontWeight: '700', marginBottom: 8 },
   dateContainer: {
     borderWidth: 1,
     borderColor: palette.border,

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -16,12 +16,15 @@ import { useUnits } from '../context/UnitsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function BatchAddShoppingModal({ visible, items = [], onSave, onClose }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette, themeName), [palette, themeName]);
   const { units, getLabel } = useUnits();
+  // subscribe to default food overrides so batch names update after refresh
+  const { overrides } = useDefaultFoods();
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -35,7 +38,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
         })),
       );
     }
-  }, [visible, items, units]);
+  }, [visible, items, units, overrides]);
 
   const updateItem = (index, changes) => {
     setData(prev => prev.map((d, i) => (i === index ? { ...d, ...changes } : d)));

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -42,6 +42,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   const [regDate, setRegDate] = useState('');
   const [expDate, setExpDate] = useState('');
   const [note, setNote] = useState('');
+  const [price, setPrice] = useState('');
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [shoppingVisible, setShoppingVisible] = useState(false);
 
@@ -62,6 +63,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
       setRegDate(item.registered || '');
       setExpDate(item.expiration || '');
       setNote(item.note || '');
+      setPrice(item.price != null ? String(item.price) : '');
     }
   }, [visible, item, units, locations]);
 
@@ -75,6 +77,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
       registered: regDate,
       expiration: expDate,
       note,
+      price: parseFloat(price) || 0,
     });
   };
 
@@ -136,11 +139,11 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                       {opt.name}
                     </Text>
                   </Pressable>
-                ))}
-              </View>
+              ))}
+            </View>
 
-              {/* Cantidad */}
-              <Text style={styles.labelBold}>Cantidad</Text>
+            {/* Cantidad */}
+            <Text style={styles.labelBold}>Cantidad</Text>
               <View style={styles.qtyRow}>
                 <TouchableOpacity
                   onPress={() => { setQuantity(q => Math.max(0, (q || 0) - 1)); bumpQty(); }}
@@ -186,11 +189,35 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                       {opt.plural}
                     </Text>
                   </Pressable>
-                ))}
-              </View>
+              ))}
+            </View>
 
-              {/* Fechas (inputs gris) */}
-              <View style={{ marginTop: 6 }}>
+            {/* Precio */}
+            <Text style={styles.labelBold}>Precio unitario</Text>
+            <TextInput
+              style={styles.priceInput}
+              value={price}
+              onChangeText={t => {
+                let sanitized = t.replace(/[^0-9.]/g, '');
+                const parts = sanitized.split('.');
+                if (parts.length > 2) {
+                  sanitized = parts[0] + '.' + parts.slice(1).join('');
+                }
+                setPrice(sanitized);
+              }}
+              keyboardType="decimal-pad"
+              inputMode="decimal"
+              placeholder="Opcional"
+              placeholderTextColor={palette.textDim}
+            />
+            {parseFloat(price) > 0 && quantity > 0 && (
+              <Text style={styles.totalPriceText}>
+                {`Total: S/${(parseFloat(price) * quantity).toFixed(2)}`}
+              </Text>
+            )}
+
+            {/* Fechas (inputs gris) */}
+            <View style={{ marginTop: 6 }}>
                 <Text style={styles.labelBold}>Fecha de registro</Text>
                 <DatePicker
                   value={regDate}
@@ -235,6 +262,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
         foodName={item?.name}
         foodIcon={item?.icon}
         initialUnit={item?.unit}
+        initialUnitPrice={item?.price}
         onSave={({ quantity: q, unit: u, unitPrice, totalPrice }) => {
           addShoppingItem(item?.name, q || 0, u, unitPrice, totalPrice);
           Alert.alert('Añadido', `${item?.name} añadido a la lista de compras`);
@@ -372,6 +400,17 @@ const createStyles = (palette) => StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
   },
+  priceInput: {
+    borderWidth: 1,
+    borderColor: palette.border,
+    backgroundColor: palette.surface2,
+    color: palette.text,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    marginBottom: 4,
+  },
+  totalPriceText: { color: palette.accent, fontWeight: '700', marginBottom: 8 },
 
   // Estilos para DatePicker (gris, consistente)
   dateContainer: {

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -26,6 +26,7 @@ import AddCustomFoodModal from './AddCustomFoodModal';
 import EditDefaultFoodModal from './EditDefaultFoodModal';
 import { useCustomFoods } from '../context/CustomFoodsContext';
 import { useCategories } from '../context/CategoriesContext';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
@@ -40,6 +41,8 @@ export default function FoodPickerModal({
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { categories } = useCategories();
+  // subscribe to default food overrides so default names update after refresh
+  const { overrides } = useDefaultFoods();
   const categoryNames = Object.keys(categories);
   const baseCategoryNames = Object.keys(baseCategories);
   const [currentCategory, setCurrentCategory] = useState(categoryNames[0] || '');

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -12,6 +12,8 @@ import {
 import { useUnits } from '../context/UnitsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useTheme } from '../context/ThemeContext';
+import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import CostPieChart from './CostPieChart';
 
 export default function ShoppingListPreview({ items = [], onItemPress, onItemLongPress, selected = [], style }) {
@@ -19,6 +21,8 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
   const { categories } = useCategories();
   const palette = useTheme();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  // subscribe to default food overrides so preview names update
+  const { overrides } = useDefaultFoods();
 
   const [detailsVisible, setDetailsVisible] = useState(false);
 
@@ -77,6 +81,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
             </View>
             {arr.map(({ item, index }) => {
               const isSelected = selected.includes(index);
+              const label = getFoodInfo(item.name)?.name || item.name;
               return (
                 <TouchableOpacity
                   key={index}
@@ -87,7 +92,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
                   <View style={[styles.row, isSelected && styles.rowSelected]}>
                     {item.icon && <Image source={item.icon} style={styles.icon} />}
                     <Text style={styles.rowText} numberOfLines={2}>
-                      {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
+                      {label} - {item.quantity} {getLabel(item.quantity, item.unit)}
                     </Text>
                     {item.totalPrice > 0 && (
                       <Text style={styles.priceBadge}>

--- a/MiAppNevera/src/context/InventoryContext.js
+++ b/MiAppNevera/src/context/InventoryContext.js
@@ -97,6 +97,7 @@ export const InventoryProvider = ({children}) => {
     registered = '',
     expiration = '',
     note = '',
+    price = 0,
   ) => {
     const icon = getFoodIcon(name);
     const foodCategory = getFoodCategory(name);
@@ -108,6 +109,7 @@ export const InventoryProvider = ({children}) => {
       registered,
       expiration,
       note,
+      price,
       foodCategory,
     };
     persist(prev => ({
@@ -119,7 +121,7 @@ export const InventoryProvider = ({children}) => {
   const updateItem = useCallback((
     oldCategory,
     index,
-    {location, quantity, unit, registered, expiration, note},
+    {location, quantity, unit, registered, expiration, note, price},
   ) => {
     persist(prev => {
       const item = prev[oldCategory][index];
@@ -130,6 +132,7 @@ export const InventoryProvider = ({children}) => {
         registered,
         expiration,
         note,
+        price,
       };
       const newCategory = location;
       if (newCategory === oldCategory) {

--- a/MiAppNevera/src/screens/CategoryScreen.js
+++ b/MiAppNevera/src/screens/CategoryScreen.js
@@ -3,17 +3,31 @@ import { Button, Image, ScrollView, Text, TextInput, View } from 'react-native';
 import { useInventory } from '../context/InventoryContext';
 import FoodPickerModal from '../components/FoodPickerModal';
 import { useCategories } from '../context/CategoriesContext';
+import { getFoodInfo } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function CategoryScreen({ route }) {
   const { category } = route.params;
   const { inventory, addItem, updateQuantity, removeItem } = useInventory();
   const { categories } = useCategories();
+  // subscribe to default food overrides so category list updates names
+  const { overrides } = useDefaultFoods();
   const [quantity, setQuantity] = useState(1);
   const [search, setSearch] = useState('');
   const [pickerVisible, setPickerVisible] = useState(false);
 
   const onSelectFood = name => {
-    addItem(category, name, quantity || 0);
+    const info = getFoodInfo(name);
+    addItem(
+      category,
+      name,
+      quantity || 0,
+      info?.defaultUnit || 'units',
+      '',
+      '',
+      '',
+      info?.defaultPrice || 0,
+    );
     setQuantity(1);
     setPickerVisible(false);
   };
@@ -45,41 +59,48 @@ export default function CategoryScreen({ route }) {
       />
       <ScrollView>
         {inventory[category]
-          ?.filter(item =>
-            item.name.toLowerCase().includes(search.toLowerCase()),
-          )
-          .map((item, idx) => (
-            <View
-              key={idx}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                padding: 5,
-                opacity: item.quantity === 0 ? 0.5 : 1,
-              }}
-            >
-              {item.icon && (
-                <Image
-                  source={item.icon}
-                  style={{ width: 32, height: 32, marginRight: 10 }}
+          ?.filter(item => {
+            const label = getFoodInfo(item.name)?.name || item.name;
+            return label.toLowerCase().includes(search.toLowerCase());
+          })
+          .map((item, idx) => {
+            const label = getFoodInfo(item.name)?.name || item.name;
+            return (
+              <View
+                key={idx}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  padding: 5,
+                  opacity: item.quantity === 0 ? 0.5 : 1,
+                }}
+              >
+                {item.icon && (
+                  <Image
+                    source={item.icon}
+                    style={{ width: 32, height: 32, marginRight: 10 }}
+                  />
+                )}
+                <Text style={{ flex: 1 }}>{label}</Text>
+                <Button
+                  title="-"
+                  onPress={() => updateQuantity(category, idx, -1)}
                 />
-              )}
-              <Text style={{ flex: 1 }}>{item.name}</Text>
-              <Button
-                title="-"
-                onPress={() => updateQuantity(category, idx, -1)}
-              />
-              <Text style={{ marginHorizontal: 10 }}>{item.quantity}</Text>
-              <Button
-                title="+"
-                onPress={() => updateQuantity(category, idx, 1)}
-              />
-              <Button
-                title="Eliminar"
-                onPress={() => removeItem(category, idx)}
-              />
-            </View>
-          ))}
+                <Text style={{ marginHorizontal: 10 }}>{item.quantity}</Text>
+                {item.price > 0 && (
+                  <Text style={{ marginRight: 10, fontWeight: '700' }}>{`S/${(item.price * item.quantity).toFixed(2)}`}</Text>
+                )}
+                <Button
+                  title="+"
+                  onPress={() => updateQuantity(category, idx, 1)}
+                />
+                <Button
+                  title="Eliminar"
+                  onPress={() => removeItem(category, idx)}
+                />
+              </View>
+            );
+          })}
       </ScrollView>
     </View>
   );

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -30,6 +30,7 @@ import { useTheme } from '../context/ThemeContext';
 import { useSavedLists } from '../context/SavedListsContext';
 import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import CostPieChart from '../components/CostPieChart';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
@@ -59,6 +60,8 @@ export default function ShoppingListScreen() {
   const { getLabel } = useUnits();
   const { locations } = useLocations();
   const { categories } = useCategories();
+  // subscribe to default food overrides so shopping names update after refresh
+  const { overrides } = useDefaultFoods();
 
   const [pickerVisible, setPickerVisible] = useState(false);
   const [addVisible, setAddVisible] = useState(false);
@@ -340,6 +343,7 @@ export default function ShoppingListScreen() {
                 {items.map(({ item, index }) => {
                   const isSel = selectMode && selected.includes(index);
                   const purchased = !!item.purchased;
+                  const label = getFoodInfo(item.name)?.name || item.name;
                   return (
                     <TouchableOpacity
                       key={index}
@@ -376,7 +380,7 @@ export default function ShoppingListScreen() {
                             ]}
                             numberOfLines={2}
                           >
-                            {item.name} - {item.quantity} {getLabel(item.quantity, item.unit)}
+                            {label} - {item.quantity} {getLabel(item.quantity, item.unit)}
                           </Text>
                         </View>
                         {item.totalPrice > 0 && (


### PR DESCRIPTION
## Summary
- support unit prices when adding or editing inventory items
- persist price field in inventory context and batch addition flows
- compute and display total cost per inventory entry based on quantity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a2d37f608324895c0ca2eac2e4bd