### PR TITLE
Display total price for inventory items and canonical food names

### DIFF
--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -39,7 +39,10 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const [regDate, setRegDate] = useState(today);
   const [expDate, setExpDate] = useState('');
   const [note, setNote] = useState('');
-  const [price, setPrice] = useState('');
+  const [unitPrice, setUnitPrice] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [unitPriceText, setUnitPriceText] = useState('');
+  const [totalPriceText, setTotalPriceText] = useState('');
   const [label, setLabel] = useState(foodName);
   const { addItem: addShoppingItem } = useShopping();
 
@@ -56,21 +59,26 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
     if (visible) {
       setLocation(initialLocation);
       setQuantity(1);
-        const info = getFoodInfo(foodName);
-        setUnit(info?.defaultUnit || units[0]?.key || 'units');
-        setRegDate(today);
-        if (info?.expirationDays != null) {
-          const d = new Date();
-          d.setDate(d.getDate() + info.expirationDays);
-          setExpDate(d.toISOString().split('T')[0]);
-        } else {
-          setExpDate('');
-        }
-        setNote('');
-        setLabel(info?.name || foodName);
-        setPrice(info?.defaultPrice != null ? String(info.defaultPrice) : '');
+      const info = getFoodInfo(foodName);
+      setUnit(info?.defaultUnit || units[0]?.key || 'units');
+      setRegDate(today);
+      if (info?.expirationDays != null) {
+        const d = new Date();
+        d.setDate(d.getDate() + info.expirationDays);
+        setExpDate(d.toISOString().split('T')[0]);
+      } else {
+        setExpDate('');
       }
-    }, [visible, initialLocation, today, units, locations, foodName, overrides]);
+      setNote('');
+      setLabel(info?.name || foodName);
+      const defaultPrice = info?.defaultPrice || 0;
+      setUnitPrice(defaultPrice);
+      setUnitPriceText(defaultPrice ? String(defaultPrice) : '');
+      const tot = defaultPrice * 1;
+      setTotalPrice(tot);
+      setTotalPriceText(tot ? tot.toFixed(2) : '');
+    }
+  }, [visible, initialLocation, today, units, locations, foodName, overrides]);
 
   const g = gradientForKey(themeName, foodName || 'item');
 
@@ -85,7 +93,13 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </TouchableOpacity>
             <TouchableOpacity
               onPress={() => {
-                addShoppingItem(foodName, quantity || 0, unit);
+                addShoppingItem(
+                  foodName,
+                  quantity || 0,
+                  unit,
+                  unitPrice || 0,
+                  totalPrice || 0,
+                );
                 Alert.alert('Añadido', `${foodName} añadido a la lista de compras`);
               }}
               style={styles.iconBtn}
@@ -130,7 +144,22 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             <Text style={styles.labelBold}>Cantidad</Text>
             <View style={styles.qtyRow}>
               <TouchableOpacity
-                onPress={() => { setQuantity(q => Math.max(0, (q || 0) - 1)); bumpQty(); }}
+                onPress={() => {
+                  setQuantity(q => {
+                    const next = Math.max(0, (q || 0) - 1);
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = next ? totalPrice / next : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
+                  bumpQty();
+                }}
                 style={styles.qtyBtn}
               >
                 <Text style={styles.qtyBtnText}>−</Text>
@@ -143,13 +172,38 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
                   value={String(quantity)}
                   onChangeText={(t) => {
                     const v = parseFloat(t.replace(/[^0-9.]/g, ''));
-                    setQuantity(Number.isFinite(v) ? v : 0);
+                    const q = Number.isFinite(v) ? v : 0;
+                    setQuantity(q);
+                    if (unitPrice) {
+                      const tot = unitPrice * q;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = q ? totalPrice / q : 0;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
                   }}
                 />
               </Animated.View>
 
               <TouchableOpacity
-                onPress={() => { setQuantity(q => (q || 0) + 1); bumpQty(); }}
+                onPress={() => {
+                  setQuantity(q => {
+                    const next = (q || 0) + 1;
+                    if (unitPrice) {
+                      const tot = unitPrice * next;
+                      setTotalPrice(tot);
+                      setTotalPriceText(tot ? tot.toFixed(2) : '');
+                    } else if (totalPrice) {
+                      const u = totalPrice / next;
+                      setUnitPrice(u);
+                      setUnitPriceText(u ? u.toFixed(2) : '');
+                    }
+                    return next;
+                  });
+                  bumpQty();
+                }}
                 style={styles.qtyBtn}
               >
                 <Text style={styles.qtyBtnText}>＋</Text>
@@ -177,23 +231,56 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </View>
 
             {/* Precio */}
-            <Text style={styles.labelBold}>Precio unitario</Text>
-            <TextInput
-              style={styles.priceInput}
-              value={price}
-              onChangeText={t => {
-                let sanitized = t.replace(/[^0-9.]/g, '');
-                const parts = sanitized.split('.');
-                if (parts.length > 2) {
-                  sanitized = parts[0] + '.' + parts.slice(1).join('');
-                }
-                setPrice(sanitized);
-              }}
-              keyboardType="decimal-pad"
-              inputMode="decimal"
-              placeholder="Opcional"
-              placeholderTextColor={palette.textDim}
-            />
+            <Text style={styles.labelBold}>Precio</Text>
+            <View style={styles.priceRow}>
+              <TextInput
+                style={[styles.priceInput, { marginRight: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo unitario"
+                placeholderTextColor={palette.textDim}
+                value={unitPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setUnitPriceText(sanitized);
+                  const u = parseFloat(sanitized);
+                  if (!isNaN(u)) {
+                    setUnitPrice(u);
+                    const tot = u * (quantity || 0);
+                    setTotalPrice(tot);
+                    setTotalPriceText(tot ? tot.toFixed(2) : '');
+                  } else {
+                    setUnitPrice(0);
+                    setTotalPrice(0);
+                    setTotalPriceText('');
+                  }
+                }}
+              />
+              <Text style={styles.priceDivider}>/</Text>
+              <TextInput
+                style={[styles.priceInput, { marginLeft: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo total"
+                placeholderTextColor={palette.textDim}
+                value={totalPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setTotalPriceText(sanitized);
+                  const tot = parseFloat(sanitized);
+                  if (!isNaN(tot)) {
+                    setTotalPrice(tot);
+                    const u = (quantity || 0) ? tot / (quantity || 0) : 0;
+                    setUnitPrice(u);
+                    setUnitPriceText(u ? u.toFixed(2) : '');
+                  } else {
+                    setTotalPrice(0);
+                    setUnitPrice(0);
+                    setUnitPriceText('');
+                  }
+                }}
+              />
+            </View>
 
             {/* Fechas (con inputs gris) */}
             <View style={{ marginTop: 6 }}>
@@ -237,7 +324,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
                 registered: regDate,
                 expiration: expDate,
                 note,
-                price: parseFloat(price) || 0,
+                price: unitPrice || 0,
               })
             }
             style={styles.saveFab}
@@ -352,16 +439,19 @@ const createStyles = (palette) => StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
   },
+  priceRow: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
   priceInput: {
+    flex: 1,
+    textAlign: 'center',
+    backgroundColor: palette.surface2,
     borderWidth: 1,
     borderColor: palette.border,
-    backgroundColor: palette.surface2,
-    color: palette.text,
     borderRadius: 10,
-    paddingHorizontal: 10,
     paddingVertical: 8,
-    marginBottom: 4,
+    paddingHorizontal: 10,
+    color: palette.text,
   },
+  priceDivider: { color: palette.text, paddingHorizontal: 4 },
 
   // Estilos sugeridos para DatePicker (si el componente los acepta)
   dateContainer: {

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -20,7 +20,7 @@ import {
   Platform,
 } from 'react-native';
 import FoodPickerModal from './FoodPickerModal';
-import { getFoodIcon } from '../foodIcons';
+import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '../context/ThemeContext';
@@ -300,7 +300,9 @@ const save = () => {
                   onPress={() => openUnitPicker(idx)}
                 >
                   <Text style={styles.ingText}>
-                    {`${ing.quantity} ${getLabel(ing.quantity, ing.unit)} de ${ing.name}`}
+                    {`${ing.quantity} ${getLabel(ing.quantity, ing.unit)} de ${
+                      getFoodInfo(ing.name)?.name || ing.name
+                    }`}
                   </Text>
                 </TouchableOpacity>
                 <TouchableOpacity

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -27,6 +27,9 @@ import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
+import { getFoodInfo, getFoodCategory } from '../foodIcons';
+import { useDefaultFoods } from '../context/DefaultFoodsContext';
+import { useCategories } from '../context/CategoriesContext';
 
 export default function EditItemModal({ visible, item, onSave, onDelete, onClose }) {
   const palette = useTheme();
@@ -35,6 +38,8 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   const { addItem: addShoppingItem } = useShopping();
   const { units } = useUnits();
   const { locations } = useLocations();
+  const { overrides } = useDefaultFoods();
+  const { categories } = useCategories();
 
   const [location, setLocation] = useState(locations[0]?.key || 'fridge');
   const [quantity, setQuantity] = useState(1);
@@ -42,7 +47,12 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   const [regDate, setRegDate] = useState('');
   const [expDate, setExpDate] = useState('');
   const [note, setNote] = useState('');
-  const [price, setPrice] = useState('');
+  const [unitPrice, setUnitPrice] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [unitPriceText, setUnitPriceText] = useState('');
+  const [totalPriceText, setTotalPriceText] = useState('');
+  const [label, setLabel] = useState('');
+  const [foodCategory, setFoodCategory] = useState('');
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [shoppingVisible, setShoppingVisible] = useState(false);
 
@@ -63,9 +73,18 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
       setRegDate(item.registered || '');
       setExpDate(item.expiration || '');
       setNote(item.note || '');
-      setPrice(item.price != null ? String(item.price) : '');
+      const info = getFoodInfo(item.name);
+      setLabel(info?.name || item.name || '');
+      const catKey = getFoodCategory(item.name) || item.foodCategory || '';
+      setFoodCategory(categories[catKey]?.name || '');
+      const u = item.price || 0;
+      setUnitPrice(u);
+      setUnitPriceText(u ? String(u) : '');
+      const tot = u * (item.quantity ?? 0);
+      setTotalPrice(tot);
+      setTotalPriceText(tot ? tot.toFixed(2) : '');
     }
-  }, [visible, item, units, locations]);
+  }, [visible, item, units, locations, overrides, categories]);
 
   const g = gradientForKey(themeName, item?.name || 'item');
 
@@ -77,7 +96,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
       registered: regDate,
       expiration: expDate,
       note,
-      price: parseFloat(price) || 0,
+      price: unitPrice || 0,
     });
   };
 
@@ -110,9 +129,9 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                 {item?.icon && <Image source={item.icon} style={{ width: 64, height: 64 }} resizeMode="contain" />}
               </View>
               <View style={{ flex: 1 }}>
-                <Text style={styles.foodName} numberOfLines={2}>{item?.name || 'Alimento'}</Text>
-                {!!item?.foodCategory && (
-                  <Text style={{ color: palette.textDim, fontSize: 12 }} numberOfLines={1}>{item.foodCategory}</Text>
+                <Text style={styles.foodName} numberOfLines={2}>{label || 'Alimento'}</Text>
+                {!!foodCategory && (
+                  <Text style={{ color: palette.textDim, fontSize: 12 }} numberOfLines={1}>{foodCategory}</Text>
                 )}
               </View>
             </LinearGradient>
@@ -146,7 +165,22 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             <Text style={styles.labelBold}>Cantidad</Text>
               <View style={styles.qtyRow}>
                 <TouchableOpacity
-                  onPress={() => { setQuantity(q => Math.max(0, (q || 0) - 1)); bumpQty(); }}
+                  onPress={() => {
+                    setQuantity(q => {
+                      const next = Math.max(0, (q || 0) - 1);
+                      if (unitPrice) {
+                        const tot = unitPrice * next;
+                        setTotalPrice(tot);
+                        setTotalPriceText(tot ? tot.toFixed(2) : '');
+                      } else if (totalPrice) {
+                        const u = next ? totalPrice / next : 0;
+                        setUnitPrice(u);
+                        setUnitPriceText(u ? u.toFixed(2) : '');
+                      }
+                      return next;
+                    });
+                    bumpQty();
+                  }}
                   style={styles.qtyBtn}
                 >
                   <Text style={styles.qtyBtnText}>−</Text>
@@ -159,13 +193,38 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                     value={String(quantity)}
                     onChangeText={(t) => {
                       const v = parseFloat(t.replace(/[^0-9.]/g, ''));
-                      setQuantity(Number.isFinite(v) ? v : 0);
+                      const q = Number.isFinite(v) ? v : 0;
+                      setQuantity(q);
+                      if (unitPrice) {
+                        const tot = unitPrice * q;
+                        setTotalPrice(tot);
+                        setTotalPriceText(tot ? tot.toFixed(2) : '');
+                      } else if (totalPrice) {
+                        const u = q ? totalPrice / q : 0;
+                        setUnitPrice(u);
+                        setUnitPriceText(u ? u.toFixed(2) : '');
+                      }
                     }}
                   />
                 </Animated.View>
 
                 <TouchableOpacity
-                  onPress={() => { setQuantity(q => (q || 0) + 1); bumpQty(); }}
+                  onPress={() => {
+                    setQuantity(q => {
+                      const next = (q || 0) + 1;
+                      if (unitPrice) {
+                        const tot = unitPrice * next;
+                        setTotalPrice(tot);
+                        setTotalPriceText(tot ? tot.toFixed(2) : '');
+                      } else if (totalPrice) {
+                        const u = totalPrice / next;
+                        setUnitPrice(u);
+                        setUnitPriceText(u ? u.toFixed(2) : '');
+                      }
+                      return next;
+                    });
+                    bumpQty();
+                  }}
                   style={styles.qtyBtn}
                 >
                   <Text style={styles.qtyBtnText}>＋</Text>
@@ -193,23 +252,56 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             </View>
 
             {/* Precio */}
-            <Text style={styles.labelBold}>Precio unitario</Text>
-            <TextInput
-              style={styles.priceInput}
-              value={price}
-              onChangeText={t => {
-                let sanitized = t.replace(/[^0-9.]/g, '');
-                const parts = sanitized.split('.');
-                if (parts.length > 2) {
-                  sanitized = parts[0] + '.' + parts.slice(1).join('');
-                }
-                setPrice(sanitized);
-              }}
-              keyboardType="decimal-pad"
-              inputMode="decimal"
-              placeholder="Opcional"
-              placeholderTextColor={palette.textDim}
-            />
+            <Text style={styles.labelBold}>Precio</Text>
+            <View style={styles.priceRow}>
+              <TextInput
+                style={[styles.priceInput, { marginRight: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo unitario"
+                placeholderTextColor={palette.textDim}
+                value={unitPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setUnitPriceText(sanitized);
+                  const u = parseFloat(sanitized);
+                  if (!isNaN(u)) {
+                    setUnitPrice(u);
+                    const tot = u * (quantity || 0);
+                    setTotalPrice(tot);
+                    setTotalPriceText(tot ? tot.toFixed(2) : '');
+                  } else {
+                    setUnitPrice(0);
+                    setTotalPrice(0);
+                    setTotalPriceText('');
+                  }
+                }}
+              />
+              <Text style={styles.priceDivider}>/</Text>
+              <TextInput
+                style={[styles.priceInput, { marginLeft: 4 }]}
+                keyboardType="decimal-pad"
+                inputMode="decimal"
+                placeholder="Costo total"
+                placeholderTextColor={palette.textDim}
+                value={totalPriceText}
+                onChangeText={(t) => {
+                  const sanitized = t.replace(/[^0-9.]/g, '');
+                  setTotalPriceText(sanitized);
+                  const tot = parseFloat(sanitized);
+                  if (!isNaN(tot)) {
+                    setTotalPrice(tot);
+                    const u = (quantity || 0) ? tot / (quantity || 0) : 0;
+                    setUnitPrice(u);
+                    setUnitPriceText(u ? u.toFixed(2) : '');
+                  } else {
+                    setTotalPrice(0);
+                    setUnitPrice(0);
+                    setUnitPriceText('');
+                  }
+                }}
+              />
+            </View>
 
             {/* Fechas (inputs gris) */}
             <View style={{ marginTop: 6 }}>
@@ -256,8 +348,10 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
         visible={shoppingVisible}
         foodName={item?.name}
         foodIcon={item?.icon}
+        initialQuantity={item?.quantity}
         initialUnit={item?.unit}
         initialUnitPrice={item?.price}
+        initialTotalPrice={item?.price ? item.price * (item.quantity ?? 0) : 0}
         onSave={({ quantity: q, unit: u, unitPrice, totalPrice }) => {
           addShoppingItem(item?.name, q || 0, u, unitPrice, totalPrice);
           Alert.alert('Añadido', `${item?.name} añadido a la lista de compras`);
@@ -395,16 +489,19 @@ const createStyles = (palette) => StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
   },
+  priceRow: { flexDirection: 'row', alignItems: 'center', marginTop: 6 },
   priceInput: {
+    flex: 1,
+    textAlign: 'center',
+    backgroundColor: palette.surface2,
     borderWidth: 1,
     borderColor: palette.border,
-    backgroundColor: palette.surface2,
-    color: palette.text,
     borderRadius: 10,
-    paddingHorizontal: 10,
     paddingVertical: 8,
-    marginBottom: 4,
+    paddingHorizontal: 10,
+    color: palette.text,
   },
+  priceDivider: { color: palette.text, paddingHorizontal: 4 },
 
   // Estilos para DatePicker (gris, consistente)
   dateContainer: {

--- a/MiAppNevera/src/foodIcons.js
+++ b/MiAppNevera/src/foodIcons.js
@@ -1116,6 +1116,7 @@ export const categories = {
 
 let customFoodsMap = {};
 let defaultOverridesMap = {};
+let overrideNameMap = {};
 
 export function setCustomFoodsMap(list) {
   customFoodsMap = {};
@@ -1137,6 +1138,7 @@ export function setCustomFoodsMap(list) {
 
 export function setDefaultFoodsMap(list) {
   defaultOverridesMap = {};
+  overrideNameMap = {};
   if (Array.isArray(list)) {
     list.forEach(item => {
       if (!item || !item.key) return;
@@ -1148,6 +1150,9 @@ export function setDefaultFoodsMap(list) {
         defaultPrice:
           item.defaultPrice != null ? Number(item.defaultPrice) : null,
       };
+      if (item.name) {
+        overrideNameMap[normalizeFoodName(item.name)] = item.key;
+      }
     });
   }
 }
@@ -1157,7 +1162,8 @@ export function normalizeFoodName(name) {
 }
 
 export function getFoodInfo(name) {
-  const key = normalizeFoodName(name);
+  const norm = normalizeFoodName(name);
+  const key = overrideNameMap[norm] || norm;
   if (customFoodsMap[key]) {
     const info = customFoodsMap[key];
     const icon = info.icon
@@ -1180,11 +1186,12 @@ export function getFoodIcon(name) {
 
 export function getFoodCategory(name) {
   const normalized = normalizeFoodName(name);
-  if (customFoodsMap[normalized]) {
-    return customFoodsMap[normalized].category || null;
+  const key = overrideNameMap[normalized] || normalized;
+  if (customFoodsMap[key]) {
+    return customFoodsMap[key].category || null;
   }
   for (const [cat, data] of Object.entries(categories)) {
-    if (data.items.includes(normalized)) {
+    if (data.items.includes(key)) {
       return cat;
     }
   }

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -357,7 +357,13 @@ export default function InventoryScreen({ navigation }) {
   };
 
   const handleAddToShopping = () => {
-    const items = getSelectedFullItems().map(it => ({ name: it.name, quantity: it.quantity, unit: it.unit }));
+    const items = getSelectedFullItems().map(it => ({
+      name: it.name,
+      quantity: it.quantity,
+      unit: it.unit,
+      unitPrice: it.price || 0,
+      totalPrice: (it.price || 0) * (it.quantity || 0),
+    }));
     addShoppingItems(items);
     clearSelection();
     setShoppingVisible(false);
@@ -491,9 +497,9 @@ export default function InventoryScreen({ navigation }) {
                                 <TouchableOpacity onPress={() => updateQuantity(item.location, item.index, -1)} style={{ backgroundColor: palette.surface3, borderWidth: 1, borderColor: palette.border, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 10, marginHorizontal: 2 }}>
                                   <Text style={{ color: palette.accent, fontSize: 16 }}>←</Text>
                                 </TouchableOpacity>
-                                <View style={{ width: 80, alignItems: 'center' }}>
+                                <View style={{ alignItems: 'center' }}>
                                   <Text style={{ color: palette.textDim, fontSize: 12 }}>
-                                    {item.quantity} {getLabel(item.quantity, item.unit)}
+                                    {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - S/${(item.price * item.quantity).toFixed(2)}`}
                                   </Text>
                                 </View>
                                 <TouchableOpacity onPress={() => updateQuantity(item.location, item.index, 1)} style={{ backgroundColor: palette.surface3, borderWidth: 1, borderColor: palette.border, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 10, marginHorizontal: 2 }}>
@@ -537,7 +543,7 @@ export default function InventoryScreen({ navigation }) {
                                 {label}
                               </Text>
                               <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
-                                {item.quantity} {getLabel(item.quantity, item.unit)}
+                                {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - S/${(item.price * item.quantity).toFixed(2)}`}
                               </Text>
                             </LinearGradient>
                           </View>

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -16,7 +16,7 @@ import { useRecipes } from '../context/RecipeContext';
 import { useInventory } from '../context/InventoryContext';
 import { useShopping } from '../context/ShoppingContext';
 import AddRecipeModal from '../components/AddRecipeModal';
-import { getFoodIcon, getFoodCategory } from '../foodIcons';
+import { getFoodIcon, getFoodCategory, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
@@ -126,7 +126,9 @@ export default function RecipeDetailScreen({ route }) {
                 <View key={idx} style={styles.ingRow}>
                   {icon && <Image source={icon} style={styles.ingIcon} />}
                   <Text style={styles.ingText}>
-                    {ing.quantity} {getLabel(ing.quantity, ing.unit)} de {ing.name}
+                    {ing.quantity} {getLabel(ing.quantity, ing.unit)} de {
+                      getFoodInfo(ing.name)?.name || ing.name
+                    }
                   </Text>
                 </View>
               );
@@ -181,7 +183,9 @@ export default function RecipeDetailScreen({ route }) {
                           <Image source={ing.icon || getFoodIcon(ing.name)} style={styles.missIcon} />
                         )}
                         <Text style={styles.missText}>
-                          {ing.quantity} {getLabel(ing.quantity, ing.unit)} de {ing.name}
+                          {ing.quantity} {getLabel(ing.quantity, ing.unit)} de {
+                            getFoodInfo(ing.name)?.name || ing.name
+                          }
                         </Text>
                       </View>
                     ))}


### PR DESCRIPTION
## Summary
- Include unit and total cost when sending new items from inventory to shopping list
- Pre-populate shopping modal with current quantity, unit, and price for single inventory items
- Forward inventory price data during multi-select transfers to the shopping list
- Show canonical ingredient names in recipe creation and detail screens
- Use formatted category names in the edit item modal

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8b5a259808324992e0623dd1a49c8