### PR TITLE
feat: improve default food management layout

### DIFF
--- a/MiAppNevera/src/components/EditDefaultFoodModal.js
+++ b/MiAppNevera/src/components/EditDefaultFoodModal.js
@@ -8,10 +8,11 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Image,
 } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { useUnits } from '../context/UnitsContext';
-import { getFoodInfo } from '../foodIcons';
+import { getFoodInfo, getFoodIcon } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
 
 export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
@@ -50,6 +51,9 @@ export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
         <View style={styles.sheet}>
           <Text style={styles.title}>Editar alimento</Text>
           <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}>
+            {foodKey && (
+              <Image source={getFoodIcon(foodKey)} style={styles.editIcon} />
+            )}
             <Text style={styles.label}>Nombre</Text>
             <TextInput value={name} onChangeText={setName} style={styles.input} />
             <Text style={styles.label}>Días de caducidad</Text>
@@ -172,4 +176,10 @@ const createStyles = palette =>
     btnTxt: { color: palette.text },
     btnPrimary: { backgroundColor: palette.accent, borderColor: '#e2b06c' },
     btnPrimaryTxt: { color: '#1b1d22', fontWeight: '700' },
+    editIcon: {
+      width: 80,
+      height: 80,
+      alignSelf: 'center',
+      marginBottom: 16,
+    },
   });

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -62,7 +62,9 @@ export default function FoodPickerModal({
   // === Estados para "ocultar" scrollbars sin mover layout (web) ===
   const [hoverCat, setHoverCat] = useState(false);
   const [hoverGrid, setHoverGrid] = useState(false);
-  const [hoverManage, setHoverManage] = useState(false);
+  const [hoverManageCat, setHoverManageCat] = useState(false);
+  const [hoverManageGrid, setHoverManageGrid] = useState(false);
+  const [manageCategory, setManageCategory] = useState(baseCategoryNames[0] || '');
   const hiddenBg = themeName === 'dark' ? '#181b22' : '#d0d0d0';
 
   useEffect(() => {
@@ -80,6 +82,12 @@ export default function FoodPickerModal({
       setSearchVisible(false);
     }
   }, [visible]);
+
+  useEffect(() => {
+    if (manageVisible && baseCategoryNames.length) {
+      setManageCategory(baseCategoryNames[0]);
+    }
+  }, [manageVisible]);
 
   useEffect(() => {
     AsyncStorage.getItem('hiddenFoods').then(data => {
@@ -330,84 +338,116 @@ export default function FoodPickerModal({
         </Modal>
       )}
 
-      {/* Administrar predeterminados */}
-      <Modal visible={manageVisible} animationType="slide" transparent>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.sheet, { padding: 12 }]}>
-            <View style={{ borderWidth: 1, borderColor: palette.border, backgroundColor: palette.surface2, padding: 10, marginBottom: 10, borderRadius: 10 }}>
-              <Text style={{ textAlign: 'center', color: palette.text }}>
-                Lista completa de todos los alimentos predeterminados
-              </Text>
-              <Text style={{ textAlign: 'center', color: palette.textDim }}>
-                Los alimentos sombreados no se mostrarán en la lista de agregar
-              </Text>
-              <Text style={{ textAlign: 'center', color: palette.textDim }}>
-                Mantener presionado el alimento para editar más detalles
-              </Text>
-            </View>
-            <ScrollView
-              onMouseEnter={() => setHoverManage(true)}
-              onMouseLeave={() => setHoverManage(false)}
-              style={[
-                { flex: 1 },
-                Platform.OS === 'web' ? webScrollBase : null,
-                Platform.OS === 'web' ? (hoverManage ? webScrollVisible : webScrollHidden) : null,
-              ]}
-              contentContainerStyle={{ paddingBottom: 10 }}
-              showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
-            >
-              {baseCategoryNames.map(cat => (
-                <View key={cat} style={{ marginBottom: 14 }}>
-                  <Text style={{ fontSize: 16, fontWeight: '700', marginBottom: 6, color: palette.accent }}>
-                    {baseCategories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1)}
-                  </Text>
-                  <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-                    {baseCategories[cat].items.map(name => {
-                      const hidden = hiddenFoods.includes(name);
-                      return (
-                        <Pressable
-                          key={name}
-                          style={{ width: '25%', padding: 6, alignItems: 'center' }}
-                          onPress={() =>
-                            setHiddenFoods(prev =>
-                              prev.includes(name)
-                                ? prev.filter(n => n !== name)
-                                : [...prev, name],
-                            )
-                          }
-                          onLongPress={() => setEditKey(name)}
+        {/* Administrar predeterminados */}
+        <Modal visible={manageVisible} animationType="slide" transparent>
+          <View style={styles.modalBackdrop}>
+            <View style={[styles.sheet, { padding: 12 }]}>
+              <View style={{ borderWidth: 1, borderColor: palette.border, backgroundColor: palette.surface2, padding: 10, marginBottom: 10, borderRadius: 10 }}>
+                <Text style={{ textAlign: 'center', color: palette.text }}>
+                  Lista completa de todos los alimentos predeterminados
+                </Text>
+                <Text style={{ textAlign: 'center', color: palette.textDim }}>
+                  Los alimentos sombreados no se mostrarán en la lista de agregar
+                </Text>
+                <Text style={{ textAlign: 'center', color: palette.textDim }}>
+                  Mantener presionado el alimento para editar más detalles
+                </Text>
+              </View>
+              <View style={styles.catBar}>
+                <ScrollView
+                  horizontal
+                  contentContainerStyle={styles.catRow}
+                  onMouseEnter={() => setHoverManageCat(true)}
+                  onMouseLeave={() => setHoverManageCat(false)}
+                  showsHorizontalScrollIndicator={Platform.OS === 'web' ? true : false}
+                  style={[
+                    Platform.OS === 'web' ? webScrollBase : null,
+                    Platform.OS === 'web' ? (hoverManageCat ? webScrollVisible : webScrollHidden) : null,
+                  ]}
+                >
+                  {baseCategoryNames.map(cat => {
+                    const active = manageCategory === cat;
+                    const g = gradientForKey(themeName, cat);
+                    return (
+                      <Pressable key={cat} onPress={() => setManageCategory(cat)} style={{ paddingHorizontal: 6 }}>
+                        <View style={[styles.catCard, active && styles.catCardActive, { width: catCardSize, height: catCardSize }]}>
+                          <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={[styles.catCardGrad, { flex: 1 }]}>
+                            <View style={styles.catIconBox}>
+                              {baseCategories[cat]?.icon && (
+                                <Image source={baseCategories[cat].icon} style={{ width: 44, height: 44 }} resizeMode="contain" />
+                              )}
+                            </View>
+                            <Text style={[styles.catTitle, active && styles.catTitleActive]} numberOfLines={1}>
+                              {baseCategories[cat]?.name || cat}
+                            </Text>
+                          </LinearGradient>
+                        </View>
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+              <ScrollView
+                onMouseEnter={() => setHoverManageGrid(true)}
+                onMouseLeave={() => setHoverManageGrid(false)}
+                style={[
+                  { flex: 1 },
+                  Platform.OS === 'web' ? webScrollBase : null,
+                  Platform.OS === 'web' ? (hoverManageGrid ? webScrollVisible : webScrollHidden) : null,
+                ]}
+                contentContainerStyle={{ flexDirection: 'row', flexWrap: 'wrap', padding: 8 }}
+                showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
+              >
+                {(baseCategories[manageCategory]?.items || []).map(name => {
+                  const hidden = hiddenFoods.includes(name);
+                  const g = gradientForKey(themeName, name);
+                  return (
+                    <Pressable
+                      key={name}
+                      style={{ width: '25%', padding: 6 }}
+                      onPress={() =>
+                        setHiddenFoods(prev =>
+                          prev.includes(name)
+                            ? prev.filter(n => n !== name)
+                            : [...prev, name],
+                        )
+                      }
+                      onLongPress={() => setEditKey(name)}
+                    >
+                      <View style={styles.card}>
+                        <LinearGradient
+                          colors={g.colors}
+                          locations={g.locations}
+                          start={g.start}
+                          end={g.end}
+                          style={styles.cardGrad}
                         >
-                          <View
-                            style={{
-                              borderRadius: 12,
-                              padding: 6,
-                              backgroundColor: hidden ? hiddenBg : palette.surface2,
-                              borderWidth: 1,
-                              borderColor: palette.border,
-                            }}
-                          >
-                            <Image
-                              source={foodIcons[name]}
-                              style={{ width: 44, height: 44, opacity: hidden ? 0.5 : 1 }}
-                              resizeMode="contain"
-                            />
+                          <View style={styles.foodIconBox}>
+                            <Image source={foodIcons[name]} style={{ width: 44, height: 44 }} resizeMode="contain" />
                           </View>
-                          <Text style={{ textAlign: 'center', marginTop: 5, color: palette.text }} numberOfLines={2}>
+                          <Text numberOfLines={2} style={styles.foodLabel}>
                             {getFoodInfo(name)?.name || name}
                           </Text>
-                        </Pressable>
-                      );
-                    })}
-                  </View>
-                </View>
-              ))}
-            </ScrollView>
-            <TouchableOpacity onPress={() => setManageVisible(false)} style={[styles.bottomBtn, { alignSelf: 'center', backgroundColor: palette.accent, marginBottom: 10 }]}>
-              <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cerrar</Text>
-            </TouchableOpacity>
+                        </LinearGradient>
+                        {hidden && (
+                          <View
+                            style={[
+                              styles.hiddenOverlay,
+                              { backgroundColor: hiddenBg, opacity: 0.6 },
+                            ]}
+                          />
+                        )}
+                      </View>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+              <TouchableOpacity onPress={() => setManageVisible(false)} style={[styles.bottomBtn, { alignSelf: 'center', backgroundColor: palette.accent, marginBottom: 10 }]}>
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cerrar</Text>
+              </TouchableOpacity>
+            </View>
           </View>
-        </View>
-      </Modal>
+        </Modal>
 
       {/* Añadir personalizado */}
       <AddCustomFoodModal visible={addVisible} onClose={() => setAddVisible(false)} />
@@ -536,6 +576,10 @@ const createStyles = (palette) => StyleSheet.create({
     marginBottom: 6,
   },
   foodLabel: { textAlign: 'center', color: palette.accent, fontSize: 12, fontWeight: '400' },
+
+  hiddenOverlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
 
   bottomBar: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- add category tabs and grid view to manage default foods
- allow toggling default foods visibility with modern card layout
- darken hidden defaults and show icon when editing

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a8ca0bc834832497593b9fe34ae013