### PR TITLE
Restart on language change and translate inventory UI

### DIFF
--- a/MiAppNevera/src/context/LanguageContext.js
+++ b/MiAppNevera/src/context/LanguageContext.js
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+import * as Updates from 'expo-updates';
 import i18n from '../i18n';
 
 const LanguageContext = createContext({
@@ -26,12 +28,31 @@ export const LanguageProvider = ({ children }) => {
 
   useEffect(() => {
     i18n.locale = lang;
-    (async () => {
-      try { await AsyncStorage.setItem('lang', lang); } catch (e) { console.error('Failed to save language', e); }
-    })();
   }, [lang]);
 
-  const value = useMemo(() => ({ lang, setLang, t: (scope, options) => i18n.t(scope, options) }), [lang]);
+  const changeLang = async newLang => {
+    setLang(newLang);
+    i18n.locale = newLang;
+    try {
+      await AsyncStorage.setItem('lang', newLang);
+    } catch (e) {
+      console.error('Failed to save language', e);
+    }
+    if (Platform.OS === 'web') {
+      window.location.reload();
+    } else {
+      await Updates.reloadAsync();
+    }
+  };
+
+  const value = useMemo(
+      () => ({
+        lang,
+        setLang: changeLang,
+        t: (scope, options) => i18n.t(scope, { locale: lang, ...(options || {}) }),
+      }),
+      [lang],
+    );
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
 };
 

--- a/MiAppNevera/src/locales/en/system.json
+++ b/MiAppNevera/src/locales/en/system.json
@@ -32,6 +32,26 @@
     "english": "English"
   },
   "inventory": {
-    "settingsButton": "Settings"
+    "settingsButton": "Settings",
+    "empty": "{{location}} is empty",
+    "addFood": "Add food",
+    "intersection": "Intersection",
+    "groupBy": "Group by",
+    "group": {
+      "category": "Category",
+      "none": "No grouping",
+      "registered": "Date added"
+    },
+    "viewTitle": "View type",
+    "view": {
+      "list": "List",
+      "grid": "Grid"
+    },
+    "addToShoppingConfirm": "Add the following {{count}} items to the shopping list?",
+    "add": "Add",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "expiredLabel": "Exp.",
+    "dayPrefix": "D-"
   }
 }

--- a/MiAppNevera/src/locales/es/system.json
+++ b/MiAppNevera/src/locales/es/system.json
@@ -32,6 +32,26 @@
     "english": "Inglés"
   },
   "inventory": {
-    "settingsButton": "Ajustes"
+    "settingsButton": "Ajustes",
+    "empty": "Su {{location}} se encuentra vacío",
+    "addFood": "Añadir alimento",
+    "intersection": "Intersección",
+    "groupBy": "Agrupar por",
+    "group": {
+      "category": "Categoría",
+      "none": "Sin agrupación",
+      "registered": "Fecha de registro"
+    },
+    "viewTitle": "Tipo de vista",
+    "view": {
+      "list": "Lista",
+      "grid": "Cuadrícula"
+    },
+    "addToShoppingConfirm": "Añadir los siguientes {{count}} elementos a la lista de compras?",
+    "add": "Añadir",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "expiredLabel": "Venc.",
+    "dayPrefix": "D-"
   }
 }

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -33,11 +33,15 @@ import { gradientForKey } from '../theme/gradients';
 import { useLanguage } from '../context/LanguageContext';
 
 // ===== Helpers =====
-const getExpiryMeta = (palette, d) => {
+const getExpiryMeta = (palette, d, t) => {
   if (d === null || isNaN(d)) return null;
-  if (d <= 0)  return { bg: palette.danger, text: '#fff', label: 'Venc.' };
-  if (d <= 3)  return { bg: palette.warn,   text: '#1b1d22', label: `D-${d}` };
-  return        { bg: palette.accent, text: '#1b1d22', label: `D-${d}` };
+  if (d <= 0) return { bg: palette.danger, text: '#fff', label: t('system.inventory.expiredLabel') };
+  const prefix = t('system.inventory.dayPrefix');
+  return {
+    bg: d <= 3 ? palette.warn : palette.accent,
+    text: '#1b1d22',
+    label: `${prefix}${d}`,
+  };
 };
 
 const SELECTED_BORDER_WIDTH = 2;
@@ -441,10 +445,10 @@ export default function InventoryScreen({ navigation }) {
           {isEmpty ? (
             <View style={styles.emptyWrap}>
               <Text style={{ color: palette.textDim, marginBottom: 8 }}>
-                {`Su "${currentLoc?.name}" se encuentra vacío`}
+                {t('system.inventory.empty', { location: currentLoc?.name })}
               </Text>
               <TouchableOpacity onPress={() => setPickerVisible(true)} style={styles.emptyBtn}>
-                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Añadir alimento</Text>
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.inventory.addFood')}</Text>
               </TouchableOpacity>
             </View>
           ) : (
@@ -469,7 +473,7 @@ export default function InventoryScreen({ navigation }) {
                     const key = `${item.location}-${item.index}`;
                     const selected = selectedItems.some(it => it.key === key);
                     const daysLeft = item.expiration ? Math.ceil((new Date(item.expiration) - new Date()) / (1000 * 60 * 60 * 24)) : null;
-                    const meta = getExpiryMeta(palette, daysLeft);
+                    const meta = getExpiryMeta(palette, daysLeft, t);
                     const g = gradientForKey(themeName, item.name || key);
                     const label = getFoodInfo(item.name)?.name || item.name;
 
@@ -522,7 +526,7 @@ export default function InventoryScreen({ navigation }) {
                       const key = `${item.location}-${item.index}`;
                       const selected = selectedItems.some(it => it.key === key);
                       const daysLeft = item.expiration ? Math.ceil((new Date(item.expiration) - new Date()) / (1000 * 60 * 60 * 24)) : null;
-                      const meta = getExpiryMeta(palette, daysLeft);
+                      const meta = getExpiryMeta(palette, daysLeft, t);
                       const g = gradientForKey(themeName, item.name || key);
                       const label = getFoodInfo(item.name)?.name || item.name;
 
@@ -611,7 +615,7 @@ export default function InventoryScreen({ navigation }) {
             <Text style={{ fontSize: 16, color: palette.text }}>Seleccionar todo</Text>
           </TouchableOpacity>
           <TouchableOpacity style={{ backgroundColor: palette.surface3, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 6, margin: 4, borderWidth: 1, borderColor: palette.border }} onPress={selectIntersection}>
-            <Text style={{ fontSize: 16, color: palette.text }}>Intersección</Text>
+            <Text style={{ fontSize: 16, color: palette.text }}>{t('system.inventory.intersection')}</Text>
           </TouchableOpacity>
           <TouchableOpacity style={{ backgroundColor: palette.accent, paddingVertical: 8, paddingHorizontal: 12, borderRadius: 6, margin: 4 }} onPress={() => setTransferType('move')}>
             <Text style={{ color: '#1b1d22', fontSize: 16 }}>🔀</Text>
@@ -657,8 +661,8 @@ export default function InventoryScreen({ navigation }) {
                     <Text style={{ marginLeft: 6, color: palette.text }}>{opt.label}</Text>
                   </TouchableOpacity>
                 ))}
-                <Text style={{ fontSize: 18, fontWeight: 'bold', marginVertical: 10, color: palette.text }}>Agrupar por</Text>
-                {[{ key: 'category', label: 'Categoría' },{ key: 'none', label: 'Sin agrupación' },{ key: 'registered', label: 'Fecha de registro' }].map(opt => (
+                <Text style={{ fontSize: 18, fontWeight: 'bold', marginVertical: 10, color: palette.text }}>{t('system.inventory.groupBy')}</Text>
+                {[{ key: 'category', label: t('system.inventory.group.category') },{ key: 'none', label: t('system.inventory.group.none') },{ key: 'registered', label: t('system.inventory.group.registered') }].map(opt => (
                   <TouchableOpacity key={opt.key} style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }} onPress={() => setTempGroupBy(opt.key)}>
                     <Text style={{ color: palette.text }}>{tempGroupBy === opt.key ? '◉' : '○'}</Text>
                     <Text style={{ marginLeft: 6, color: palette.text }}>{opt.label}</Text>
@@ -666,10 +670,10 @@ export default function InventoryScreen({ navigation }) {
                 ))}
                 <View style={{ flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10 }}>
                   <TouchableOpacity onPress={() => setSortVisible(false)} style={{ padding: 10, marginRight: 10 }}>
-                    <Text style={{ color: palette.accent }}>Cancelar</Text>
+                    <Text style={{ color: palette.accent }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={() => { setSortOrder(tempSortOrder); setGroupBy(tempGroupBy); setSortVisible(false); }} style={{ backgroundColor: palette.accent, padding: 10, borderRadius: 6 }}>
-                    <Text style={{ color: '#1b1d22' }}>Confirmar</Text>
+                    <Text style={{ color: '#1b1d22' }}>{t('system.inventory.confirm')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -683,8 +687,8 @@ export default function InventoryScreen({ navigation }) {
           <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.35)' }}>
             <TouchableWithoutFeedback>
               <View style={{ backgroundColor: palette.surface, padding: 20, borderRadius: 12, width: '80%', maxWidth: 300, borderWidth: 1, borderColor: palette.border }}>
-                <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: palette.text }}>Tipo de vista</Text>
-                {[{ key: 'list', label: 'Lista' },{ key: 'grid', label: 'Cuadrícula' }].map(opt => (
+                <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: palette.text }}>{t('system.inventory.viewTitle')}</Text>
+                {[{ key: 'list', label: t('system.inventory.view.list') },{ key: 'grid', label: t('system.inventory.view.grid') }].map(opt => (
                   <TouchableOpacity key={opt.key} style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }} onPress={() => setTempViewType(opt.key)}>
                     <Text style={{ color: palette.text }}>{tempViewType === opt.key ? '◉' : '○'}</Text>
                     <Text style={{ marginLeft: 6, color: palette.text }}>{opt.label}</Text>
@@ -692,10 +696,10 @@ export default function InventoryScreen({ navigation }) {
                 ))}
                 <View style={{ flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10 }}>
                   <TouchableOpacity onPress={() => setViewVisible(false)} style={{ padding: 10, marginRight: 10 }}>
-                    <Text style={{ color: palette.accent }}>Cancelar</Text>
+                    <Text style={{ color: palette.accent }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={() => { setViewType(tempViewType); setViewVisible(false); }} style={{ backgroundColor: palette.accent, padding: 10, borderRadius: 6 }}>
-                    <Text style={{ color: '#1b1d22' }}>Confirmar</Text>
+                    <Text style={{ color: '#1b1d22' }}>{t('system.inventory.confirm')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -722,7 +726,7 @@ export default function InventoryScreen({ navigation }) {
             <TouchableWithoutFeedback>
               <View style={{ backgroundColor: palette.surface, padding: 20, borderRadius: 12, maxHeight: '80%', width: '80%', borderWidth: 1, borderColor: palette.border }}>
                 <Text style={{ marginBottom: 10, color: palette.text }}>
-                  Añadir los siguientes {selectedItems.length} elementos a la lista de compras?
+                  {t('system.inventory.addToShoppingConfirm', { count: selectedItems.length })}
                 </Text>
                 <ScrollView style={{ marginBottom: 10 }}>
                   {getSelectedFullItems().map((item, idx) => (
@@ -752,8 +756,8 @@ export default function InventoryScreen({ navigation }) {
                   ))}
                 </ScrollView>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-                  <Button title="Cancelar" color={palette.accent} onPress={() => setShoppingVisible(false)} />
-                  <Button title="Añadir" color={palette.accent} onPress={handleAddToShopping} />
+                  <Button title={t('system.inventory.cancel')} color={palette.accent} onPress={() => setShoppingVisible(false)} />
+                  <Button title={t('system.inventory.add')} color={palette.accent} onPress={handleAddToShopping} />
                 </View>
               </View>
             </TouchableWithoutFeedback>
@@ -773,7 +777,7 @@ export default function InventoryScreen({ navigation }) {
                   <Button key={opt.key} title={opt.name} color={palette.accent} onPress={() => handleTransfer(opt.key)} />
                 ))}
                 <View style={{ height: 8 }} />
-                <Button title="Cancelar" color={palette.accent} onPress={() => setTransferType(null)} />
+                <Button title={t('system.inventory.cancel')} color={palette.accent} onPress={() => setTransferType(null)} />
               </View>
             </TouchableWithoutFeedback>
           </View>
@@ -789,7 +793,7 @@ export default function InventoryScreen({ navigation }) {
                   ¿Eliminar {selectedItems.length} items?
                 </Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-                  <Button title="Cancelar" color={palette.accent} onPress={() => setConfirmVisible(false)} />
+                  <Button title={t('system.inventory.cancel')} color={palette.accent} onPress={() => setConfirmVisible(false)} />
                   <Button title="Eliminar" color={palette.accent} onPress={handleDelete} />
                 </View>
               </View>


### PR DESCRIPTION
## Summary
- reload app after changing language to apply translations
- add missing translations for inventory screen and i18n strings
- remove quotes from inventory empty message so location names display cleanly
- ensure translation lookups respect the active locale so empty inventory text localizes properly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab65c6647883248c3c11d28f49875b