### PR TITLE
feat: localize item and food pickers

### DIFF
--- a/MiAppNevera/src/components/AddCategoryModal.js
+++ b/MiAppNevera/src/components/AddCategoryModal.js
@@ -3,9 +3,11 @@ import React, { useState, useMemo } from 'react';
 import { Modal, View, Text, TextInput, TouchableOpacity, Image, StyleSheet, Platform, TouchableWithoutFeedback } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function AddCategoryModal({ visible, onClose, onSave }) {
   const palette = useTheme();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const [name, setName] = useState('');
   const [iconUri, setIconUri] = useState(null);
@@ -35,34 +37,34 @@ export default function AddCategoryModal({ visible, onClose, onSave }) {
         <View style={styles.backdrop}>
           <TouchableWithoutFeedback>
             <View style={styles.card}>
-              <Text style={styles.title}>Nueva categoría</Text>
-              <Text style={styles.help}>Opcionalmente, agrega un icono personalizado.</Text>
+              <Text style={styles.title}>{t('system.categories.addTitle')}</Text>
+              <Text style={styles.help}>{t('system.categories.help')}</Text>
 
-              <Text style={styles.label}>Nombre</Text>
+              <Text style={styles.label}>{t('system.categories.nameLabel')}</Text>
               <TextInput
                 style={styles.input}
-                placeholder="Ej. Frutas"
+                placeholder={t('system.categories.namePlaceholder')}
                 placeholderTextColor={palette.textDim}
                 value={name}
                 onChangeText={setName}
               />
 
-              <Text style={styles.label}>Icono</Text>
+              <Text style={styles.label}>{t('system.categories.iconLabel')}</Text>
               {iconUri ? (
                 <Image source={{ uri: iconUri }} style={styles.preview} />
               ) : (
                 <View style={[styles.preview, { alignItems: 'center', justifyContent: 'center' }]}>
-                  <Text style={{ color: palette.textDim, fontSize: 12 }}>Sin icono</Text>
+                  <Text style={{ color: palette.textDim, fontSize: 12 }}>{t('system.categories.noIcon')}</Text>
                 </View>
               )}
 
               <View style={{ flexDirection: 'row', marginTop: 8 }}>
                 <TouchableOpacity onPress={pickImage} style={[styles.btn, styles.btnNeutral, { flex: 1 }]}>
-                  <Text style={styles.btnNeutralText}>Cargar imagen</Text>
+                  <Text style={styles.btnNeutralText}>{t('system.categories.pickImage')}</Text>
                 </TouchableOpacity>
                 {iconUri && (
                   <TouchableOpacity onPress={() => setIconUri(null)} style={[styles.btn, { flex: 1, marginLeft: 8 }]}>
-                    <Text style={styles.btnText}>Quitar</Text>
+                    <Text style={styles.btnText}>{t('system.categories.removeImage')}</Text>
                   </TouchableOpacity>
                 )}
               </View>
@@ -71,10 +73,10 @@ export default function AddCategoryModal({ visible, onClose, onSave }) {
 
               <View style={{ flexDirection: 'row' }}>
                 <TouchableOpacity onPress={onClose} style={[styles.btn, { flex: 1 }]}>
-                  <Text style={styles.btnText}>Cancelar</Text>
+                  <Text style={styles.btnText}>{t('system.categories.cancel')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity onPress={save} style={[styles.btn, styles.btnPrimary, { flex: 1, marginLeft: 10 }]}>
-                  <Text style={styles.btnPrimaryText}>Guardar</Text>
+                  <Text style={styles.btnPrimaryText}>{t('system.categories.save')}</Text>
                 </TouchableOpacity>
               </View>
             </View>

--- a/MiAppNevera/src/components/AddCustomFoodModal.js
+++ b/MiAppNevera/src/components/AddCustomFoodModal.js
@@ -25,6 +25,7 @@ import { useShopping } from '../context/ShoppingContext';
 import { useRecipes } from '../context/RecipeContext';
 import AddCategoryModal from './AddCategoryModal';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 import { useUnits } from '../context/UnitsContext';
 
 // ========================
@@ -312,6 +313,7 @@ export default function AddCustomFoodModal({ visible, onClose }) {
   const { addCustomFood, updateCustomFood } = useCustomFoods();
   const { categories, addCategory } = useCategories();
   const { units } = useUnits();
+  const { t } = useLanguage();
   const categoryNames = Object.keys(categories);
   const [name, setName] = useState('');
   const [category, setCategory] = useState(categoryNames[0]);
@@ -399,7 +401,7 @@ export default function AddCustomFoodModal({ visible, onClose }) {
             <Text style={styles.iconTxt}>←</Text>
           </TouchableOpacity>
           <TouchableOpacity onPress={() => setManageVisible(true)} style={styles.actionBtn}>
-            <Text style={styles.actionTxt}>Mis ingredientes</Text>
+            <Text style={styles.actionTxt}>{t('system.customFood.manage')}</Text>
           </TouchableOpacity>
         </View>
 
@@ -408,20 +410,18 @@ export default function AddCustomFoodModal({ visible, onClose }) {
           contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
           showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
         >
-          <Text style={styles.helpCentered}>
-            Crea tus propios ingredientes. Usa iconos predeterminados o carga una imagen.
-          </Text>
+          <Text style={styles.helpCentered}>{t('system.customFood.help')}</Text>
 
-          <Text style={styles.label}>Nombre</Text>
+          <Text style={styles.label}>{t('system.customFood.name')}</Text>
           <TextInput
             style={styles.input}
-            placeholder="Ej. Chimichurri"
+            placeholder={t('system.customFood.namePlaceholder')}
             placeholderTextColor={palette.textDim}
             value={name}
             onChangeText={setName}
           />
 
-          <Text style={styles.label}>Categoría</Text>
+          <Text style={styles.label}>{t('system.customFood.category')}</Text>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
             {categoryNames.map(cat => (
               <TouchableOpacity
@@ -439,17 +439,17 @@ export default function AddCustomFoodModal({ visible, onClose }) {
             </TouchableOpacity>
           </View>
 
-          <Text style={styles.label}>Días de caducidad por defecto</Text>
+          <Text style={styles.label}>{t('system.customFood.expirationDays')}</Text>
           <TextInput
             style={styles.input}
             keyboardType="numeric"
             value={expirationDays}
             onChangeText={t => setExpirationDays(t.replace(/[^0-9]/g, ''))}
-            placeholder="Opcional"
+            placeholder={t('system.common.optional')}
             placeholderTextColor={palette.textDim}
           />
 
-          <Text style={styles.label}>Unidad por defecto</Text>
+          <Text style={styles.label}>{t('system.customFood.defaultUnit')}</Text>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
             {units.map(u => (
               <TouchableOpacity
@@ -464,7 +464,7 @@ export default function AddCustomFoodModal({ visible, onClose }) {
             ))}
           </View>
 
-          <Text style={styles.label}>Precio unitario por defecto</Text>
+          <Text style={styles.label}>{t('system.customFood.defaultPrice')}</Text>
           <TextInput
             style={styles.input}
             value={defaultPrice}
@@ -478,31 +478,31 @@ export default function AddCustomFoodModal({ visible, onClose }) {
             }}
             keyboardType="decimal-pad"
             inputMode="decimal"
-            placeholder="Opcional"
+            placeholder={t('system.common.optional')}
             placeholderTextColor={palette.textDim}
           />
 
-          <Text style={styles.label}>Icono</Text>
+          <Text style={styles.label}>{t('system.customFood.icon')}</Text>
           {(iconUri || baseIcon) ? (
             <Image source={iconUri ? { uri: iconUri } : getFoodIcon(baseIcon)} style={styles.preview} />
           ) : (
             <View style={[styles.preview, { alignItems: 'center', justifyContent: 'center' }]}>
-              <Text style={{ color: palette.textDim, fontSize: 12 }}>Sin icono</Text>
+              <Text style={{ color: palette.textDim, fontSize: 12 }}>{t('system.customFood.noIcon')}</Text>
             </View>
           )}
           <View style={{ flexDirection: 'row', marginTop: 8 }}>
             <TouchableOpacity onPress={() => setPickerVisible(true)} style={[styles.btn, styles.btnNeutral, { flex: 1 }]}>
-              <Text style={styles.btnNeutralText}>Predeterminado</Text>
+              <Text style={styles.btnNeutralText}>{t('system.customFood.default')}</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={pickImage} style={[styles.btn, styles.btnNeutral, { flex: 1, marginLeft: 10 }]}>
-              <Text style={styles.btnNeutralText}>Cargar</Text>
+              <Text style={styles.btnNeutralText}>{t('system.customFood.upload')}</Text>
             </TouchableOpacity>
           </View>
         </ScrollView>
 
         {/* Guardar */}
         <TouchableOpacity onPress={save} style={styles.fab}>
-          <Text style={styles.fabTxt}>Guardar</Text>
+          <Text style={styles.fabTxt}>{t('system.common.save')}</Text>
         </TouchableOpacity>
 
         {/* Modales internos */}

--- a/MiAppNevera/src/components/AddItemModal.js
+++ b/MiAppNevera/src/components/AddItemModal.js
@@ -23,6 +23,7 @@ import { getFoodInfo } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function AddItemModal({ visible, foodName, foodIcon, initialLocation = 'fridge', onSave, onClose }) {
   const palette = useTheme();
@@ -31,6 +32,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
   const today = new Date().toISOString().split('T')[0];
   const { units } = useUnits();
   const { locations } = useLocations();
+  const { t } = useLanguage();
   // subscribe to default food overrides so edits persist after refresh
   const { overrides } = useDefaultFoods();
   const [location, setLocation] = useState(initialLocation);
@@ -100,7 +102,10 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
                   unitPrice || 0,
                   totalPrice || 0,
                 );
-                Alert.alert('Añadido', `${foodName} añadido a la lista de compras`);
+                Alert.alert(
+                  t('system.inventory.addItem.addedTitle'),
+                  t('system.inventory.addItem.addedMsg', { name: foodName })
+                );
               }}
               style={styles.iconBtn}
             >
@@ -121,7 +126,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             contentContainerStyle={{ padding: 16 }}
           >
             {/* Ubicación */}
-            <Text style={styles.labelBold}>Ubicación</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.addItem.location')}</Text>
             <View style={styles.chipWrap}>
               {locations.map((opt, idx) => (
                 <Pressable
@@ -141,7 +146,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </View>
 
             {/* Cantidad */}
-            <Text style={styles.labelBold}>Cantidad</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.addItem.quantity')}</Text>
             <View style={styles.qtyRow}>
               <TouchableOpacity
                 onPress={() => {
@@ -211,7 +216,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </View>
 
             {/* Unidad */}
-            <Text style={styles.labelBold}>Unidad</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.addItem.unit')}</Text>
             <View style={styles.chipWrap}>
               {units.map((opt, idx) => (
                 <Pressable
@@ -231,13 +236,13 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </View>
 
             {/* Precio */}
-            <Text style={styles.labelBold}>Precio</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.addItem.price')}</Text>
             <View style={styles.priceRow}>
               <TextInput
                 style={[styles.priceInput, { marginRight: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo unitario"
+                placeholder={t('system.inventory.addItem.unitCost')}
                 placeholderTextColor={palette.textDim}
                 value={unitPriceText}
                 onChangeText={(t) => {
@@ -261,7 +266,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
                 style={[styles.priceInput, { marginLeft: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo total"
+                placeholder={t('system.inventory.addItem.totalCost')}
                 placeholderTextColor={palette.textDim}
                 value={totalPriceText}
                 onChangeText={(t) => {
@@ -284,7 +289,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
 
             {/* Fechas (con inputs gris) */}
             <View style={{ marginTop: 6 }}>
-              <Text style={styles.labelBold}>Fecha de registro</Text>
+              <Text style={styles.labelBold}>{t('system.inventory.addItem.regDate')}</Text>
               <DatePicker
                 value={regDate}
                 onChange={setRegDate}
@@ -292,7 +297,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
                 containerStyle={styles.dateContainer}
               />
               <View style={{ height: 8 }} />
-              <Text style={styles.labelBold}>Fecha de caducidad</Text>
+              <Text style={styles.labelBold}>{t('system.inventory.addItem.expDate')}</Text>
               <DatePicker
                 value={expDate}
                 onChange={setExpDate}
@@ -302,12 +307,12 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             </View>
 
             {/* Nota */}
-            <Text style={styles.labelBold}>Nota</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.addItem.note')}</Text>
             <TextInput
               style={styles.noteInput}
               value={note}
               onChangeText={setNote}
-              placeholder="Opcional"
+              placeholder={t('system.common.optional')}
               placeholderTextColor={palette.textDim}
             />
 
@@ -329,7 +334,7 @@ export default function AddItemModal({ visible, foodName, foodIcon, initialLocat
             }
             style={styles.saveFab}
           >
-            <Text style={styles.saveFabText}>Guardar</Text>
+            <Text style={styles.saveFabText}>{t('system.common.save')}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -22,6 +22,7 @@ import {
 import FoodPickerModal from './FoodPickerModal';
 import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import { useUnits } from '../context/UnitsContext';
+import { useLanguage } from '../context/LanguageContext';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '../context/ThemeContext';
 
@@ -33,6 +34,7 @@ export default function AddRecipeModal({
 }) {
   const palette = useTheme();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  const { t, lang } = useLanguage();
   const { units, getLabel } = useUnits();
   const [name, setName] = useState('');
   const [image, setImage] = useState('');
@@ -159,8 +161,8 @@ export default function AddRecipeModal({
   
 const save = () => {
   const nm = (name || '').trim();
-  if (!nm) { setErrorMsg('Escribe el nombre de la receta.'); return; }
-  if (!ingredients.length) { setErrorMsg('Añade al menos un ingrediente.'); return; }
+  if (!nm) { setErrorMsg(t('system.recipes.add.errorName')); return; }
+  if (!ingredients.length) { setErrorMsg(t('system.recipes.add.errorIngredients')); return; }
   const per = Math.max(1, parseInt(persons, 10) || 0);
   onSave({
 
@@ -178,7 +180,7 @@ const save = () => {
     });
   };
 
-  const diffOptions = useMemo(() => ['facil', 'intermedio', 'dificil'], []);
+  const diffOptions = useMemo(() => ['easy', 'medium', 'hard'], []);
 
   return (
     <Modal visible={visible} animationType="slide">
@@ -188,9 +190,9 @@ const save = () => {
           <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
             <Text style={styles.iconTxt}>←</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>{isEditing ? 'Editar receta' : 'Nueva receta'}</Text>
+          <Text style={styles.headerTitle}>{isEditing ? t('system.recipes.add.editTitle') : t('system.recipes.add.newTitle')}</Text>
           <TouchableOpacity onPress={save} style={styles.saveBtn}>
-            <Text style={styles.saveBtnText}>Guardar</Text>
+            <Text style={styles.saveBtnText}>{t('system.common.save')}</Text>
           </TouchableOpacity>
         </View>
 
@@ -200,45 +202,45 @@ const save = () => {
           showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
         >
           {/* Nombre */}
-          <Text style={styles.label}>Nombre</Text>
+          <Text style={styles.label}>{t('system.recipes.add.nameLabel')}</Text>
           <TextInput
             style={styles.input}
             value={name}
             onChangeText={setName}
-            placeholder="Ej. Pasta con salsa roja"
+            placeholder={t('system.recipes.add.namePlaceholder')}
             placeholderTextColor={palette.textDim}
           />
 
           {/* Imagen */}
-          <Text style={styles.label}>Foto</Text>
+          <Text style={styles.label}>{t('system.recipes.add.imageLabel')}</Text>
           {image ? (
             <Image source={{ uri: image }} style={styles.image} resizeMode="cover" />
           ) : (
             <View style={[styles.image, styles.imagePlaceholder]}>
-              <Text style={{ color: palette.textDim }}>Sin imagen</Text>
+                <Text style={{ color: palette.textDim }}>{t('system.recipes.add.noImage')}</Text>
             </View>
           )}
           <View style={{ flexDirection: 'row', marginTop: 8 }}>
-            <TouchableOpacity style={[styles.btn, styles.btnNeutral, { flex: 1 }]} onPress={pickImage}>
-              <Text style={styles.btnNeutralText}>Seleccionar imagen</Text>
-            </TouchableOpacity>
+              <TouchableOpacity style={[styles.btn, styles.btnNeutral, { flex: 1 }]} onPress={pickImage}>
+                <Text style={styles.btnNeutralText}>{t('system.recipes.add.selectImage')}</Text>
+              </TouchableOpacity>
             <TouchableOpacity
               style={[styles.btn, { flex: 1, marginLeft: 10 }]}
               onPress={() => setImage('')}
             >
-              <Text style={styles.btnText}>Quitar</Text>
+                <Text style={styles.btnText}>{t('system.recipes.add.remove')}</Text>
             </TouchableOpacity>
           </View>
           <TextInput
             style={[styles.input, { marginTop: 8 }]}
-            placeholder="o pega una URL"
+            placeholder={t('system.recipes.add.urlPlaceholder')}
             placeholderTextColor={palette.textDim}
             value={image}
             onChangeText={setImage}
           />
 
           {/* Personas */}
-          <Text style={styles.label}>Personas</Text>
+          <Text style={styles.label}>{t('system.recipes.add.personsLabel')}</Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
             <TouchableOpacity
               onPress={() => setPersons(p => String(Math.max(1, (parseInt(p, 10) || 1) - 1)))}
@@ -261,7 +263,7 @@ const save = () => {
           </View>
 
           {/* Dificultad */}
-          <Text style={styles.label}>Dificultad</Text>
+          <Text style={styles.label}>{t('system.recipes.add.difficultyLabel')}</Text>
           <View style={{ flexDirection: 'row', marginBottom: 10 }}>
             {diffOptions.map(level => (
               <TouchableOpacity
@@ -270,14 +272,14 @@ const save = () => {
                 style={[styles.chip, difficulty === level && styles.chipOn]}
               >
                 <Text style={[styles.chipTxt, difficulty === level && styles.chipTxtOn]}>
-                  {level.charAt(0).toUpperCase() + level.slice(1)}
+                  {t(`system.recipes.add.difficulty.${level}`)}
                 </Text>
               </TouchableOpacity>
             ))}
           </View>
 
           {/* Ingredientes */}
-          <Text style={styles.label}>Ingredientes</Text>
+          <Text style={styles.label}>{t('system.recipes.add.ingredientsLabel')}</Text>
           {ingredients.map((ing, idx) => (
             <TouchableOpacity
               key={idx}
@@ -300,7 +302,7 @@ const save = () => {
                   onPress={() => openUnitPicker(idx)}
                 >
                   <Text style={styles.ingText}>
-                    {`${ing.quantity} ${getLabel(ing.quantity, ing.unit)} de ${
+                    {`${ing.quantity} ${getLabel(ing.quantity, ing.unit)} ${t('system.common.of')} ${
                       getFoodInfo(ing.name)?.name || ing.name
                     }`}
                   </Text>
@@ -344,27 +346,32 @@ const save = () => {
           {selectMode ? (
             <View style={{ flexDirection: 'row', marginTop: 6 }}>
               <TouchableOpacity style={[styles.btn, { flex: 1 }]} onPress={cancelSelect}>
-                <Text style={styles.btnText}>Cancelar</Text>
+                <Text style={styles.btnText}>{t('system.common.cancel')}</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.btn, styles.btnDanger, { flex: 1, marginLeft: 10 }]}
                 onPress={deleteSelectedIngredients}
               >
-                <Text style={styles.btnDangerText}>Eliminar</Text>
+                <Text style={styles.btnDangerText}>{t('system.common.delete')}</Text>
               </TouchableOpacity>
             </View>
           ) : (
-            <TouchableOpacity onPress={() => setPickerVisible(true)} style={[styles.btn, styles.btnNeutral, { alignSelf: 'center', marginTop: 6 }]}>
-              <Text style={styles.btnNeutralText}>Añadir ingrediente</Text>
+            <TouchableOpacity
+              onPress={() => setPickerVisible(true)}
+              style={[styles.btn, styles.btnNeutral, { alignSelf: 'center', marginTop: 6 }]}
+            >
+              <Text style={styles.btnNeutralText}>
+                {t('system.recipes.add.addIngredient')}
+              </Text>
             </TouchableOpacity>
           )}
 
           {/* Pasos */}
-          <Text style={styles.label}>Pasos (admite Markdown)</Text>
+          <Text style={styles.label}>{t('system.recipes.add.stepsLabel')}</Text>
           <TextInput
             multiline
             style={[styles.input, { height: 120, textAlignVertical: 'top' }]}
-            placeholder="Usa **negrita**, - listas, 1. enumeraciones"
+            placeholder={t('system.recipes.add.stepsPlaceholder')}
             placeholderTextColor={palette.textDim}
             value={steps}
             onChangeText={setSteps}
@@ -377,7 +384,7 @@ const save = () => {
             <View style={styles.modalBackdrop}>
               <TouchableWithoutFeedback>
                 <View style={styles.modalCard}>
-                  <Text style={styles.modalTitle}>Elegir unidad</Text>
+                  <Text style={styles.modalTitle}>{t('system.recipes.add.chooseUnit')}</Text>
                   <ScrollView style={{ maxHeight: 260 }}>
                     {units.map(opt => (
                       <TouchableOpacity key={opt.key} onPress={() => selectUnit(opt.key)} style={styles.optionRow}>
@@ -399,11 +406,11 @@ const save = () => {
     <View style={styles.modalBackdrop}>
       <TouchableWithoutFeedback>
         <View style={styles.modalCard}>
-          <Text style={styles.modalTitle}>Revisa los datos</Text>
+          <Text style={styles.modalTitle}>{t('system.recipes.add.errorTitle')}</Text>
           <Text style={styles.modalErrorText}>{errorMsg}</Text>
           <View style={styles.modalRow}>
             <TouchableOpacity onPress={() => setErrorMsg(null)} style={[styles.modalBtnOK]}>
-              <Text style={styles.modalBtnOKText}>Aceptar</Text>
+              <Text style={styles.modalBtnOKText}>{t('system.recipes.add.accept')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/MiAppNevera/src/components/AddShoppingItemModal.js
+++ b/MiAppNevera/src/components/AddShoppingItemModal.js
@@ -18,6 +18,7 @@ import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function AddShoppingItemModal({
   visible,
@@ -32,6 +33,7 @@ export default function AddShoppingItemModal({
 }) {
   const palette = useTheme();
   const { themeName } = useThemeController();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
   // subscribe to default food overrides so edits persist
@@ -112,7 +114,7 @@ export default function AddShoppingItemModal({
             style={styles.scroll}
             contentContainerStyle={{ padding: 16 }}
           >
-            <Text style={styles.labelBold}>Cantidad</Text>
+            <Text style={styles.labelBold}>{t('system.shopping.addItem.quantity')}</Text>
             <View style={styles.qtyRow}>
               <TouchableOpacity
                 onPress={() => {
@@ -181,7 +183,7 @@ export default function AddShoppingItemModal({
               </TouchableOpacity>
             </View>
 
-            <Text style={styles.labelBold}>Unidad</Text>
+            <Text style={styles.labelBold}>{t('system.shopping.addItem.unit')}</Text>
             <View style={styles.chipWrap}>
               {units.map((opt, idx) => (
                 <Pressable
@@ -206,13 +208,13 @@ export default function AddShoppingItemModal({
               ))}
             </View>
 
-            <Text style={styles.labelBold}>Precio</Text>
+            <Text style={styles.labelBold}>{t('system.shopping.addItem.price')}</Text>
             <View style={styles.priceRow}>
               <TextInput
                 style={[styles.priceInput, { marginRight: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo unitario"
+                placeholder={t('system.shopping.addItem.unitCost')}
                 placeholderTextColor={palette.textDim}
                 value={unitPriceText}
                 onChangeText={(t) => {
@@ -236,7 +238,7 @@ export default function AddShoppingItemModal({
                 style={[styles.priceInput, { marginLeft: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo total"
+                placeholder={t('system.shopping.addItem.totalCost')}
                 placeholderTextColor={palette.textDim}
                 value={totalPriceText}
                 onChangeText={(t) => {
@@ -260,7 +262,7 @@ export default function AddShoppingItemModal({
 
           <View style={styles.footerRow}>
             <TouchableOpacity style={styles.footerBtn} onPress={onClose}>
-              <Text style={styles.footerBtnText}>Cancelar</Text>
+              <Text style={styles.footerBtnText}>{t('system.shopping.addItem.cancel')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.footerBtn, styles.footerPrimary]}
@@ -276,7 +278,7 @@ export default function AddShoppingItemModal({
               <Text
                 style={[styles.footerBtnText, styles.footerPrimaryText]}
               >
-                Guardar
+                {t('system.shopping.addItem.save')}
               </Text>
             </TouchableOpacity>
           </View>

--- a/MiAppNevera/src/components/BatchAddItemModal.js
+++ b/MiAppNevera/src/components/BatchAddItemModal.js
@@ -17,6 +17,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useUnits } from '../context/UnitsContext';
 import { useLocations } from '../context/LocationsContext';
 import DatePicker from './DatePicker';
+import { useLanguage } from '../context/LanguageContext';
 import { getFoodInfo } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
@@ -26,6 +27,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette, themeName), [palette, themeName]);
+  const { t } = useLanguage();
 
   const today = new Date().toISOString().split('T')[0];
   const { units, getLabel } = useUnits();
@@ -87,14 +89,14 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
               <Text style={styles.iconText}>←</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={saveAll} style={styles.iconBtnAccent}>
-              <Text style={styles.iconTextOnAccent}>Guardar</Text>
+              <Text style={styles.iconTextOnAccent}>{t('system.common.save')}</Text>
             </TouchableOpacity>
           </View>
 
           {/* Hero con gradiente y resumen */}
           <LinearGradient colors={g.colors} locations={g.locations} start={g.start} end={g.end} style={styles.hero}>
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-              <Text style={styles.heroTitle}>Añadir {items.length} alimento(s)</Text>
+              <Text style={styles.heroTitle}>{t('system.inventory.batchAdd.title', { count: items.length })}</Text>
             </View>
           </LinearGradient>
 
@@ -119,7 +121,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                   </View>
 
                 {/* Ubicación */}
-                <Text style={styles.labelBold}>Ubicación</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.location')}</Text>
                 <View style={styles.chipWrap}>
                   {locations.map((opt, k) => (
                     <Pressable
@@ -142,7 +144,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                 </View>
 
                 {/* Cantidad */}
-                <Text style={styles.labelBold}>Cantidad</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.quantity')}</Text>
                 <View style={styles.qtyRow}>
                   <TouchableOpacity
                     onPress={() => updateField(idx, 'quantity', String(Math.max(0, (parseFloat(data[idx]?.quantity) || 0) - 1)))}
@@ -170,7 +172,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                 </View>
 
                 {/* Unidad */}
-                <Text style={styles.labelBold}>Unidad</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.unit')}</Text>
                 <View style={styles.chipWrap}>
                   {units.map((opt, k) => (
                     <Pressable
@@ -193,7 +195,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                 </View>
 
                 {/* Precio */}
-                <Text style={styles.labelBold}>Precio unitario</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.unitPrice')}</Text>
                 <TextInput
                   style={styles.priceInput}
                   value={data[idx]?.price}
@@ -207,13 +209,13 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                   }}
                   keyboardType="decimal-pad"
                   inputMode="decimal"
-                  placeholder="Opcional"
+                  placeholder={t('system.common.optional')}
                   placeholderTextColor={palette.textDim}
                 />
 
                 {/* Fechas */}
                 <View style={{ marginTop: 6 }}>
-                  <Text style={styles.labelBold}>Fecha de registro</Text>
+                  <Text style={styles.labelBold}>{t('system.inventory.batchAdd.regDate')}</Text>
                   <DatePicker
                     value={data[idx]?.regDate}
                     onChange={t => updateField(idx, 'regDate', t)}
@@ -221,7 +223,7 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                     containerStyle={styles.dateContainer}
                   />
                   <View style={{ height: 8 }} />
-                  <Text style={styles.labelBold}>Fecha de caducidad</Text>
+                  <Text style={styles.labelBold}>{t('system.inventory.batchAdd.expDate')}</Text>
                   <DatePicker
                     value={data[idx]?.expDate}
                     onChange={t => updateField(idx, 'expDate', t)}
@@ -231,12 +233,12 @@ export default function BatchAddItemModal({ visible, items = [], onSave, onClose
                 </View>
 
                 {/* Nota */}
-                <Text style={styles.labelBold}>Nota</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.note')}</Text>
                 <TextInput
                   style={styles.noteInput}
                   value={data[idx]?.note}
                   onChangeText={t => updateField(idx, 'note', t)}
-                  placeholder="Opcional"
+                  placeholder={t('system.common.optional')}
                   placeholderTextColor={palette.textDim}
                 />
               </View>

--- a/MiAppNevera/src/components/BatchAddShoppingModal.js
+++ b/MiAppNevera/src/components/BatchAddShoppingModal.js
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useUnits } from '../context/UnitsContext';
+import { useLanguage } from '../context/LanguageContext';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
 import { getFoodInfo } from '../foodIcons';
@@ -67,7 +68,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
               <Text style={styles.iconText}>←</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={saveAll} style={styles.iconBtnAccent}>
-              <Text style={styles.iconTextOnAccent}>Guardar</Text>
+              <Text style={styles.iconTextOnAccent}>{t('system.common.save')}</Text>
             </TouchableOpacity>
           </View>
 
@@ -78,7 +79,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
             end={g.end}
             style={styles.hero}
           >
-            <Text style={styles.heroTitle}>Añadir {items.length} alimento(s)</Text>
+            <Text style={styles.heroTitle}>{t('system.shopping.batchAdd.title', { count: items.length })}</Text>
           </LinearGradient>
 
           <ScrollView
@@ -112,7 +113,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                       </Text>
                     </View>
 
-                  <Text style={styles.labelBold}>Cantidad</Text>
+                  <Text style={styles.labelBold}>{t('system.shopping.batchAdd.quantity')}</Text>
                   <View style={styles.qtyRow}>
                     <TouchableOpacity
                       onPress={() =>
@@ -207,7 +208,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                     </TouchableOpacity>
                   </View>
 
-                  <Text style={styles.labelBold}>Unidad</Text>
+                  <Text style={styles.labelBold}>{t('system.shopping.batchAdd.unit')}</Text>
                   <View style={styles.chipWrap}>
                     {units.map(opt => (
                       <Pressable
@@ -231,13 +232,13 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                     ))}
                   </View>
 
-                  <Text style={styles.labelBold}>Precio</Text>
+                  <Text style={styles.labelBold}>{t('system.shopping.batchAdd.price')}</Text>
                   <View style={styles.priceRow}>
                     <TextInput
                       style={[styles.priceInput, { marginRight: 4 }]}
                       keyboardType="decimal-pad"
                       inputMode="decimal"
-                      placeholder="Costo unitario"
+                      placeholder={t('system.shopping.batchAdd.unitPricePlaceholder')}
                       placeholderTextColor={palette.textDim}
                       value={entry.unitPriceText || ''}
                       onChangeText={t => {
@@ -256,7 +257,7 @@ export default function BatchAddShoppingModal({ visible, items = [], onSave, onC
                       style={[styles.priceInput, { marginLeft: 4 }]}
                       keyboardType="decimal-pad"
                       inputMode="decimal"
-                      placeholder="Costo total"
+                      placeholder={t('system.shopping.batchAdd.totalPricePlaceholder')}
                       placeholderTextColor={palette.textDim}
                       value={entry.totalPriceText || ''}
                       onChangeText={t => {

--- a/MiAppNevera/src/components/DatePicker.js
+++ b/MiAppNevera/src/components/DatePicker.js
@@ -9,10 +9,12 @@ import {
   Animated,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function DatePicker({ label, value, onChange }) {
   const [show, setShow] = useState(false);
   const fadeAnim = React.useRef(new Animated.Value(0)).current;
+  const { t } = useLanguage();
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -50,7 +52,7 @@ export default function DatePicker({ label, value, onChange }) {
               <TextInput
                 style={styles.input}
                 value={displayValue}
-                placeholder="YYYY-MM-DD"
+                placeholder={t('system.datePicker.placeholder')}
                 editable={false}
               />
             </View>

--- a/MiAppNevera/src/components/EditDefaultFoodModal.js
+++ b/MiAppNevera/src/components/EditDefaultFoodModal.js
@@ -14,9 +14,11 @@ import { useTheme } from '../context/ThemeContext';
 import { useUnits } from '../context/UnitsContext';
 import { getFoodInfo, getFoodIcon } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
   const palette = useTheme();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { units } = useUnits();
   const { updateOverride } = useDefaultFoods();
@@ -49,21 +51,21 @@ export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
     <Modal visible={visible} animationType="slide" transparent>
       <View style={styles.modalBackdrop}>
         <View style={styles.sheet}>
-          <Text style={styles.title}>Editar alimento</Text>
+          <Text style={styles.title}>{t('system.defaultFood.editTitle')}</Text>
           <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}>
             {foodKey && (
               <Image source={getFoodIcon(foodKey)} style={styles.editIcon} />
             )}
-            <Text style={styles.label}>Nombre</Text>
+            <Text style={styles.label}>{t('system.defaultFood.nameLabel')}</Text>
             <TextInput value={name} onChangeText={setName} style={styles.input} />
-            <Text style={styles.label}>Días de caducidad</Text>
+            <Text style={styles.label}>{t('system.defaultFood.expirationLabel')}</Text>
             <TextInput
               value={days}
               onChangeText={t => setDays(t.replace(/[^0-9]/g, ''))}
               keyboardType="numeric"
               style={styles.input}
             />
-            <Text style={styles.label}>Unidad por defecto</Text>
+            <Text style={styles.label}>{t('system.defaultFood.unitLabel')}</Text>
             <View style={styles.chipWrap}>
               {units.map(u => (
                 <Pressable
@@ -77,7 +79,7 @@ export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
                 </Pressable>
               ))}
             </View>
-            <Text style={styles.label}>Precio unitario</Text>
+            <Text style={styles.label}>{t('system.defaultFood.priceLabel')}</Text>
             <TextInput
               value={price}
               onChangeText={t => {
@@ -95,10 +97,10 @@ export default function EditDefaultFoodModal({ visible, foodKey, onClose }) {
           </ScrollView>
           <View style={styles.footer}>
             <TouchableOpacity onPress={onClose} style={styles.btn}>
-              <Text style={styles.btnTxt}>Cancelar</Text>
+              <Text style={styles.btnTxt}>{t('system.defaultFood.cancel')}</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={handleSave} style={[styles.btn, styles.btnPrimary]}>
-              <Text style={styles.btnPrimaryTxt}>Guardar</Text>
+              <Text style={styles.btnPrimaryTxt}>{t('system.defaultFood.save')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/MiAppNevera/src/components/EditItemModal.js
+++ b/MiAppNevera/src/components/EditItemModal.js
@@ -21,6 +21,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useShopping } from '../context/ShoppingContext';
+import { useLanguage } from '../context/LanguageContext';
 import AddShoppingItemModal from './AddShoppingItemModal';
 import DatePicker from './DatePicker';
 import { useUnits } from '../context/UnitsContext';
@@ -35,6 +36,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  const { t } = useLanguage();
   const { addItem: addShoppingItem } = useShopping();
   const { units } = useUnits();
   const { locations } = useLocations();
@@ -129,7 +131,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                 {item?.icon && <Image source={item.icon} style={{ width: 64, height: 64 }} resizeMode="contain" />}
               </View>
               <View style={{ flex: 1 }}>
-                <Text style={styles.foodName} numberOfLines={2}>{label || 'Alimento'}</Text>
+                <Text style={styles.foodName} numberOfLines={2}>{label || ''}</Text>
                 {!!foodCategory && (
                   <Text style={{ color: palette.textDim, fontSize: 12 }} numberOfLines={1}>{foodCategory}</Text>
                 )}
@@ -142,7 +144,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
               showsVerticalScrollIndicator={Platform.OS === 'web' ? true : false}
             >
               {/* Ubicación */}
-              <Text style={styles.labelBold}>Ubicación</Text>
+              <Text style={styles.labelBold}>{t('system.inventory.batchAdd.location')}</Text>
               <View style={styles.chipWrap}>
                 {locations.map((opt, idx) => (
                   <Pressable
@@ -162,7 +164,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             </View>
 
             {/* Cantidad */}
-            <Text style={styles.labelBold}>Cantidad</Text>
+            <Text style={styles.labelBold}>{t('system.inventory.batchAdd.quantity')}</Text>
               <View style={styles.qtyRow}>
                 <TouchableOpacity
                   onPress={() => {
@@ -232,7 +234,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
               </View>
 
               {/* Unidad */}
-              <Text style={styles.labelBold}>Unidad</Text>
+              <Text style={styles.labelBold}>{t('system.inventory.batchAdd.unit')}</Text>
               <View style={styles.chipWrap}>
                 {units.map((opt, idx) => (
                   <Pressable
@@ -252,13 +254,13 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             </View>
 
             {/* Precio */}
-            <Text style={styles.labelBold}>Precio</Text>
+            <Text style={styles.labelBold}>{t('system.shopping.batchAdd.price')}</Text>
             <View style={styles.priceRow}>
               <TextInput
                 style={[styles.priceInput, { marginRight: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo unitario"
+                  placeholder={t('system.shopping.batchAdd.unitPricePlaceholder')}
                 placeholderTextColor={palette.textDim}
                 value={unitPriceText}
                 onChangeText={(t) => {
@@ -282,7 +284,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                 style={[styles.priceInput, { marginLeft: 4 }]}
                 keyboardType="decimal-pad"
                 inputMode="decimal"
-                placeholder="Costo total"
+                  placeholder={t('system.shopping.batchAdd.totalPricePlaceholder')}
                 placeholderTextColor={palette.textDim}
                 value={totalPriceText}
                 onChangeText={(t) => {
@@ -305,7 +307,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
 
             {/* Fechas (inputs gris) */}
             <View style={{ marginTop: 6 }}>
-                <Text style={styles.labelBold}>Fecha de registro</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.regDate')}</Text>
                 <DatePicker
                   value={regDate}
                   onChange={setRegDate}
@@ -313,7 +315,7 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
                   containerStyle={styles.dateContainer}
                 />
                 <View style={{ height: 8 }} />
-                <Text style={styles.labelBold}>Fecha de caducidad</Text>
+                <Text style={styles.labelBold}>{t('system.inventory.batchAdd.expDate')}</Text>
                 <DatePicker
                   value={expDate}
                   onChange={setExpDate}
@@ -323,12 +325,12 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
               </View>
 
               {/* Nota */}
-              <Text style={styles.labelBold}>Nota</Text>
+              <Text style={styles.labelBold}>{t('system.inventory.batchAdd.note')}</Text>
               <TextInput
                 style={styles.noteInput}
                 value={note}
                 onChangeText={setNote}
-                placeholder="Opcional"
+                placeholder={t('system.common.optional')}
                 placeholderTextColor={palette.textDim}
               />
 
@@ -336,9 +338,9 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             </ScrollView>
 
             {/* Guardar */}
-            <TouchableOpacity onPress={handleSave} style={styles.saveFab}>
-              <Text style={styles.saveFabText}>Guardar</Text>
-            </TouchableOpacity>
+              <TouchableOpacity onPress={handleSave} style={styles.saveFab}>
+                <Text style={styles.saveFabText}>{t('system.common.save')}</Text>
+              </TouchableOpacity>
           </View>
         </View>
       </Modal>
@@ -354,7 +356,10 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
         initialTotalPrice={item?.price ? item.price * (item.quantity ?? 0) : 0}
         onSave={({ quantity: q, unit: u, unitPrice, totalPrice }) => {
           addShoppingItem(item?.name, q || 0, u, unitPrice, totalPrice);
-          Alert.alert('Añadido', `${item?.name} añadido a la lista de compras`);
+          Alert.alert(
+            t('system.inventory.addItem.addedTitle'),
+            t('system.inventory.addItem.addedMsg', { name: item?.name })
+          );
           setShoppingVisible(false);
         }}
         onClose={() => setShoppingVisible(false)}
@@ -367,18 +372,18 @@ export default function EditItemModal({ visible, item, onSave, onDelete, onClose
             <View style={{ alignItems: 'center', marginBottom: 10 }}>
               {item?.icon && <Image source={item.icon} style={{ width: 64, height: 64, marginBottom: 10 }} />}
               <Text style={{ color: palette.text, textAlign: 'center' }}>
-                ¿Seguro que deseas eliminar <Text style={{ color: palette.accent }}>{item?.name}</Text>?
+                {t('system.inventory.deleteItemPrompt', { name: item?.name })}
               </Text>
             </View>
             <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
               <TouchableOpacity onPress={() => setConfirmVisible(false)} style={[styles.bottomBtn, { backgroundColor: palette.surface3, flex: 1, marginRight: 8 }]}>
-                <Text style={{ color: palette.text }}>Cancelar</Text>
+                <Text style={{ color: palette.text }}>{t('system.common.cancel')}</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 onPress={() => { setConfirmVisible(false); onDelete && onDelete(); }}
                 style={[styles.bottomBtn, { backgroundColor: '#e53935', flex: 1, marginLeft: 8 }]}
               >
-                <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                <Text style={{ color: '#fff', fontWeight: '700' }}>{t('system.common.delete')}</Text>
               </TouchableOpacity>
             </View>
           </Pressable>

--- a/MiAppNevera/src/components/FoodPickerModal.js
+++ b/MiAppNevera/src/components/FoodPickerModal.js
@@ -30,6 +30,7 @@ import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, useThemeController } from '../context/ThemeContext';
 import { gradientForKey } from '../theme/gradients';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function FoodPickerModal({
   visible,
@@ -42,6 +43,7 @@ export default function FoodPickerModal({
   const palette = useTheme();
   const { themeName } = useThemeController();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  const { t } = useLanguage();
   const { categories } = useCategories();
   // subscribe to default food overrides so default names update after refresh
   const { overrides } = useDefaultFoods();
@@ -179,7 +181,7 @@ export default function FoodPickerModal({
                     onPress={() => setAddVisible(true)}
                     style={[styles.createBtn, { marginRight: showMenu ? 8 : 0 }]}
                   >
-                    <Text style={styles.createText}>Crear Nuevo</Text>
+                    <Text style={styles.createText}>{t('system.foodPicker.createNew')}</Text>
                   </TouchableOpacity>
                 )}
                 {showMenu && (
@@ -239,7 +241,7 @@ export default function FoodPickerModal({
               <View style={{ paddingHorizontal: 12, paddingTop: 6, backgroundColor: palette.bg }}>
                 <TextInput
                   style={styles.searchInput}
-                  placeholder="Buscar alimento"
+                  placeholder={t('system.foodPicker.searchPlaceholder')}
                   placeholderTextColor={palette.textDim}
                   value={search}
                   onChangeText={setSearch}
@@ -306,10 +308,10 @@ export default function FoodPickerModal({
                   onPress={() => { setSelectMode(false); setSelected([]); }}
                   style={[styles.bottomBtn, { backgroundColor: palette.surface3 }]}
                 >
-                  <Text style={{ color: palette.text }}>Cancelar</Text>
+                  <Text style={{ color: palette.text }}>{t('system.common.cancel')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity onPress={handleSave} style={[styles.bottomBtn, { backgroundColor: palette.accent }]}>
-                  <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Guardar</Text>
+                  <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.common.save')}</Text>
                 </TouchableOpacity>
               </View>
             ) : null}
@@ -330,7 +332,7 @@ export default function FoodPickerModal({
                   }}
                   style={styles.menuItem}
                 >
-                  <Text style={{ color: palette.text }}>Administrar alimentos predeterminados</Text>
+                  <Text style={{ color: palette.text }}>{t('system.foodPicker.manageDefaults')}</Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -344,13 +346,13 @@ export default function FoodPickerModal({
             <View style={[styles.sheet, { padding: 12 }]}>
               <View style={{ borderWidth: 1, borderColor: palette.border, backgroundColor: palette.surface2, padding: 10, marginBottom: 10, borderRadius: 10 }}>
                 <Text style={{ textAlign: 'center', color: palette.text }}>
-                  Lista completa de todos los alimentos predeterminados
+                  {t('system.foodPicker.manage.title')}
                 </Text>
                 <Text style={{ textAlign: 'center', color: palette.textDim }}>
-                  Los alimentos sombreados no se mostrarán en la lista de agregar
+                  {t('system.foodPicker.manage.hiddenNote')}
                 </Text>
                 <Text style={{ textAlign: 'center', color: palette.textDim }}>
-                  Mantener presionado el alimento para editar más detalles
+                  {t('system.foodPicker.manage.holdNote')}
                 </Text>
               </View>
               <View style={styles.catBar}>
@@ -443,7 +445,7 @@ export default function FoodPickerModal({
                 })}
               </ScrollView>
               <TouchableOpacity onPress={() => setManageVisible(false)} style={[styles.bottomBtn, { alignSelf: 'center', backgroundColor: palette.accent, marginBottom: 10 }]}>
-                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cerrar</Text>
+                <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.common.close')}</Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/MiAppNevera/src/components/ListPreviewModal.js
+++ b/MiAppNevera/src/components/ListPreviewModal.js
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
 import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 import ShoppingListPreview from './ShoppingListPreview';
 
 export default function ListPreviewModal({ visible, name, items = [], onClose }) {
   const palette = useTheme();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   return (
     <Modal visible={visible} animationType="slide">
@@ -13,7 +15,7 @@ export default function ListPreviewModal({ visible, name, items = [], onClose })
           <TouchableOpacity onPress={onClose} style={styles.iconBtn}>
             <Text style={styles.iconText}>←</Text>
           </TouchableOpacity>
-          <Text style={styles.title}>{name || 'Lista'}</Text>
+          <Text style={styles.title}>{name || t('system.savedLists.list')}</Text>
         </View>
         <ShoppingListPreview items={items} style={{ flex: 1 }} />
       </View>

--- a/MiAppNevera/src/components/SaveListModal.js
+++ b/MiAppNevera/src/components/SaveListModal.js
@@ -5,6 +5,7 @@ import AddShoppingItemModal from './AddShoppingItemModal';
 import FoodPickerModal from './FoodPickerModal';
 import { getFoodCategory } from '../foodIcons';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function SaveListModal({ visible, items = [], initialName = '', initialNote = '', onSave, onClose }) {
   const [name, setName] = useState('');
@@ -17,6 +18,7 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
   const [adding, setAdding] = useState(null);
   const [addVisible, setAddVisible] = useState(false);
   const palette = useTheme();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
 
   useEffect(() => {
@@ -97,15 +99,15 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
   return (
     <Modal visible={visible} animationType="slide">
       <View style={styles.container}>
-        <Text style={styles.title}>Guardar lista</Text>
+        <Text style={styles.title}>{t('system.savedLists.saveModal.title')}</Text>
         <TextInput
-          placeholder="Nombre"
+          placeholder={t('system.savedLists.saveModal.namePlaceholder')}
           style={styles.input}
           value={name}
           onChangeText={setName}
         />
         <TextInput
-          placeholder="Nota"
+          placeholder={t('system.savedLists.saveModal.notePlaceholder')}
           style={styles.input}
           value={note}
           onChangeText={setNote}
@@ -119,14 +121,14 @@ export default function SaveListModal({ visible, items = [], initialName = '', i
         />
         <View style={styles.actions}>
           <Button
-            title={selectMode ? 'Cancelar selección' : 'Cancelar'}
+            title={selectMode ? t('system.savedLists.saveModal.cancelSelection') : t('system.savedLists.saveModal.cancel')}
             onPress={selectMode ? () => { setSelectMode(false); setSelected([]); } : onClose}
           />
-          <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+          <Button title={t('system.savedLists.saveModal.add')} onPress={() => setPickerVisible(true)} />
           {selectMode && selected.length > 0 && (
-            <Button title="Eliminar" color="#b00" onPress={deleteSelected} />
+            <Button title={t('system.savedLists.saveModal.delete')} color="#b00" onPress={deleteSelected} />
           )}
-          <Button title="Guardar" onPress={() => onSave({ name: name.trim(), note, items: localItems })} />
+          <Button title={t('system.savedLists.saveModal.save')} onPress={() => onSave({ name: name.trim(), note, items: localItems })} />
         </View>
         <AddShoppingItemModal
           visible={editIdx !== null}

--- a/MiAppNevera/src/components/ShoppingListPreview.js
+++ b/MiAppNevera/src/components/ShoppingListPreview.js
@@ -16,12 +16,14 @@ import { useCurrency } from '../context/CurrencyContext';
 import { getFoodInfo } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
 import CostPieChart from './CostPieChart';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function ShoppingListPreview({ items = [], onItemPress, onItemLongPress, selected = [], style }) {
   const { getLabel } = useUnits();
   const { categories } = useCategories();
   const palette = useTheme();
   const { symbol } = useCurrency();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   // subscribe to default food overrides so preview names update
   const { overrides } = useDefaultFoods();
@@ -110,13 +112,13 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
         {items.length > 0 && (
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
-              <Text style={styles.sectionTitle}>Detalles de lista de compra</Text>
+              <Text style={styles.sectionTitle}>{t('system.shopping.detailsTitle')}</Text>
             </View>
             <View style={styles.detailsRow}>
               <TouchableOpacity style={styles.actionBtn} onPress={() => setDetailsVisible(true)}>
-                <Text style={styles.actionText}>Más detalles</Text>
+                <Text style={styles.actionText}>{t('system.shopping.moreDetails')}</Text>
               </TouchableOpacity>
-              <Text style={styles.totalText}>{`Costo Total: ${symbol}${totalCost.toFixed(2)}`}</Text>
+              <Text style={styles.totalText}>{`${t('system.shopping.totalCost')}: ${symbol}${totalCost.toFixed(2)}`}</Text>
             </View>
           </View>
         )}
@@ -132,7 +134,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={[styles.card, { alignItems: 'center' }]}>
-                <Text style={[styles.cardTitle, { marginBottom: 16 }]}>Distribución de costos</Text>
+                <Text style={[styles.cardTitle, { marginBottom: 16 }]}>{t('system.shopping.costDistribution')}</Text>
                 {totalCost > 0 ? (
                   <>
                     <CostPieChart data={chartData} size={200} />
@@ -150,7 +152,7 @@ export default function ShoppingListPreview({ items = [], onItemPress, onItemLon
                     </View>
                   </>
                 ) : (
-                  <Text style={{ color: palette.textDim }}>Sin datos de costo</Text>
+                  <Text style={{ color: palette.textDim }}>{t('system.shopping.noCostData')}</Text>
                 )}
               </View>
             </TouchableWithoutFeedback>

--- a/MiAppNevera/src/locales/en/system.json
+++ b/MiAppNevera/src/locales/en/system.json
@@ -11,7 +11,9 @@
     "currencySettings": "Currency type",
     "locationSettings": "Location management",
     "userData": "User data",
-    "languageSettings": "Language"
+    "languageSettings": "Language",
+    "freezer": "Freezer",
+    "pantry": "Pantry"
   },
   "settings": {
     "themeTitle": "Color theme",
@@ -30,6 +32,52 @@
   "language": {
     "spanish": "Spanish",
     "english": "English"
+  },
+  "currency": {
+    "current": "Current"
+  },
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "close": "Close",
+    "optional": "Optional",
+    "of": "of"
+  },
+  "shopping": {
+    "selectAll": "Select all",
+    "edit": "Edit",
+    "save": "Save",
+    "empty": "Your shopping list is empty",
+    "addFood": "Add food",
+    "detailsTitle": "Shopping list details",
+    "moreDetails": "More details",
+    "totalCost": "Total cost",
+    "costDistribution": "Cost distribution",
+    "noCostData": "No cost data",
+    "deleteSelectedTitle": "Delete selected",
+    "deleteSelectedPrompt": "Delete %{count} item(s) from the shopping list?",
+    "clearTitle": "Clear list",
+    "clearPrompt": "Remove all items from the shopping list?",
+    "autoAddTitle": "Auto add",
+    "autoAddPrompt": "Add all inventory items with quantity 0 to the shopping list? Existing items won't be added.",
+    "addItem": {
+      "quantity": "Quantity",
+      "unit": "Unit",
+      "price": "Price",
+      "unitCost": "Unit cost",
+      "totalCost": "Total cost",
+      "cancel": "Cancel",
+      "save": "Save"
+    }
+    ,"batchAdd": {
+      "title": "Add %{count} item(s)",
+      "quantity": "Quantity",
+      "unit": "Unit",
+      "price": "Price",
+      "unitPricePlaceholder": "Unit cost",
+      "totalPricePlaceholder": "Total cost"
+    }
   },
   "inventory": {
     "settingsButton": "Settings",
@@ -65,6 +113,207 @@
     "delete": "Delete",
     "expiredLabel": "Exp.",
     "dayPrefix": "D-",
-    "unregistered": "No record"
+    "unregistered": "No record",
+    "otherCategory": "Others",
+    "batchAdd": {
+      "title": "Add %{count} item(s)",
+      "location": "Location",
+      "quantity": "Quantity",
+      "unit": "Unit",
+      "unitPrice": "Unit price",
+      "regDate": "Register date",
+      "expDate": "Expiration date",
+      "note": "Note"
+    },
+    "addItem": {
+      "location": "Location",
+      "quantity": "Quantity",
+      "unit": "Unit",
+      "price": "Price",
+      "unitCost": "Unit cost",
+      "totalCost": "Total cost",
+      "regDate": "Register date",
+      "expDate": "Expiration date",
+      "note": "Note",
+      "addedTitle": "Added",
+      "addedMsg": "%{name} added to the shopping list"
+    },
+    "deleteItemPrompt": "Are you sure you want to delete %{name}?"
+  },
+  "locations": {
+    "warningNotEmpty": "The location contains food. Empty it before deleting.",
+    "inactive": "Inactive",
+    "deactivate": "Deactivate",
+    "activate": "Activate",
+    "delete": "Delete",
+    "editTitle": "Edit location",
+    "addTitle": "Add location",
+    "namePlaceholder": "Name",
+    "save": "Save",
+    "add": "Add",
+    "deletePrompt": "Delete this location?"
+  },
+  "recipes": {
+    "noImage": "No image",
+    "missing": "Missing",
+    "meta": "Serves %{persons} people • Difficulty: %{difficulty}",
+    "detail": {
+      "notFound": "Recipe not found",
+      "ingredients": "Ingredients",
+      "addToShopping": "Add to shopping",
+      "missingPrompt": "Add the following missing ingredients to the shopping list?",
+      "addAllPrompt": "Or add all ingredients?",
+      "addMissing": "Add missing",
+      "addAll": "Add all",
+      "steps": "Steps"
+    }
+    ,"add": {
+      "newTitle": "New recipe",
+      "editTitle": "Edit recipe",
+      "nameLabel": "Name",
+      "namePlaceholder": "e.g. Pasta with red sauce",
+      "imageLabel": "Photo",
+      "noImage": "No image",
+      "selectImage": "Select image",
+      "remove": "Remove",
+      "urlPlaceholder": "or paste a URL",
+      "personsLabel": "Persons",
+      "difficultyLabel": "Difficulty",
+      "ingredientsLabel": "Ingredients",
+      "addIngredient": "Add ingredient",
+      "stepsLabel": "Steps (supports Markdown)",
+      "stepsPlaceholder": "Use **bold**, - lists, 1. numbered",
+      "errorTitle": "Check data",
+      "errorName": "Enter the recipe name.",
+      "errorIngredients": "Add at least one ingredient.",
+      "chooseUnit": "Choose unit",
+      "accept": "OK",
+      "difficulty": {"easy": "Easy","medium": "Medium","hard": "Hard"}
+    }
+  },
+  "savedLists": {
+    "untitled": "Untitled",
+    "totalCost": "Total cost",
+    "items": "%{count} items",
+    "load": "Load",
+    "preview": "Preview",
+    "edit": "Edit",
+    "delete": "Delete",
+    "deleteTitle": "Delete list",
+    "deletePrompt": "Delete this saved list?",
+    "list": "List",
+    "saveModal": {
+      "title": "Save list",
+      "namePlaceholder": "Name",
+      "notePlaceholder": "Note",
+      "cancel": "Cancel",
+      "cancelSelection": "Cancel selection",
+      "add": "Add",
+      "delete": "Delete",
+      "save": "Save"
+    }
+  },
+  "theme": {
+    "dark": "Dark Premium",
+    "light": "Light",
+    "current": "Current"
+  },
+  "units": {
+    "error": "Please fill singular and plural.",
+    "edit": "Edit",
+    "delete": "Delete",
+    "editTitle": "Edit unit",
+    "addTitle": "Add unit",
+    "singularPlaceholder": "Singular",
+    "pluralPlaceholder": "Plural",
+    "update": "Update",
+    "add": "Add",
+    "cancel": "Cancel"
+  },
+  "userData": {
+    "syncTitle": "Synchronization",
+    "syncSubtitle": "Connect your Google account to store a backup in the cloud.",
+    "connectedAs": "Connected as %{email}",
+    "uploadBackup": "Upload backup",
+    "restoreBackup": "Restore backup",
+    "disconnect": "Disconnect account",
+    "connectGoogle": "Connect with Google",
+    "backupTitle": "Backup and data",
+    "backupSubtitle": "Export or import all your data.",
+    "exportData": "Export data",
+    "importData": "Import data",
+    "deleteTitle": "Delete all",
+    "deleteSubtitle": "This will permanently delete all user data.",
+    "deleteData": "Delete all data",
+    "uploadConfirmTitle": "Upload backup",
+    "uploadConfirmBody": "A copy of your data and settings will be saved to Google Drive, replacing any previous backup. Continue?",
+    "downloadConfirmTitle": "Restore backup",
+    "downloadConfirmBody": "All local data will be replaced with the copy stored in Google Drive. This action will overwrite your current information. Continue?",
+    "exportConfirmTitle": "Export data",
+    "exportConfirmBody": "Do you want to export all user data?",
+    "resetConfirmTitle": "Delete all data",
+    "resetConfirmBody": "This action is permanent. Continue?",
+    "googleSignInError": "Could not sign in with Google.",
+    "uploadSuccess": "Backup uploaded to Google Drive.",
+    "uploadError": "Could not upload the backup.",
+    "downloadError": "Could not restore the backup.",
+    "resetTitle": "Restart",
+    "resetMessage": "The app will restart",
+    "success": "Success",
+    "error": "Error",
+    "accept": "Accept",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "ok": "OK",
+    "user": "user"
+  },
+  "defaultFood": {
+    "editTitle": "Edit food",
+    "nameLabel": "Name",
+    "expirationLabel": "Expiration days",
+    "unitLabel": "Default unit",
+    "priceLabel": "Unit price",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "categories": {
+    "addTitle": "New category",
+    "help": "Optionally add a custom icon.",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Fruits",
+    "iconLabel": "Icon",
+    "noIcon": "No icon",
+    "pickImage": "Pick image",
+    "removeImage": "Remove",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "foodPicker": {
+    "createNew": "Create new",
+    "searchPlaceholder": "Search food",
+    "manageDefaults": "Manage default foods",
+    "manage": {
+      "title": "Full list of all default foods",
+      "hiddenNote": "Shaded foods won't appear in the add list",
+      "holdNote": "Hold a food to edit more details"
+    }
+  }
+,  "datePicker": {
+    "placeholder": "YYYY-MM-DD"
+  },
+  "customFood": {
+    "manage": "My ingredients",
+    "help": "Create your own ingredients. Use default icons or upload an image.",
+    "name": "Name",
+    "namePlaceholder": "e.g. Chimichurri",
+    "category": "Category",
+    "expirationDays": "Default expiration days",
+    "defaultUnit": "Default unit",
+    "defaultPrice": "Default unit price",
+    "icon": "Icon",
+    "noIcon": "No icon",
+    "default": "Default",
+    "upload": "Upload",
+    "save": "Save"
   }
 }

--- a/MiAppNevera/src/locales/es/system.json
+++ b/MiAppNevera/src/locales/es/system.json
@@ -11,7 +11,9 @@
     "currencySettings": "Tipo de Moneda",
     "locationSettings": "Gestión de ubicación",
     "userData": "Datos de usuario",
-    "languageSettings": "Idioma"
+    "languageSettings": "Idioma",
+    "freezer": "Congelador",
+    "pantry": "Despensa"
   },
   "settings": {
     "themeTitle": "Tema de colores",
@@ -30,6 +32,52 @@
   "language": {
     "spanish": "Español",
     "english": "Inglés"
+  },
+  "currency": {
+    "current": "Actual"
+  },
+  "common": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "close": "Cerrar",
+    "optional": "Opcional",
+    "of": "de"
+  },
+  "shopping": {
+    "selectAll": "Seleccionar todo",
+    "edit": "Editar",
+    "save": "Guardar",
+    "empty": "Tu lista de compras está vacía",
+    "addFood": "Añadir alimento",
+    "detailsTitle": "Detalles de lista de compra",
+    "moreDetails": "Más detalles",
+    "totalCost": "Costo Total",
+    "costDistribution": "Distribución de costos",
+    "noCostData": "Sin datos de costo",
+    "deleteSelectedTitle": "Eliminar seleccionados",
+    "deleteSelectedPrompt": "¿Eliminar %{count} alimento(s) de la lista de compras?",
+    "clearTitle": "Limpiar lista",
+    "clearPrompt": "¿Eliminar todos los alimentos de la lista de compras?",
+    "autoAddTitle": "Añadir automáticamente",
+    "autoAddPrompt": "¿Deseas añadir todos los alimentos con cantidad 0 del inventario a la lista de compras? Los que ya estén en la lista no se agregarán.",
+    "addItem": {
+      "quantity": "Cantidad",
+      "unit": "Unidad",
+      "price": "Precio",
+      "unitCost": "Costo unitario",
+      "totalCost": "Costo total",
+      "cancel": "Cancelar",
+      "save": "Guardar"
+    }
+    ,"batchAdd": {
+      "title": "Añadir %{count} alimento(s)",
+      "quantity": "Cantidad",
+      "unit": "Unidad",
+      "price": "Precio",
+      "unitPricePlaceholder": "Costo unitario",
+      "totalPricePlaceholder": "Costo total"
+    }
   },
   "inventory": {
     "settingsButton": "Ajustes",
@@ -65,6 +113,207 @@
     "delete": "Eliminar",
     "expiredLabel": "Venc.",
     "dayPrefix": "D-",
-    "unregistered": "Sin registro"
+    "unregistered": "Sin registro",
+    "otherCategory": "Otros",
+    "batchAdd": {
+      "title": "Añadir %{count} alimento(s)",
+      "location": "Ubicación",
+      "quantity": "Cantidad",
+      "unit": "Unidad",
+      "unitPrice": "Precio unitario",
+      "regDate": "Fecha de registro",
+      "expDate": "Fecha de caducidad",
+      "note": "Nota"
+    },
+    "addItem": {
+      "location": "Ubicación",
+      "quantity": "Cantidad",
+      "unit": "Unidad",
+      "price": "Precio",
+      "unitCost": "Costo unitario",
+      "totalCost": "Costo total",
+      "regDate": "Fecha de registro",
+      "expDate": "Fecha de caducidad",
+      "note": "Nota",
+      "addedTitle": "Añadido",
+      "addedMsg": "%{name} añadido a la lista de compras"
+    },
+    "deleteItemPrompt": "¿Seguro que deseas eliminar %{name}?"
+  },
+  "locations": {
+    "warningNotEmpty": "La ubicación contiene alimentos. Vacíe la ubicación antes de eliminarla.",
+    "inactive": "Inactiva",
+    "deactivate": "Desactivar",
+    "activate": "Activar",
+    "delete": "Eliminar",
+    "editTitle": "Editar ubicación",
+    "addTitle": "Añadir ubicación",
+    "namePlaceholder": "Nombre",
+    "save": "Guardar",
+    "add": "Añadir",
+    "deletePrompt": "¿Seguro que deseas eliminar esta ubicación?"
+  },
+  "recipes": {
+    "noImage": "Sin imagen",
+    "missing": "Faltan",
+    "meta": "Para %{persons} personas • Dificultad: %{difficulty}",
+    "detail": {
+      "notFound": "Receta no encontrada",
+      "ingredients": "Ingredientes",
+      "addToShopping": "Añadir a compras",
+      "missingPrompt": "¿Quieres añadir los siguientes ingredientes faltantes a la lista de compras?",
+      "addAllPrompt": "¿O deseas añadir todos los ingredientes?",
+      "addMissing": "Añadir faltantes",
+      "addAll": "Añadir todos",
+      "steps": "Pasos"
+    }
+    ,"add": {
+      "newTitle": "Nueva receta",
+      "editTitle": "Editar receta",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Ej. Pasta con salsa roja",
+      "imageLabel": "Foto",
+      "noImage": "Sin imagen",
+      "selectImage": "Seleccionar imagen",
+      "remove": "Quitar",
+      "urlPlaceholder": "o pega una URL",
+      "personsLabel": "Personas",
+      "difficultyLabel": "Dificultad",
+      "ingredientsLabel": "Ingredientes",
+      "addIngredient": "Añadir ingrediente",
+      "stepsLabel": "Pasos (admite Markdown)",
+      "stepsPlaceholder": "Usa **negrita**, - listas, 1. enumeraciones",
+      "errorTitle": "Revisa los datos",
+      "errorName": "Escribe el nombre de la receta.",
+      "errorIngredients": "Añade al menos un ingrediente.",
+      "chooseUnit": "Elegir unidad",
+      "accept": "Aceptar",
+      "difficulty": {"easy": "Fácil","medium": "Intermedio","hard": "Difícil"}
+    }
+  },
+  "savedLists": {
+    "untitled": "Sin título",
+    "totalCost": "Costo Total",
+    "items": "%{count} artículos",
+    "load": "Cargar",
+    "preview": "Previsualizar",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "deleteTitle": "Eliminar lista",
+    "deletePrompt": "¿Eliminar esta lista guardada?",
+    "list": "Lista",
+    "saveModal": {
+      "title": "Guardar lista",
+      "namePlaceholder": "Nombre",
+      "notePlaceholder": "Nota",
+      "cancel": "Cancelar",
+      "cancelSelection": "Cancelar selección",
+      "add": "Añadir",
+      "delete": "Eliminar",
+      "save": "Guardar"
+    }
+  },
+  "theme": {
+    "dark": "Oscuro Premium",
+    "light": "Claro",
+    "current": "Actual"
+  },
+  "units": {
+    "error": "Completa singular y plural.",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "editTitle": "Editar unidad",
+    "addTitle": "Añadir unidad",
+    "singularPlaceholder": "Singular",
+    "pluralPlaceholder": "Plural",
+    "update": "Actualizar",
+    "add": "Añadir",
+    "cancel": "Cancelar"
+  },
+  "userData": {
+    "syncTitle": "Sincronización",
+    "syncSubtitle": "Conecta tu cuenta de Google para guardar un respaldo en la nube.",
+    "connectedAs": "Conectado como %{email}",
+    "uploadBackup": "Subir respaldo",
+    "restoreBackup": "Restaurar respaldo",
+    "disconnect": "Desconectar cuenta",
+    "connectGoogle": "Conectar con Google",
+    "backupTitle": "Respaldo y datos",
+    "backupSubtitle": "Exporta o importa todos tus datos.",
+    "exportData": "Exportar datos",
+    "importData": "Importar datos",
+    "deleteTitle": "Eliminar todo",
+    "deleteSubtitle": "Esto borrará permanentemente todos los datos de usuario.",
+    "deleteData": "Eliminar todos los datos",
+    "uploadConfirmTitle": "Subir respaldo",
+    "uploadConfirmBody": "Se guardará en Google Drive una copia de tus datos y configuraciones actuales, reemplazando cualquier respaldo anterior. ¿Deseas continuar?",
+    "downloadConfirmTitle": "Restaurar respaldo",
+    "downloadConfirmBody": "Se reemplazarán todos los datos locales con la copia almacenada en Google Drive. Esta acción sobrescribirá tu información actual. ¿Deseas continuar?",
+    "exportConfirmTitle": "Exportar datos",
+    "exportConfirmBody": "¿Deseas exportar todos los datos de usuario?",
+    "resetConfirmTitle": "Eliminar todos los datos",
+    "resetConfirmBody": "Esta acción es permanente. ¿Deseas continuar?",
+    "googleSignInError": "No se pudo iniciar sesión con Google.",
+    "uploadSuccess": "Respaldo subido a Google Drive.",
+    "uploadError": "No se pudo subir el respaldo.",
+    "downloadError": "No se pudo restaurar el respaldo.",
+    "resetTitle": "Reinicio",
+    "resetMessage": "La aplicación se reiniciará",
+    "success": "Éxito",
+    "error": "Error",
+    "accept": "Aceptar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "ok": "OK",
+    "user": "usuario"
+  },
+  "defaultFood": {
+    "editTitle": "Editar alimento",
+    "nameLabel": "Nombre",
+    "expirationLabel": "Días de caducidad",
+    "unitLabel": "Unidad por defecto",
+    "priceLabel": "Precio unitario",
+    "cancel": "Cancelar",
+    "save": "Guardar"
+  },
+  "categories": {
+    "addTitle": "Nueva categoría",
+    "help": "Opcionalmente, agrega un icono personalizado.",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "Ej. Frutas",
+    "iconLabel": "Icono",
+    "noIcon": "Sin icono",
+    "pickImage": "Cargar imagen",
+    "removeImage": "Quitar",
+    "cancel": "Cancelar",
+    "save": "Guardar"
+  },
+  "foodPicker": {
+    "createNew": "Crear nuevo",
+    "searchPlaceholder": "Buscar alimento",
+    "manageDefaults": "Administrar alimentos predeterminados",
+    "manage": {
+      "title": "Lista completa de todos los alimentos predeterminados",
+      "hiddenNote": "Los alimentos sombreados no se mostrarán en la lista de agregar",
+      "holdNote": "Mantener presionado el alimento para editar más detalles"
+    }
+  }
+,  "datePicker": {
+    "placeholder": "AAAA-MM-DD"
+  },
+  "customFood": {
+    "manage": "Mis ingredientes",
+    "help": "Crea tus propios ingredientes. Usa iconos predeterminados o carga una imagen.",
+    "name": "Nombre",
+    "namePlaceholder": "Ej. Chimichurri",
+    "category": "Categoría",
+    "expirationDays": "Días de caducidad por defecto",
+    "defaultUnit": "Unidad por defecto",
+    "defaultPrice": "Precio unitario por defecto",
+    "icon": "Icono",
+    "noIcon": "Sin icono",
+    "default": "Predeterminado",
+    "upload": "Cargar",
+    "save": "Guardar"
   }
 }

--- a/MiAppNevera/src/screens/CategoryScreen.js
+++ b/MiAppNevera/src/screens/CategoryScreen.js
@@ -5,6 +5,7 @@ import FoodPickerModal from '../components/FoodPickerModal';
 import { useCategories } from '../context/CategoriesContext';
 import { getFoodInfo } from '../foodIcons';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function CategoryScreen({ route }) {
   const { category } = route.params;
@@ -12,6 +13,7 @@ export default function CategoryScreen({ route }) {
   const { categories } = useCategories();
   // subscribe to default food overrides so category list updates names
   const { overrides } = useDefaultFoods();
+  const { t } = useLanguage();
   const [quantity, setQuantity] = useState(1);
   const [search, setSearch] = useState('');
   const [pickerVisible, setPickerVisible] = useState(false);
@@ -39,7 +41,7 @@ export default function CategoryScreen({ route }) {
       </Text>
       <TextInput
         style={{ borderWidth: 1, padding: 5, marginBottom: 10 }}
-        placeholder="Buscar"
+        placeholder={t('system.inventory.searchPlaceholder')}
         value={search}
         onChangeText={setSearch}
       />
@@ -50,7 +52,7 @@ export default function CategoryScreen({ route }) {
           onChangeText={t => setQuantity(parseInt(t, 10) || 0)}
           keyboardType="numeric"
         />
-        <Button title="Añadir" onPress={() => setPickerVisible(true)} />
+        <Button title={t('system.inventory.add')} onPress={() => setPickerVisible(true)} />
       </View>
       <FoodPickerModal
         visible={pickerVisible}
@@ -92,7 +94,7 @@ export default function CategoryScreen({ route }) {
                   onPress={() => updateQuantity(category, idx, 1)}
                 />
                 <Button
-                  title="Eliminar"
+                  title={t('system.inventory.delete')}
                   onPress={() => removeItem(category, idx)}
                 />
               </View>

--- a/MiAppNevera/src/screens/CurrencySettingsScreen.js
+++ b/MiAppNevera/src/screens/CurrencySettingsScreen.js
@@ -3,10 +3,12 @@ import { View, Text, TouchableOpacity, StyleSheet, Platform, ScrollView } from '
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../context/ThemeContext';
 import { currencyOptions, useCurrencyController } from '../context/CurrencyContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function CurrencySettingsScreen() {
   const palette = useTheme();
   const { currencyKey, setCurrencyKey } = useCurrencyController();
+  const { t } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
 
@@ -26,7 +28,9 @@ export default function CurrencySettingsScreen() {
         {currencyOptions.map(c => (
           <TouchableOpacity key={c.key} style={styles.item} onPress={() => setCurrencyKey(c.key)}>
             <Text style={styles.itemTitle}>{`${c.label} (${c.symbol})`}</Text>
-            {currencyKey === c.key ? <Text style={styles.current}>Actual</Text> : null}
+            {currencyKey === c.key ? (
+              <Text style={styles.current}>{t('system.currency.current')}</Text>
+            ) : null}
           </TouchableOpacity>
         ))}
       </ScrollView>

--- a/MiAppNevera/src/screens/HomeScreen.js
+++ b/MiAppNevera/src/screens/HomeScreen.js
@@ -1,13 +1,27 @@
 import React from 'react';
 import { Button, View } from 'react-native';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function HomeScreen({ navigation }) {
+  const { t } = useLanguage();
   return (
     <View style={{ flex: 1, justifyContent: 'center', gap: 10, padding: 20 }}>
-      <Button title="Nevera" onPress={() => navigation.navigate('Fridge')} />
-      <Button title="Congelador" onPress={() => navigation.navigate('Freezer')} />
-      <Button title="Despensa" onPress={() => navigation.navigate('Pantry')} />
-      <Button title="Lista de compras" onPress={() => navigation.navigate('Shopping')} />
+      <Button
+        title={t('system.navigation.inventory')}
+        onPress={() => navigation.navigate('Fridge')}
+      />
+      <Button
+        title={t('system.navigation.freezer')}
+        onPress={() => navigation.navigate('Freezer')}
+      />
+      <Button
+        title={t('system.navigation.pantry')}
+        onPress={() => navigation.navigate('Pantry')}
+      />
+      <Button
+        title={t('system.navigation.shopping')}
+        onPress={() => navigation.navigate('Shopping')}
+      />
     </View>
   );
 }

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -465,7 +465,7 @@ export default function InventoryScreen({ navigation }) {
                     )}
                     <Text style={{ fontSize: 14, color: palette.text }}>
                       {groupBy === 'category'
-                        ? (categories[cat]?.name || cat.charAt(0).toUpperCase() + cat.slice(1))
+                        ? (categories[cat]?.name || (cat === 'otros' ? t('system.inventory.otherCategory') : cat.charAt(0).toUpperCase() + cat.slice(1)))
                         : groupBy === 'registered'
                           ? (cat === UNREGISTERED_KEY ? t('system.inventory.unregistered') : cat)
                           : cat}

--- a/MiAppNevera/src/screens/LocationSettingsScreen.js
+++ b/MiAppNevera/src/screens/LocationSettingsScreen.js
@@ -15,6 +15,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useLocations } from '../context/LocationsContext';
 import { useInventory } from '../context/InventoryContext';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 const icons = ['🥶','❄️','🗃️','📦','🍽️','🧊','🥫','🥕','🥩','🥛'];
 
@@ -22,15 +23,16 @@ export default function LocationSettingsScreen() {
   const palette = useTheme();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
+  const { t } = useLanguage();
   useLayoutEffect(() => {
     nav.setOptions?.({
       headerStyle: { backgroundColor: palette.surface },
       headerTintColor: palette.text,
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
-      title: 'Ubicaciones',
+      title: t('system.navigation.locationSettings'),
     });
-  }, [nav, palette]);
+  }, [nav, palette, t]);
 
   const { locations, addLocation, updateLocation, removeLocation, toggleActive } = useLocations();
   const { inventory } = useInventory();
@@ -55,7 +57,7 @@ export default function LocationSettingsScreen() {
 
   const handleRemove = key => {
     if (inventory[key] && inventory[key].length > 0) {
-      setWarning('La ubicación contiene alimentos. Vacíe la ubicación antes de eliminarla.');
+      setWarning(t('system.locations.warningNotEmpty'));
       setPendingKey(null);
       setConfirmVisible(true);
       return;
@@ -72,16 +74,16 @@ export default function LocationSettingsScreen() {
           <Text style={{ fontSize: 18 }}>{item.icon}</Text>  {item.name}
           <Text style={styles.rowSub}>  • {item.key}</Text>
         </Text>
-        {!item.active && <Text style={[styles.badge, { color: '#ffcc80' }]}>Inactiva</Text>}
+        {!item.active && <Text style={[styles.badge, { color: '#ffcc80' }]}>{t('system.locations.inactive')}</Text>}
       </TouchableOpacity>
       <View style={{ flexDirection: 'row' }}>
         <TouchableOpacity style={[styles.smallBtn, item.active ? null : styles.smallBtnAccent]} onPress={() => toggleActive(item.key)}>
           <Text style={item.active ? styles.smallBtnText : styles.smallBtnAccentText}>
-            {item.active ? 'Desactivar' : 'Activar'}
+            {item.active ? t('system.locations.deactivate') : t('system.locations.activate')}
           </Text>
         </TouchableOpacity>
         <TouchableOpacity style={[styles.smallBtn, styles.smallBtnDanger]} onPress={() => handleRemove(item.key)}>
-          <Text style={styles.smallBtnDangerText}>Eliminar</Text>
+          <Text style={styles.smallBtnDangerText}>{t('system.locations.delete')}</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -100,9 +102,9 @@ export default function LocationSettingsScreen() {
 
       {/* Editor */}
       <View style={styles.editor}>
-        <Text style={styles.editorTitle}>{editingKey ? 'Editar ubicación' : 'Añadir ubicación'}</Text>
+        <Text style={styles.editorTitle}>{editingKey ? t('system.locations.editTitle') : t('system.locations.addTitle')}</Text>
         <TextInput
-          placeholder="Nombre"
+          placeholder={t('system.locations.namePlaceholder')}
           placeholderTextColor={palette.textDim}
           value={name}
           onChangeText={setName}
@@ -130,11 +132,11 @@ export default function LocationSettingsScreen() {
               }
             }}
           >
-            <Text style={styles.primaryBtnText}>{editingKey ? 'Guardar' : 'Añadir'}</Text>
+            <Text style={styles.primaryBtnText}>{editingKey ? t('system.locations.save') : t('system.locations.add')}</Text>
           </TouchableOpacity>
           {editingKey ? (
             <TouchableOpacity style={[styles.btn, { flex: 1, marginLeft: 10 }]} onPress={cancelEdit}>
-              <Text style={styles.btnText}>Cancelar</Text>
+              <Text style={styles.btnText}>{t('system.inventory.cancel')}</Text>
             </TouchableOpacity>
           ) : null}
         </View>
@@ -154,20 +156,18 @@ export default function LocationSettingsScreen() {
                 {warning ? (
                   <Text style={styles.modalBody}>{warning}</Text>
                 ) : (
-                  <Text style={styles.modalBody}>
-                    ¿Seguro que deseas eliminar esta ubicación?
-                  </Text>
+                  <Text style={styles.modalBody}>{t('system.locations.deletePrompt')}</Text>
                 )}
                 <View style={styles.modalRow}>
                   <TouchableOpacity style={[styles.btn, { flex: 1 }]} onPress={() => setConfirmVisible(false)}>
-                    <Text style={styles.btnText}>Cancelar</Text>
+                    <Text style={styles.btnText}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   {!warning && (
                     <TouchableOpacity
                       style={[styles.dangerBtn, { flex: 1, marginLeft: 12 }]}
                       onPress={() => { removeLocation(pendingKey); setConfirmVisible(false); }}
                     >
-                      <Text style={styles.dangerBtnText}>Eliminar</Text>
+                      <Text style={styles.dangerBtnText}>{t('system.locations.delete')}</Text>
                     </TouchableOpacity>
                   )}
                 </View>

--- a/MiAppNevera/src/screens/RecipeBookScreen.js
+++ b/MiAppNevera/src/screens/RecipeBookScreen.js
@@ -7,6 +7,7 @@ import AddRecipeModal from '../components/AddRecipeModal';
 import { useLocations } from '../context/LocationsContext';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function RecipeBookScreen({ navigation }) {
   const palette = useTheme();
@@ -16,6 +17,7 @@ export default function RecipeBookScreen({ navigation }) {
   const { inventory } = useInventory();
   const { locations } = useLocations();
   const [addVisible, setAddVisible] = useState(false);
+  const { t } = useLanguage();
 
   useLayoutEffect(() => {
     nav.setOptions?.({
@@ -23,14 +25,14 @@ export default function RecipeBookScreen({ navigation }) {
       headerTintColor: palette.text,
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
-      title: 'Recetario',
+      title: t('system.navigation.recipes'),
       headerRight: () => (
         <TouchableOpacity onPress={() => setAddVisible(true)} style={styles.headerIconBtn}>
           <Text style={styles.headerIconTxt}>＋</Text>
         </TouchableOpacity>
       ),
     });
-  }, [nav, palette]);
+  }, [nav, palette, t]);
 
   const hasIngredients = (recipe) => {
     return recipe.ingredients.every((ing) => {
@@ -62,13 +64,13 @@ export default function RecipeBookScreen({ navigation }) {
                   <Image source={{ uri: rec.image }} style={styles.thumb} resizeMode="cover" />
                 ) : (
                   <View style={styles.thumbPlaceholder}>
-                    <Text style={{ color: palette.textDim }}>Sin imagen</Text>
+                    <Text style={{ color: palette.textDim }}>{t('system.recipes.noImage')}</Text>
                   </View>
                 )}
-                {!enough && <Text style={styles.badge}>Faltan</Text>}
+                {!enough && <Text style={styles.badge}>{t('system.recipes.missing')}</Text>}
               </View>
               <Text style={styles.cardTitle} numberOfLines={2}>{rec.name}</Text>
-              <Text style={styles.cardMeta}>Para {rec.persons} personas • Dificultad: {rec.difficulty}</Text>
+              <Text style={styles.cardMeta}>{t('system.recipes.meta', { persons: rec.persons, difficulty: rec.difficulty })}</Text>
             </TouchableOpacity>
           );
         })}

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -22,6 +22,7 @@ import { useLocations } from '../context/LocationsContext';
 import { useCategories } from '../context/CategoriesContext';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function RecipeDetailScreen({ route }) {
   const palette = useTheme();
@@ -37,6 +38,7 @@ export default function RecipeDetailScreen({ route }) {
   const { categories } = useCategories();
   const [editVisible, setEditVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
+  const { t } = useLanguage();
 
   const groupedIngredients = useMemo(() => {
     if (!recipe) return {};
@@ -71,7 +73,7 @@ export default function RecipeDetailScreen({ route }) {
       headerTintColor: palette.text,
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
-      title: recipe ? recipe.name : 'Receta',
+      title: recipe ? recipe.name : t('system.navigation.recipe'),
       headerRight: () => (
         <View style={{ flexDirection: 'row' }}>
           <TouchableOpacity onPress={() => setEditVisible(true)} style={[styles.iconBtn, { marginRight: 8 }]}>
@@ -86,12 +88,12 @@ export default function RecipeDetailScreen({ route }) {
         </View>
       ),
     });
-  }, [nav, missing, recipe, palette]);
+  }, [nav, missing, recipe, palette, t]);
 
   if (!recipe) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: palette.bg }}>
-        <Text style={{ color: palette.textDim }}>Receta no encontrada</Text>
+        <Text style={{ color: palette.textDim }}>{t('system.recipes.detail.notFound')}</Text>
       </View>
     );
   }
@@ -111,14 +113,13 @@ export default function RecipeDetailScreen({ route }) {
           />
         ) : null}
         <Text style={styles.title}>{recipe.name}</Text>
-        <Text style={styles.meta}>Para {recipe.persons} personas • Dificultad: {recipe.difficulty}</Text>
-
-        <Text style={styles.blockTitle}>Ingredientes</Text>
+        <Text style={styles.meta}>{t('system.recipes.meta', { persons: recipe.persons, difficulty: recipe.difficulty })}</Text>
+        <Text style={styles.blockTitle}>{t('system.recipes.detail.ingredients')}</Text>
         {groupedOrder.map((cat) => (
           <View key={cat} style={styles.section}>
             <View style={styles.sectionHeader}>
               {categories[cat]?.icon && <Image source={categories[cat].icon} style={styles.catIcon} />}
-              <Text style={styles.sectionTitle}>{categories[cat]?.name || cat}</Text>
+              <Text style={styles.sectionTitle}>{categories[cat]?.name || (cat === 'otros' ? t('system.inventory.otherCategory') : cat)}</Text>
             </View>
             {groupedIngredients[cat].map((ing, idx) => {
               const icon = ing.icon || getFoodIcon(ing.name);
@@ -136,7 +137,7 @@ export default function RecipeDetailScreen({ route }) {
           </View>
         ))}
 
-        <Text style={styles.blockTitle}>Pasos</Text>
+        <Text style={styles.blockTitle}>{t('system.recipes.detail.steps')}</Text>
         <Markdown
           style={{
             body: { color: palette.text, lineHeight: 20 },
@@ -173,8 +174,8 @@ export default function RecipeDetailScreen({ route }) {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.modalCard}>
-                <Text style={styles.modalTitle}>Añadir a compras</Text>
-                <Text style={styles.modalBody}>¿Quieres añadir los siguientes ingredientes faltantes a la lista de compras?</Text>
+                <Text style={styles.modalTitle}>{t('system.recipes.detail.addToShopping')}</Text>
+                <Text style={styles.modalBody}>{t('system.recipes.detail.missingPrompt')}</Text>
                 <View style={{ maxHeight: 220 }}>
                   <ScrollView>
                     {missing.map((ing, idx) => (
@@ -191,10 +192,10 @@ export default function RecipeDetailScreen({ route }) {
                     ))}
                   </ScrollView>
                 </View>
-                <Text style={[styles.modalBody, { marginTop: 8 }]}>¿O deseas añadir <Text style={{ color: palette.accent, fontWeight: '700' }}>todos</Text> los ingredientes?</Text>
+                <Text style={[styles.modalBody, { marginTop: 8 }]}>{t('system.recipes.detail.addAllPrompt')}</Text>
                 <View style={styles.modalRow}>
                   <TouchableOpacity onPress={() => setConfirmVisible(false)} style={[styles.modalBtn, { backgroundColor: palette.surface3 }]}>
-                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                    <Text style={{ color: palette.text }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity
                     onPress={() => {
@@ -203,7 +204,7 @@ export default function RecipeDetailScreen({ route }) {
                     }}
                     style={[styles.modalBtn, { backgroundColor: palette.accent }]}
                   >
-                    <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Añadir faltantes</Text>
+                    <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.recipes.detail.addMissing')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity
                     onPress={() => {
@@ -212,7 +213,7 @@ export default function RecipeDetailScreen({ route }) {
                     }}
                     style={[styles.modalBtn, { backgroundColor: palette.selected, borderColor: palette.frame }]}
                   >
-                    <Text style={{ color: palette.accent, fontWeight: '700' }}>Añadir todos</Text>
+                    <Text style={{ color: palette.accent, fontWeight: '700' }}>{t('system.recipes.detail.addAll')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>

--- a/MiAppNevera/src/screens/SavedListsScreen.js
+++ b/MiAppNevera/src/screens/SavedListsScreen.js
@@ -6,6 +6,7 @@ import SaveListModal from '../components/SaveListModal';
 import ListPreviewModal from '../components/ListPreviewModal';
 import { useTheme } from '../context/ThemeContext';
 import { useCurrency } from '../context/CurrencyContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function SavedListsScreen({ navigation }) {
   const { savedLists, deleteList, saveList } = useSavedLists();
@@ -13,6 +14,7 @@ export default function SavedListsScreen({ navigation }) {
   const palette = useTheme();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const { symbol } = useCurrency();
+  const { t } = useLanguage();
 
   const [editing, setEditing] = useState(null);
   const [previewing, setPreviewing] = useState(null);
@@ -26,11 +28,11 @@ export default function SavedListsScreen({ navigation }) {
           return (
             <View key={list.id} style={styles.card}>
               <View style={styles.headerRow}>
-                <Text style={styles.title}>{list.name || 'Sin título'}</Text>
-                <Text style={styles.total}>{`Costo Total: ${symbol}${totalCost.toFixed(2)}`}</Text>
+                <Text style={styles.title}>{list.name || t('system.savedLists.untitled')}</Text>
+                <Text style={styles.total}>{`${t('system.savedLists.totalCost')}: ${symbol}${totalCost.toFixed(2)}`}</Text>
               </View>
               {list.note ? <Text style={styles.note}>{list.note}</Text> : null}
-              <Text style={styles.count}>{list.items?.length || 0} artículos</Text>
+              <Text style={styles.count}>{t('system.savedLists.items', { count: list.items?.length || 0 })}</Text>
               <View style={styles.actions}>
                 <TouchableOpacity
                   style={[styles.actionBtn, { backgroundColor: palette.accent }]}
@@ -39,19 +41,19 @@ export default function SavedListsScreen({ navigation }) {
                     navigation.navigate('Shopping');
                   }}
                 >
-                  <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Cargar</Text>
+                  <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.savedLists.load')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity style={styles.actionBtn} onPress={() => setPreviewing(list)}>
-                  <Text style={styles.actionText}>Previsualizar</Text>
+                  <Text style={styles.actionText}>{t('system.savedLists.preview')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity style={styles.actionBtn} onPress={() => setEditing(list)}>
-                  <Text style={styles.actionText}>Editar</Text>
+                  <Text style={styles.actionText}>{t('system.savedLists.edit')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={[styles.actionBtn, { backgroundColor: palette.danger }]}
                   onPress={() => setConfirmDel(list.id)}
                 >
-                  <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                  <Text style={{ color: '#fff', fontWeight: '700' }}>{t('system.savedLists.delete')}</Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -83,11 +85,11 @@ export default function SavedListsScreen({ navigation }) {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.cardModal}>
-                <Text style={styles.modalTitle}>Eliminar lista</Text>
-                <Text style={styles.modalBody}>¿Eliminar esta lista guardada?</Text>
+                <Text style={styles.modalTitle}>{t('system.savedLists.deleteTitle')}</Text>
+                <Text style={styles.modalBody}>{t('system.savedLists.deletePrompt')}</Text>
                 <View style={styles.modalActions}>
                   <TouchableOpacity style={[styles.modalBtn, { backgroundColor: palette.surface3 }]} onPress={() => setConfirmDel(null)}>
-                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                    <Text style={{ color: palette.text }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity
                     style={[styles.modalBtn, { backgroundColor: palette.danger }]}
@@ -96,7 +98,7 @@ export default function SavedListsScreen({ navigation }) {
                       setConfirmDel(null);
                     }}
                   >
-                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>{t('system.savedLists.delete')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>

--- a/MiAppNevera/src/screens/ShoppingListScreen.js
+++ b/MiAppNevera/src/screens/ShoppingListScreen.js
@@ -32,11 +32,13 @@ import { useCurrency } from '../context/CurrencyContext';
 import { getFoodIcon, getFoodInfo } from '../foodIcons';
 import CostPieChart from '../components/CostPieChart';
 import { useDefaultFoods } from '../context/DefaultFoodsContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function ShoppingListScreen() {
   const palette = useTheme();
   const { symbol } = useCurrency();
   const styles = useMemo(() => createStyles(palette), [palette]);
+  const { t } = useLanguage();
   const navigation = useNavigation();
   useLayoutEffect(() => {
     navigation.setOptions?.({
@@ -274,7 +276,7 @@ export default function ShoppingListScreen() {
         {!selectMode ? (
           <View style={styles.headerActions}>
             <TouchableOpacity style={styles.actionBtn} onPress={() => setPickerVisible(true)}>
-              <Text style={styles.actionText}>＋ Añadir</Text>
+              <Text style={styles.actionText}>＋ {t('system.shopping.addFood')}</Text>
             </TouchableOpacity>
             <View style={{ flexDirection: 'row' }}>
               <TouchableOpacity style={[styles.iconBtn, { marginLeft: 8 }]} onPress={() => setAutoVisible(true)}>
@@ -294,27 +296,27 @@ export default function ShoppingListScreen() {
         ) : (
           <View style={styles.headerActions}>
             <TouchableOpacity style={styles.actionBtn} onPress={selectAll}>
-              <Text style={styles.actionText}>Seleccionar todo</Text>
+              <Text style={styles.actionText}>{t('system.shopping.selectAll')}</Text>
             </TouchableOpacity>
             {selected.length === 1 && (
               <TouchableOpacity
                 style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]}
                 onPress={() => setEditIdx(selected[0])}
               >
-                <Text style={[styles.actionText, { color: palette.accent }]}>Editar</Text>
+                <Text style={[styles.actionText, { color: palette.accent }]}>{t('system.shopping.edit')}</Text>
               </TouchableOpacity>
             )}
             <TouchableOpacity
               style={[styles.actionBtn, { backgroundColor: palette.surface3, borderColor: palette.border }]}
               onPress={() => setBatchVisible(true)}
             >
-              <Text style={[styles.actionText, { color: palette.accent }]}>Guardar</Text>
+              <Text style={[styles.actionText, { color: palette.accent }]}>{t('system.shopping.save')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.actionBtn, { backgroundColor: palette.danger, borderColor: '#ad2c2c' }]}
               onPress={() => setConfirmVisible(true)}
             >
-              <Text style={[styles.actionText, { color: '#fff' }]}>Eliminar</Text>
+              <Text style={[styles.actionText, { color: '#fff' }]}>{t('system.inventory.delete')}</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -328,9 +330,9 @@ export default function ShoppingListScreen() {
       >
         {empty ? (
           <View style={styles.emptyWrap}>
-            <Text style={{ color: palette.textDim, marginBottom: 8 }}>Tu lista de compras está vacía</Text>
+            <Text style={{ color: palette.textDim, marginBottom: 8 }}>{t('system.shopping.empty')}</Text>
             <TouchableOpacity onPress={() => setPickerVisible(true)} style={styles.emptyBtn}>
-              <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Añadir alimento</Text>
+              <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.shopping.addFood')}</Text>
             </TouchableOpacity>
           </View>
         ) : (
@@ -398,13 +400,13 @@ export default function ShoppingListScreen() {
             ))}
             <View style={styles.section}>
               <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>Detalles de lista de compra</Text>
+                <Text style={styles.sectionTitle}>{t('system.shopping.detailsTitle')}</Text>
               </View>
               <View style={styles.detailsRow}>
                 <TouchableOpacity style={styles.actionBtn} onPress={() => setDetailsVisible(true)}>
-                  <Text style={styles.actionText}>Más detalles</Text>
+                  <Text style={styles.actionText}>{t('system.shopping.moreDetails')}</Text>
                 </TouchableOpacity>
-                <Text style={styles.totalText}>{`Costo Total: ${symbol}${totalCost.toFixed(2)}`}</Text>
+                <Text style={styles.totalText}>{`${t('system.shopping.totalCost')}: ${symbol}${totalCost.toFixed(2)}`}</Text>
               </View>
             </View>
           </>
@@ -473,7 +475,7 @@ export default function ShoppingListScreen() {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={[styles.card, { alignItems: 'center' }]}> 
-                <Text style={[styles.cardTitle, { marginBottom: 16 }]}>Distribución de costos</Text>
+                <Text style={[styles.cardTitle, { marginBottom: 16 }]}>{t('system.shopping.costDistribution')}</Text>
                 {totalCost > 0 ? (
                   <>
                     <CostPieChart data={chartData} size={200} />
@@ -491,7 +493,7 @@ export default function ShoppingListScreen() {
                     </View>
                   </>
                 ) : (
-                  <Text style={{ color: palette.textDim }}>Sin datos de costo</Text>
+                  <Text style={{ color: palette.textDim }}>{t('system.shopping.noCostData')}</Text>
                 )}
               </View>
             </TouchableWithoutFeedback>
@@ -510,16 +512,16 @@ export default function ShoppingListScreen() {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.card}>
-                <Text style={styles.cardTitle}>Eliminar seleccionados</Text>
+                <Text style={styles.cardTitle}>{t('system.shopping.deleteSelectedTitle')}</Text>
                 <Text style={styles.cardBody}>
-                  ¿Eliminar {selected.length} {selected.length === 1 ? 'alimento' : 'alimentos'} de la lista de compras?
+                  {t('system.shopping.deleteSelectedPrompt', { count: selected.length })}
                 </Text>
                 <View style={styles.cardActions}>
                   <TouchableOpacity onPress={() => setConfirmVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
-                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                    <Text style={{ color: palette.text }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={deleteSelected} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
-                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>{t('system.inventory.delete')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -539,14 +541,14 @@ export default function ShoppingListScreen() {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.card}>
-                <Text style={styles.cardTitle}>Limpiar lista</Text>
-                <Text style={styles.cardBody}>¿Eliminar todos los alimentos de la lista de compras?</Text>
+                <Text style={styles.cardTitle}>{t('system.shopping.clearTitle')}</Text>
+                <Text style={styles.cardBody}>{t('system.shopping.clearPrompt')}</Text>
                 <View style={styles.cardActions}>
                   <TouchableOpacity onPress={() => setClearVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
-                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                    <Text style={{ color: palette.text }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={clearAll} style={[styles.cardBtn, { backgroundColor: palette.danger }]}>
-                    <Text style={{ color: '#fff', fontWeight: '700' }}>Eliminar</Text>
+                    <Text style={{ color: '#fff', fontWeight: '700' }}>{t('system.inventory.delete')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -566,16 +568,14 @@ export default function ShoppingListScreen() {
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.card}>
-                <Text style={styles.cardTitle}>Añadir automáticamente</Text>
-                <Text style={styles.cardBody}>
-                  ¿Deseas añadir todos los alimentos con cantidad 0 del inventario a la lista de compras? Los que ya estén en la lista no se agregarán.
-                </Text>
+                <Text style={styles.cardTitle}>{t('system.shopping.autoAddTitle')}</Text>
+                <Text style={styles.cardBody}>{t('system.shopping.autoAddPrompt')}</Text>
                 <View style={styles.cardActions}>
                   <TouchableOpacity onPress={() => setAutoVisible(false)} style={[styles.cardBtn, { backgroundColor: palette.surface3 }]}>
-                    <Text style={{ color: palette.text }}>Cancelar</Text>
+                    <Text style={{ color: palette.text }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
                   <TouchableOpacity onPress={handleAutoAdd} style={[styles.cardBtn, { backgroundColor: palette.accent }]}>
-                    <Text style={{ color: '#1b1d22', fontWeight: '700' }}>Aceptar</Text>
+                    <Text style={{ color: '#1b1d22', fontWeight: '700' }}>{t('system.inventory.confirm')}</Text>
                   </TouchableOpacity>
                 </View>
               </View>

--- a/MiAppNevera/src/screens/ThemeSettingsScreen.js
+++ b/MiAppNevera/src/screens/ThemeSettingsScreen.js
@@ -2,25 +2,28 @@ import React, { useLayoutEffect, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme, useThemeController } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function ThemeSettingsScreen() {
   const palette = useTheme();
   const { themeName, setThemeName } = useThemeController();
+  const { t, lang } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
 
   useLayoutEffect(() => {
     nav.setOptions?.({
+      title: t('system.navigation.themeSettings'),
       headerStyle: { backgroundColor: palette.surface },
       headerTintColor: palette.text,
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [nav, palette]);
+  }, [nav, palette, t, lang]);
 
   const themes = [
-    { key: 'dark', label: 'Dark Premium' },
-    { key: 'light', label: 'Claro' },
+    { key: 'dark', label: t('system.theme.dark') },
+    { key: 'light', label: t('system.theme.light') },
   ];
 
   return (
@@ -30,7 +33,7 @@ export default function ThemeSettingsScreen() {
         {themes.map(t => (
           <TouchableOpacity key={t.key} style={styles.item} onPress={() => setThemeName(t.key)}>
             <Text style={styles.itemTitle}>{t.label}</Text>
-            {themeName === t.key ? <Text style={styles.current}>Actual</Text> : null}
+            {themeName === t.key ? <Text style={styles.current}>{t('system.theme.current')}</Text> : null}
           </TouchableOpacity>
         ))}
       </ScrollView>

--- a/MiAppNevera/src/screens/UnitSettingsScreen.js
+++ b/MiAppNevera/src/screens/UnitSettingsScreen.js
@@ -5,19 +5,22 @@ import { View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet, Platform
 import { useNavigation } from '@react-navigation/native';
 import { useUnits } from '../context/UnitsContext';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function UnitSettingsScreen() {
   const palette = useTheme();
+  const { t, lang } = useLanguage();
   const styles = useMemo(() => createStyles(palette), [palette]);
   const nav = useNavigation();
   useLayoutEffect(() => {
     nav.setOptions?.({
+      title: t('system.navigation.unitSettings'),
       headerStyle: { backgroundColor: palette.surface },
       headerTintColor: palette.text,
       headerTitleStyle: { color: palette.text },
       headerShadowVisible: false,
     });
-  }, [nav, palette]);
+  }, [nav, palette, t, lang]);
 
   const { units, addUnit, updateUnit, removeUnit } = useUnits();
   const [singular, setSingular] = useState('');
@@ -31,7 +34,7 @@ export default function UnitSettingsScreen() {
   const onSubmit = () => {
     const s = (singular || '').trim();
     const p = (plural || '').trim();
-    if (!s || !p) { setError('Completa singular y plural.'); return; }
+    if (!s || !p) { setError(t('system.units.error')); return; }
     if (editingKey) { updateUnit(editingKey, s, p); cancelEdit(); }
     else { addUnit(s, p); setSingular(''); setPlural(''); setError(''); }
   };
@@ -43,11 +46,11 @@ export default function UnitSettingsScreen() {
         <Text style={styles.rowSub}>{item.key}</Text>
       </View>
       <TouchableOpacity style={styles.smallBtn} onPress={() => startEdit(item)}>
-        <Text style={styles.smallBtnText}>✏️ Editar</Text>
+        <Text style={styles.smallBtnText}>✏️ {t('system.units.edit')}</Text>
       </TouchableOpacity>
-        <TouchableOpacity style={[styles.smallBtn, styles.smallBtnDanger, { marginLeft: 8 }]} onPress={() => removeUnit(item.key)}>
-          <Text style={styles.smallBtnDangerText}>🗑️ Eliminar</Text>
-        </TouchableOpacity>
+      <TouchableOpacity style={[styles.smallBtn, styles.smallBtnDanger, { marginLeft: 8 }]} onPress={() => removeUnit(item.key)}>
+        <Text style={styles.smallBtnDangerText}>🗑️ {t('system.units.delete')}</Text>
+      </TouchableOpacity>
       </View>
     );
 
@@ -63,20 +66,30 @@ export default function UnitSettingsScreen() {
       />
 
       <View style={styles.editor}>
-        <Text style={styles.editorTitle}>{editingKey ? 'Editar unidad' : 'Añadir unidad'}</Text>
-        <TextInput placeholder="Singular" placeholderTextColor={palette.textDim} value={singular}
-          onChangeText={t => { setSingular(t); setError(''); }} style={styles.input} />
-        <TextInput placeholder="Plural" placeholderTextColor={palette.textDim} value={plural}
-          onChangeText={t => { setPlural(t); setError(''); }} style={styles.input} />
+        <Text style={styles.editorTitle}>{editingKey ? t('system.units.editTitle') : t('system.units.addTitle')}</Text>
+        <TextInput
+          placeholder={t('system.units.singularPlaceholder')}
+          placeholderTextColor={palette.textDim}
+          value={singular}
+          onChangeText={txt => { setSingular(txt); setError(''); }}
+          style={styles.input}
+        />
+        <TextInput
+          placeholder={t('system.units.pluralPlaceholder')}
+          placeholderTextColor={palette.textDim}
+          value={plural}
+          onChangeText={txt => { setPlural(txt); setError(''); }}
+          style={styles.input}
+        />
         {error ? <Text style={styles.error}>{error}</Text> : null}
 
         <View style={{ flexDirection: 'row', marginTop: 6 }}>
           <TouchableOpacity style={[styles.primaryBtn, { flex: 1 }]} onPress={onSubmit}>
-            <Text style={styles.primaryBtnText}>{editingKey ? 'Actualizar' : 'Añadir'}</Text>
+            <Text style={styles.primaryBtnText}>{editingKey ? t('system.units.update') : t('system.units.add')}</Text>
           </TouchableOpacity>
           {editingKey ? (
             <TouchableOpacity style={[styles.btn, { flex: 1, marginLeft: 10 }]} onPress={cancelEdit}>
-              <Text style={styles.btnText}>Cancelar</Text>
+              <Text style={styles.btnText}>{t('system.units.cancel')}</Text>
             </TouchableOpacity>
           ) : null}
         </View>


### PR DESCRIPTION
## Summary
- localize inventory item modal with translated labels and success alerts
- translate food picker controls and management tips
- expand English and Spanish locale files and adjust shopping add button
- fix AddRecipeModal syntax by closing translation text tag
- define translation hooks in custom and batch item modals to avoid runtime errors
- hook edit-item modal into language context and translate shopping/deletion alerts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab81bd7f608324a5a3967eb734cff8