### PR TITLE
feat: translate units and locations

### DIFF
--- a/MiAppNevera/src/context/LocationsContext.js
+++ b/MiAppNevera/src/context/LocationsContext.js
@@ -1,15 +1,29 @@
 import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useLanguage } from './LanguageContext';
+import esDefaults from '../locales/es/defaults.json';
+import enDefaults from '../locales/en/defaults.json';
 
-const defaultLocations = [
-  { key: 'fridge', name: 'Nevera', icon: '🥶', active: true },
-  { key: 'freezer', name: 'Congelador', icon: '❄️', active: true },
-  { key: 'pantry', name: 'Despensa', icon: '🗃️', active: true },
+const baseLocations = [
+  { key: 'fridge', icon: '🥶', active: true },
+  { key: 'freezer', icon: '❄️', active: true },
+  { key: 'pantry', icon: '🗃️', active: true },
 ];
+
+const defaultLocations = baseLocations.map(l => ({
+  ...l,
+  name: { es: esDefaults.locations[l.key], en: enDefaults.locations[l.key] },
+}));
+
+const defaultLocationMap = defaultLocations.reduce((acc, l) => {
+  acc[l.key] = l;
+  return acc;
+}, {});
 
 const LocationsContext = createContext();
 
 export const LocationsProvider = ({ children }) => {
+  const { lang } = useLanguage();
   const [locations, setLocations] = useState(defaultLocations);
 
   useEffect(() => {
@@ -18,7 +32,20 @@ export const LocationsProvider = ({ children }) => {
         try {
           const parsed = JSON.parse(stored);
           if (Array.isArray(parsed) && parsed.length > 0) {
-            setLocations(parsed);
+            const upgraded = parsed.map(l => {
+              const def = defaultLocationMap[l.key];
+              let name;
+              if (typeof l.name === 'string') {
+                name = { es: l.name, en: def?.name.en || l.name };
+              } else {
+                name = {
+                  es: l.name.es || def?.name.es || '',
+                  en: l.name.en || def?.name.en || l.name.es || '',
+                };
+              }
+              return { ...def, ...l, name };
+            });
+            setLocations(upgraded);
           }
         } catch (e) {
           console.error('Failed to parse locations', e);
@@ -35,11 +62,18 @@ export const LocationsProvider = ({ children }) => {
 
   const addLocation = useCallback((name, icon) => {
     const key = name.toLowerCase();
-    setLocations(prev => [...prev, { key, name, icon, active: true }]);
+    setLocations(prev => [
+      ...prev,
+      { key, name: { es: name, en: name }, icon, active: true },
+    ]);
   }, []);
 
   const updateLocation = useCallback((key, name, icon) => {
-    setLocations(prev => prev.map(l => (l.key === key ? { ...l, name, icon } : l)));
+    setLocations(prev =>
+      prev.map(l =>
+        l.key === key ? { ...l, name: { es: name, en: name }, icon } : l,
+      ),
+    );
   }, []);
 
   const removeLocation = useCallback(key => {
@@ -57,9 +91,18 @@ export const LocationsProvider = ({ children }) => {
     });
   }, []);
 
+  const localizedLocations = useMemo(
+    () =>
+      locations.map(l => ({
+        ...l,
+        name: typeof l.name === 'string' ? l.name : l.name[lang] || l.name.es,
+      })),
+    [locations, lang],
+  );
+
   const value = useMemo(
-    () => ({ locations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations }),
-    [locations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations],
+    () => ({ locations: localizedLocations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations }),
+    [localizedLocations, addLocation, updateLocation, removeLocation, toggleActive, resetLocations],
   );
 
   return (

--- a/MiAppNevera/src/context/UnitsContext.js
+++ b/MiAppNevera/src/context/UnitsContext.js
@@ -1,15 +1,24 @@
 import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useLanguage } from './LanguageContext';
+import esDefaults from '../locales/es/defaults.json';
+import enDefaults from '../locales/en/defaults.json';
 
-const defaultUnits = [
-  { key: 'units', singular: 'Unidad', plural: 'Unidades' },
-  { key: 'kg', singular: 'Kilo', plural: 'Kilos' },
-  { key: 'l', singular: 'Litro', plural: 'Litros' },
-];
+const defaultUnits = Object.keys(esDefaults.units).map(key => ({
+  key,
+  singular: { es: esDefaults.units[key].singular, en: enDefaults.units[key].singular },
+  plural: { es: esDefaults.units[key].plural, en: enDefaults.units[key].plural },
+}));
+
+const defaultUnitMap = defaultUnits.reduce((acc, u) => {
+  acc[u.key] = u;
+  return acc;
+}, {});
 
 const UnitsContext = createContext();
 
 export const UnitsProvider = ({ children }) => {
+  const { lang } = useLanguage();
   const [units, setUnits] = useState(defaultUnits);
 
   useEffect(() => {
@@ -18,7 +27,22 @@ export const UnitsProvider = ({ children }) => {
         try {
           const parsed = JSON.parse(stored);
           if (Array.isArray(parsed) && parsed.length > 0) {
-            setUnits(parsed);
+            const upgraded = parsed.map(u => {
+              const def = defaultUnitMap[u.key];
+              const normalize = (form, defForm) => {
+                if (typeof form === 'string') {
+                  return { es: form, en: defForm?.en || form };
+                }
+                return {
+                  es: form.es || defForm?.es || '',
+                  en: form.en || defForm?.en || form.es || '',
+                };
+              };
+              const singular = normalize(u.singular, def?.singular);
+              const plural = normalize(u.plural, def?.plural);
+              return { ...def, ...u, singular, plural };
+            });
+            setUnits(upgraded);
           }
         } catch (e) {
           console.error('Failed to parse units', e);
@@ -35,22 +59,44 @@ export const UnitsProvider = ({ children }) => {
 
   const addUnit = useCallback((singular, plural) => {
     const key = plural.toLowerCase();
-    setUnits(prev => [...prev, { key, singular, plural }]);
+    setUnits(prev => [
+      ...prev,
+      {
+        key,
+        singular: { es: singular, en: singular },
+        plural: { es: plural, en: plural },
+      },
+    ]);
   }, []);
 
   const updateUnit = useCallback((key, singular, plural) => {
-    setUnits(prev => prev.map(u => (u.key === key ? { ...u, singular, plural } : u)));
+    setUnits(prev =>
+      prev.map(u =>
+        u.key === key
+          ? {
+              ...u,
+              singular: { es: singular, en: singular },
+              plural: { es: plural, en: plural },
+            }
+          : u,
+      ),
+    );
   }, []);
 
   const removeUnit = useCallback(key => {
     setUnits(prev => prev.filter(u => u.key !== key));
   }, []);
 
-  const getLabel = useCallback((quantity, key) => {
-    const unit = units.find(u => u.key === key);
-    if (!unit) return key;
-    return Number(quantity) === 1 ? unit.singular : unit.plural;
-  }, [units]);
+  const getLabel = useCallback(
+    (quantity, key) => {
+      const unit = units.find(u => u.key === key);
+      if (!unit) return key;
+      const form = Number(quantity) === 1 ? unit.singular : unit.plural;
+      if (typeof form === 'string') return form;
+      return form[lang] || form.es;
+    },
+    [units, lang],
+  );
 
   const resetUnits = useCallback(() => {
     setUnits(defaultUnits);
@@ -59,9 +105,19 @@ export const UnitsProvider = ({ children }) => {
     });
   }, []);
 
+  const localizedUnits = useMemo(
+    () =>
+      units.map(u => ({
+        ...u,
+        singular: typeof u.singular === 'string' ? u.singular : u.singular[lang] || u.singular.es,
+        plural: typeof u.plural === 'string' ? u.plural : u.plural[lang] || u.plural.es,
+      })),
+    [units, lang],
+  );
+
   const value = useMemo(
-    () => ({ units, addUnit, updateUnit, removeUnit, getLabel, resetUnits }),
-    [units, addUnit, updateUnit, removeUnit, getLabel, resetUnits],
+    () => ({ units: localizedUnits, addUnit, updateUnit, removeUnit, getLabel, resetUnits }),
+    [localizedUnits, addUnit, updateUnit, removeUnit, getLabel, resetUnits],
   );
 
   return (

--- a/MiAppNevera/src/i18n.js
+++ b/MiAppNevera/src/i18n.js
@@ -5,10 +5,24 @@ import esFoods from './locales/es/foods.json';
 import enFoods from './locales/en/foods.json';
 import esCategories from './locales/es/categories.json';
 import enCategories from './locales/en/categories.json';
+import esDefaults from './locales/es/defaults.json';
+import enDefaults from './locales/en/defaults.json';
 
 const i18n = new I18n({
-  es: { system: esSystem, foods: esFoods, categories: esCategories },
-  en: { system: enSystem, foods: enFoods, categories: enCategories },
+  es: {
+    system: esSystem,
+    foods: esFoods,
+    categories: esCategories,
+    units: esDefaults.units,
+    locations: esDefaults.locations,
+  },
+  en: {
+    system: enSystem,
+    foods: enFoods,
+    categories: enCategories,
+    units: enDefaults.units,
+    locations: enDefaults.locations,
+  },
 });
 
 i18n.enableFallback = true;

--- a/MiAppNevera/src/locales/en/defaults.json
+++ b/MiAppNevera/src/locales/en/defaults.json
@@ -1,0 +1,12 @@
+{
+  "units": {
+    "units": { "singular": "Unit", "plural": "Units" },
+    "kg": { "singular": "Kilogram", "plural": "Kilograms" },
+    "l": { "singular": "Liter", "plural": "Liters" }
+  },
+  "locations": {
+    "fridge": "Fridge",
+    "freezer": "Freezer",
+    "pantry": "Pantry"
+  }
+}

--- a/MiAppNevera/src/locales/es/defaults.json
+++ b/MiAppNevera/src/locales/es/defaults.json
@@ -1,0 +1,12 @@
+{
+  "units": {
+    "units": { "singular": "Unidad", "plural": "Unidades" },
+    "kg": { "singular": "Kilo", "plural": "Kilos" },
+    "l": { "singular": "Litro", "plural": "Litros" }
+  },
+  "locations": {
+    "fridge": "Nevera",
+    "freezer": "Congelador",
+    "pantry": "Despensa"
+  }
+}


### PR DESCRIPTION
## Summary
- merge persisted units with default bilingual names so labels change when switching languages
- upgrade stored locations with English and Spanish names using default data
- ensure unit and location contexts save bilingual structures compatible with existing add/update flows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab9d0c76388324b76a6acbd3497daa