### PR TITLE
Integrate AdMob banner for main screens

### DIFF
--- a/MiAppNevera/App.js
+++ b/MiAppNevera/App.js
@@ -2,7 +2,7 @@ import '@expo/metro-runtime';
 import React, { useEffect } from 'react';
 import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import InventoryScreen from './src/screens/InventoryScreen';
 import ShoppingListScreen from './src/screens/ShoppingListScreen';
 import SavedListsScreen from './src/screens/SavedListsScreen';
@@ -28,6 +28,7 @@ import { CategoriesProvider } from './src/context/CategoriesContext';
 import { ThemeProvider, useThemeController } from './src/context/ThemeContext';
 import { CurrencyProvider } from './src/context/CurrencyContext';
 import { LanguageProvider, useLanguage } from './src/context/LanguageContext';
+import AdBanner from './src/components/AdBanner';
 
 const Stack = createNativeStackNavigator();
 
@@ -54,6 +55,7 @@ function MainApp() {
                   <SavedListsProvider>
                     <ShoppingProvider>
                       <RecipeProvider>
+                        <View style={{ flex: 1 }}>
                   <NavigationContainer theme={themeName === 'light' ? DefaultTheme : DarkTheme}>
                     <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
                     <Stack.Navigator>
@@ -119,13 +121,15 @@ function MainApp() {
                     />
                     </Stack.Navigator>
                   </NavigationContainer>
-                </RecipeProvider>
-              </ShoppingProvider>
-            </SavedListsProvider>
-            </InventoryProvider>
-            </LocationsProvider>
-          </UnitsProvider>
-        </CurrencyProvider>
+                          <AdBanner />
+                        </View>
+                      </RecipeProvider>
+                    </ShoppingProvider>
+                  </SavedListsProvider>
+                </InventoryProvider>
+              </LocationsProvider>
+            </UnitsProvider>
+          </CurrencyProvider>
         </CustomFoodsProvider>
         </DefaultFoodsProvider>
       </CategoriesProvider>

--- a/MiAppNevera/app.json
+++ b/MiAppNevera/app.json
@@ -13,6 +13,12 @@
       "package": "com.anonymous.miappnevera",
       "edgeToEdgeEnabled": true
     },
+    "plugins": [
+      ["expo-ads-admob", {
+        "androidAppId": "ca-app-pub-3940256099942544~3347511713",
+        "iosAppId": "ca-app-pub-3940256099942544~1458002511"
+      }]
+    ],
     "extra": {
       "eas": {
         "projectId": "29bdbb1e-a7ff-4f47-a1c8-178ab45939ff"

--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "^53.0.20",
+    "expo-ads-admob": "~13.1.0",
     "expo-auth-session": "^6.2.1",
     "expo-document-picker": "^13.1.6",
     "expo-file-system": "^18.1.11",

--- a/MiAppNevera/src/components/AdBanner.js
+++ b/MiAppNevera/src/components/AdBanner.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { AdMobBanner } from 'expo-ads-admob';
+
+const adUnitID = Platform.select({
+  ios: 'ca-app-pub-3940256099942544/2934735716',
+  android: 'ca-app-pub-3940256099942544/6300978111',
+});
+
+export default function AdBanner() {
+  const adRef = useRef(null);
+
+  useEffect(() => {
+    if (Platform.OS === 'web' && adRef.current) {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+      script.setAttribute('data-ad-client', 'ca-pub-3940256099942544');
+      document.head.appendChild(script);
+
+      const ins = document.createElement('ins');
+      ins.className = 'adsbygoogle';
+      ins.style.display = 'block';
+      ins.setAttribute('data-ad-client', 'ca-pub-3940256099942544');
+      ins.setAttribute('data-ad-slot', '1234567890');
+      ins.setAttribute('data-ad-format', 'auto');
+      ins.setAttribute('data-full-width-responsive', 'true');
+      adRef.current.appendChild(ins);
+
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+
+      return () => {
+        document.head.removeChild(script);
+        adRef.current?.removeChild(ins);
+      };
+    }
+  }, []);
+
+  if (Platform.OS === 'web') {
+    return <div ref={adRef} />;
+  }
+
+  return (
+    <AdMobBanner
+      bannerSize="smartBannerPortrait"
+      adUnitID={adUnitID}
+      servePersonalizedAds
+      onDidFailToReceiveAdWithError={(e) => console.log(e)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add expo-ads-admob dependency and config
- create reusable AdBanner component
- render AdBanner below navigation to show banner on primary screens
- add AdSense script to display banner on web

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abcb5ffaf08324bd10222630709655