### PR TITLE
feat: display price below units

### DIFF
--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -512,8 +512,13 @@ export default function InventoryScreen({ navigation }) {
                                 </TouchableOpacity>
                                 <View style={{ alignItems: 'center' }}>
                                   <Text style={{ color: palette.textDim, fontSize: 12 }}>
-                                    {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - ${symbol}${(item.price * item.quantity).toFixed(2)}`}
+                                    {item.quantity} {getLabel(item.quantity, item.unit)}
                                   </Text>
+                                  {item.price > 0 && (
+                                    <Text style={{ color: palette.textDim, fontSize: 12 }}>
+                                      {symbol}{(item.price * item.quantity).toFixed(2)}
+                                    </Text>
+                                  )}
                                 </View>
                                 <TouchableOpacity onPress={() => updateQuantity(item.location, item.index, 1)} style={{ backgroundColor: palette.surface3, borderWidth: 1, borderColor: palette.border, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 10, marginHorizontal: 2 }}>
                                   <Text style={{ color: palette.accent, fontSize: 16 }}>→</Text>
@@ -556,8 +561,13 @@ export default function InventoryScreen({ navigation }) {
                                 {label}
                               </Text>
                               <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
-                                {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - ${symbol}${(item.price * item.quantity).toFixed(2)}`}
+                                {item.quantity} {getLabel(item.quantity, item.unit)}
                               </Text>
+                              {item.price > 0 && (
+                                <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
+                                  {symbol}{(item.price * item.quantity).toFixed(2)}
+                                </Text>
+                              )}
                             </LinearGradient>
                           </View>
                         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- show item price below unit count in inventory lists

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae7291104c8324bccea04a59d56e73