### PR TITLE
feat: add price toggle and price sorting

### DIFF
--- a/MiAppNevera/src/locales/en/system.json
+++ b/MiAppNevera/src/locales/en/system.json
@@ -96,13 +96,16 @@
     "sort": {
       "name": "Name",
       "expiration": "Expiration date",
-      "registered": "Date added"
+      "registered": "Date added",
+      "unitPrice": "Unit price",
+      "totalPrice": "Total price"
     },
     "viewTitle": "View type",
     "view": {
       "list": "List",
       "grid": "Grid"
     },
+    "showPrices": "Show prices",
     "addToShoppingConfirm": "Add the following %{count} items to the shopping list?",
     "add": "Add",
     "cancel": "Cancel",

--- a/MiAppNevera/src/locales/es/system.json
+++ b/MiAppNevera/src/locales/es/system.json
@@ -96,13 +96,16 @@
     "sort": {
       "name": "Nombre",
       "expiration": "Fecha de caducidad",
-      "registered": "Fecha de registro"
+      "registered": "Fecha de registro",
+      "unitPrice": "Precio unitario",
+      "totalPrice": "Precio total"
     },
     "viewTitle": "Tipo de vista",
     "view": {
       "list": "Lista",
       "grid": "Cuadrícula"
     },
+    "showPrices": "Mostrar precios",
     "addToShoppingConfirm": "Añadir los siguientes %{count} elementos a la lista de compras?",
     "add": "Añadir",
     "cancel": "Cancelar",

--- a/MiAppNevera/src/screens/InventoryScreen.js
+++ b/MiAppNevera/src/screens/InventoryScreen.js
@@ -166,9 +166,11 @@ export default function InventoryScreen({ navigation }) {
   const [sortOrder, setSortOrder] = useState('name');
   const [groupBy, setGroupBy] = useState('category');
   const [viewType, setViewType] = useState('grid');
+  const [showPrices, setShowPrices] = useState(true);
   const [tempSortOrder, setTempSortOrder] = useState(sortOrder);
   const [tempGroupBy, setTempGroupBy] = useState(groupBy);
   const [tempViewType, setTempViewType] = useState(viewType);
+  const [tempShowPrices, setTempShowPrices] = useState(showPrices);
   const [searchVisible, setSearchVisible] = useState(false);
 
   // ---- Selección múltiple ----
@@ -181,7 +183,7 @@ export default function InventoryScreen({ navigation }) {
   const [confirmVisible, setConfirmVisible] = useState(false);
 
   useEffect(() => { if (sortVisible) { setTempSortOrder(sortOrder); setTempGroupBy(groupBy); } }, [sortVisible]);
-  useEffect(() => { if (viewVisible) { setTempViewType(viewType); } }, [viewVisible]);
+  useEffect(() => { if (viewVisible) { setTempViewType(viewType); setTempShowPrices(showPrices); } }, [viewVisible]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -239,6 +241,8 @@ export default function InventoryScreen({ navigation }) {
     if (sortOrder === 'name') return a.name.localeCompare(b.name);
     if (sortOrder === 'expiration') return new Date(a.expiration || '9999-12-31') - new Date(b.expiration || '9999-12-31');
     if (sortOrder === 'registered') return new Date(a.registered || '9999-12-31') - new Date(b.registered || '9999-12-31');
+    if (sortOrder === 'unitPrice') return (a.price || 0) - (b.price || 0);
+    if (sortOrder === 'totalPrice') return (a.price || 0) * (a.quantity || 0) - (b.price || 0) * (b.quantity || 0);
     return 0;
   });
 
@@ -512,8 +516,13 @@ export default function InventoryScreen({ navigation }) {
                                 </TouchableOpacity>
                                 <View style={{ alignItems: 'center' }}>
                                   <Text style={{ color: palette.textDim, fontSize: 12 }}>
-                                    {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - ${symbol}${(item.price * item.quantity).toFixed(2)}`}
+                                    {item.quantity} {getLabel(item.quantity, item.unit)}
                                   </Text>
+                                  {showPrices && item.price > 0 && (
+                                    <Text style={{ color: palette.textDim, fontSize: 12 }}>
+                                      {symbol}{(item.price * item.quantity).toFixed(2)}
+                                    </Text>
+                                  )}
                                 </View>
                                 <TouchableOpacity onPress={() => updateQuantity(item.location, item.index, 1)} style={{ backgroundColor: palette.surface3, borderWidth: 1, borderColor: palette.border, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 10, marginHorizontal: 2 }}>
                                   <Text style={{ color: palette.accent, fontSize: 16 }}>→</Text>
@@ -556,8 +565,13 @@ export default function InventoryScreen({ navigation }) {
                                 {label}
                               </Text>
                               <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
-                                {item.quantity} {getLabel(item.quantity, item.unit)}{item.price > 0 && ` - ${symbol}${(item.price * item.quantity).toFixed(2)}`}
+                                {item.quantity} {getLabel(item.quantity, item.unit)}
                               </Text>
+                              {showPrices && item.price > 0 && (
+                                <Text style={{ textAlign: 'center', color: palette.textDim, fontSize: 11 }}>
+                                  {symbol}{(item.price * item.quantity).toFixed(2)}
+                                </Text>
+                              )}
                             </LinearGradient>
                           </View>
                         </TouchableOpacity>
@@ -660,7 +674,7 @@ export default function InventoryScreen({ navigation }) {
             <TouchableWithoutFeedback>
               <View style={{ backgroundColor: palette.surface, padding: 20, borderRadius: 12, width: '80%', maxWidth: 300, borderWidth: 1, borderColor: palette.border }}>
                 <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 10, color: palette.text }}>{t('system.inventory.sortTitle')}</Text>
-                {[{ key: 'name', label: t('system.inventory.sort.name') },{ key: 'expiration', label: t('system.inventory.sort.expiration') },{ key: 'registered', label: t('system.inventory.sort.registered') }].map(opt => (
+                {[{ key: 'name', label: t('system.inventory.sort.name') },{ key: 'expiration', label: t('system.inventory.sort.expiration') },{ key: 'registered', label: t('system.inventory.sort.registered') },{ key: 'unitPrice', label: t('system.inventory.sort.unitPrice') },{ key: 'totalPrice', label: t('system.inventory.sort.totalPrice') }].map(opt => (
                   <TouchableOpacity key={opt.key} style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }} onPress={() => setTempSortOrder(opt.key)}>
                     <Text style={{ color: palette.text }}>{tempSortOrder === opt.key ? '◉' : '○'}</Text>
                     <Text style={{ marginLeft: 6, color: palette.text }}>{opt.label}</Text>
@@ -699,11 +713,15 @@ export default function InventoryScreen({ navigation }) {
                     <Text style={{ marginLeft: 6, color: palette.text }}>{opt.label}</Text>
                   </TouchableOpacity>
                 ))}
+                <TouchableOpacity style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }} onPress={() => setTempShowPrices(v => !v)}>
+                  <Text style={{ color: palette.text }}>{tempShowPrices ? '☑' : '☐'}</Text>
+                  <Text style={{ marginLeft: 6, color: palette.text }}>{t('system.inventory.showPrices')}</Text>
+                </TouchableOpacity>
                 <View style={{ flexDirection: 'row', justifyContent: 'flex-end', marginTop: 10 }}>
                   <TouchableOpacity onPress={() => setViewVisible(false)} style={{ padding: 10, marginRight: 10 }}>
                     <Text style={{ color: palette.accent }}>{t('system.inventory.cancel')}</Text>
                   </TouchableOpacity>
-                  <TouchableOpacity onPress={() => { setViewType(tempViewType); setViewVisible(false); }} style={{ backgroundColor: palette.accent, padding: 10, borderRadius: 6 }}>
+                  <TouchableOpacity onPress={() => { setViewType(tempViewType); setShowPrices(tempShowPrices); setViewVisible(false); }} style={{ backgroundColor: palette.accent, padding: 10, borderRadius: 6 }}>
                     <Text style={{ color: '#1b1d22' }}>{t('system.inventory.confirm')}</Text>
                   </TouchableOpacity>
                 </View>


### PR DESCRIPTION
## Summary
- add inventory setting to toggle price visibility
- allow sorting items by unit price or total price

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae7291104c8324bccea04a59d56e73