### PR TITLE
feat: add price toggle and enhanced sorting controls

### DIFF
--- a/MiAppNevera/src/locales/en/system.json
+++ b/MiAppNevera/src/locales/en/system.json
@@ -96,13 +96,17 @@
     "sort": {
       "name": "Name",
       "expiration": "Expiration date",
-      "registered": "Date added"
+      "registered": "Date added",
+      "unitPrice": "Unit price",
+      "totalPrice": "Total price"
     },
+    "invertOrder": "Reverse order",
     "viewTitle": "View type",
     "view": {
       "list": "List",
       "grid": "Grid"
     },
+    "showPrices": "Show prices",
     "addToShoppingConfirm": "Add the following %{count} items to the shopping list?",
     "add": "Add",
     "cancel": "Cancel",

--- a/MiAppNevera/src/locales/es/system.json
+++ b/MiAppNevera/src/locales/es/system.json
@@ -96,13 +96,17 @@
     "sort": {
       "name": "Nombre",
       "expiration": "Fecha de caducidad",
-      "registered": "Fecha de registro"
+      "registered": "Fecha de registro",
+      "unitPrice": "Precio unitario",
+      "totalPrice": "Precio total"
     },
+    "invertOrder": "Invertir orden",
     "viewTitle": "Tipo de vista",
     "view": {
       "list": "Lista",
       "grid": "Cuadrícula"
     },
+    "showPrices": "Mostrar precios",
     "addToShoppingConfirm": "Añadir los siguientes %{count} elementos a la lista de compras?",
     "add": "Añadir",
     "cancel": "Cancelar",


### PR DESCRIPTION
## Summary
- add inventory setting to toggle price visibility
- allow sorting items by unit price or total price with optional reverse order
- revamp sorting menu with icons for clearer grouping options

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68ae7291104c8324bccea04a59d56e73