### PR TITLE
feat: adjustable step font while editing recipes

### DIFF
--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -51,6 +51,7 @@ export default function AddRecipeModal({
   const [difficulty, setDifficulty] = useState('');
   const [ingredients, setIngredients] = useState([]);
   const [steps, setSteps] = useState('');
+  const [stepFont, setStepFont] = useState(1);
   const richText = useRef(null);
   const webEditor = useRef(null);
   const fileInput = useRef(null);
@@ -287,6 +288,7 @@ export default function AddRecipeModal({
       setDifficulty(initialRecipe.difficulty || '');
       const initialSteps = initialRecipe.steps || '';
       setSteps(initialSteps);
+      setStepFont(1);
       if (isWeb && webEditor.current) {
         webEditor.current.innerHTML = initialSteps;
       } else {
@@ -308,6 +310,7 @@ export default function AddRecipeModal({
       } else {
         richText.current?.setContentHTML?.('');
       }
+      setStepFont(1);
     } else if (!visible) {
       // resetear cuando se cierra
       setName('');
@@ -318,6 +321,7 @@ export default function AddRecipeModal({
       setIngredients([]);
       setSelectMode(false);
       setSelected([]);
+      setStepFont(1);
     }
   }, [visible, initialRecipe]);
 
@@ -597,6 +601,20 @@ const save = () => {
 
           {/* Pasos */}
           <Text style={styles.label}>{t('system.recipes.add.stepsLabel')}</Text>
+          <View style={styles.stepControls}>
+            <TouchableOpacity
+              onPress={() => setStepFont((s) => Math.max(0.5, s - 0.1))}
+              style={styles.stepBtn}
+            >
+              <Text style={styles.stepBtnTxt}>A-</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setStepFont((s) => Math.min(2, s + 0.1))}
+              style={styles.stepBtn}
+            >
+              <Text style={styles.stepBtnTxt}>A+</Text>
+            </TouchableOpacity>
+          </View>
           {isWeb ? (
             <>
               <div
@@ -607,6 +625,7 @@ const save = () => {
                   ...StyleSheet.flatten(styles.rich),
                   minHeight: 120,
                   outline: 'none',
+                  fontSize: 16 * stepFont,
                 }}
                 onInput={handleWebChange}
                 onKeyUp={saveRange}
@@ -703,6 +722,10 @@ const save = () => {
                 ref={richText}
                 initialContentHTML={steps}
                 style={[styles.rich, { minHeight: 120 }]}
+                editorStyle={{
+                  cssText: `font-size:${16 * stepFont}px;color:${palette.text};`,
+                  contentCSSText: `font-size:${16 * stepFont}px;color:${palette.text};`,
+                }}
                 placeholder={t('system.recipes.add.stepsPlaceholder')}
                 onChange={setSteps}
               />
@@ -889,6 +912,22 @@ const createStyles = (palette) => StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+
+  stepControls: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginBottom: 6,
+  },
+  stepBtn: {
+    backgroundColor: palette.surface3,
+    borderColor: palette.border,
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    marginLeft: 6,
+  },
+  stepBtnTxt: { color: palette.text, fontSize: 16 },
 
   // image
   image: { width: '60%',

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -167,10 +167,10 @@ export default function RecipeDetailScreen({ route }) {
           <RenderHtml
             contentWidth={width - 56}
             source={{ html: recipe.steps }}
-            baseStyle={{ color: palette.text, lineHeight: 20 }}
+            baseStyle={{ color: palette.text, lineHeight: 20, fontSize: 16 }}
             tagsStyles={{
-              p: { color: palette.text },
-              li: { color: palette.text },
+              p: { color: palette.text, lineHeight: 20, fontSize: 16 },
+              li: { color: palette.text, lineHeight: 20, fontSize: 16 },
             }}
             renderersProps={{ img: { enableExperimentalPercentWidth: true } }}
             domVisitors={domVisitors}


### PR DESCRIPTION
## Summary
- enable font size controls when writing recipe steps
- remove step text scaling from detail view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68afd3be1adc8324ba46e799f5fe0d0f