### PR TITLE
feat: show selected text font size in recipe steps

### DIFF
--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -51,6 +51,7 @@ export default function AddRecipeModal({
   const [difficulty, setDifficulty] = useState('');
   const [ingredients, setIngredients] = useState([]);
   const [steps, setSteps] = useState('');
+  const [fontLevel, setFontLevel] = useState(3); // track last used font size level
   const richText = useRef(null);
   const webEditor = useRef(null);
   const fileInput = useRef(null);
@@ -73,9 +74,17 @@ export default function AddRecipeModal({
     }
   };
 
+  const sizeMap = { 1: '10px', 2: '13px', 3: '16px', 4: '18px', 5: '24px', 6: '32px', 7: '48px' };
+  const normalizeFontTags = html =>
+    html
+      ? html.replace(/<font[^>]*size="([1-7])"[^>]*>(.*?)<\/font>/gi, (_, s, c) =>
+          `<span style="font-size:${sizeMap[s]};">${c}</span>`,
+        )
+      : '';
+
   const handleWebChange = () => {
     if (isWeb && webEditor.current) {
-      setSteps(webEditor.current.innerHTML);
+      setSteps(normalizeFontTags(webEditor.current.innerHTML));
     }
   };
 
@@ -110,6 +119,28 @@ export default function AddRecipeModal({
 
   const lastRange = useRef(null);
   const selectedImage = useRef(null);
+  const updateFontFromSelection = () => {
+    if (isWeb) {
+      const sel = window.getSelection();
+      if (sel && sel.focusNode) {
+        const node = sel.focusNode.nodeType === 3 ? sel.focusNode.parentElement : sel.focusNode;
+        if (node) {
+          const size = window.getComputedStyle(node).fontSize;
+          const found = Object.entries(sizeMap).find(([, v]) => parseInt(v) === parseInt(size));
+          if (found) setFontLevel(Number(found[0]));
+        }
+      }
+    } else {
+      richText.current?.commandDOM?.(`(function(){
+        var sel = window.getSelection();
+        if(sel && sel.focusNode){
+          var node = sel.focusNode.nodeType===3? sel.focusNode.parentElement : sel.focusNode;
+          var size = window.getComputedStyle(node).fontSize;
+          window.ReactNativeWebView.postMessage(JSON.stringify({type:'FONT_SIZE', data:size}));
+        }
+      })()`);
+    }
+  };
   const saveRange = e => {
     if (!isWeb) return;
     const sel = window.getSelection();
@@ -117,6 +148,7 @@ export default function AddRecipeModal({
       lastRange.current = sel.getRangeAt(0);
     }
     selectedImage.current = e?.target?.tagName === 'IMG' ? e.target : null;
+    updateFontFromSelection();
   };
 
   const resizeImage = pct => {
@@ -255,6 +287,38 @@ export default function AddRecipeModal({
     }
   };
 
+  const changeFontSize = dir => {
+    setFontLevel(level => {
+      const next = Math.max(1, Math.min(7, level + dir));
+      if (isWeb) {
+        const sel = window.getSelection();
+        if (lastRange.current && sel) {
+          sel.removeAllRanges();
+          sel.addRange(lastRange.current);
+          document.execCommand('fontSize', false, String(next));
+          handleWebChange();
+          sel.removeAllRanges();
+          sel.addRange(lastRange.current);
+          lastRange.current = sel.getRangeAt(0);
+        } else {
+          document.execCommand('fontSize', false, String(next));
+          handleWebChange();
+        }
+      } else {
+        richText.current?.setFontSize(String(next));
+      }
+      return next;
+    });
+  };
+
+  const handleEditorMessage = message => {
+    if (message?.type === 'FONT_SIZE') {
+      const px = parseInt(message.data);
+      const found = Object.entries(sizeMap).find(([, v]) => parseInt(v) === px);
+      if (found) setFontLevel(Number(found[0]));
+    }
+  };
+
   const handleToolbarPress = action => {
     if (action === actions.insertImage) {
       handleInsertImage();
@@ -278,6 +342,12 @@ export default function AddRecipeModal({
     }
   };
 
+  useEffect(() => {
+    if (!isWeb && visible) {
+      richText.current?.registerToolbar(() => updateFontFromSelection());
+    }
+  }, [visible]);
+
   // cargar/limpiar datos
   useEffect(() => {
     if (visible && initialRecipe) {
@@ -285,8 +355,9 @@ export default function AddRecipeModal({
       setImage(initialRecipe.image || '');
       setPersons(String(initialRecipe.persons || 1));
       setDifficulty(initialRecipe.difficulty || '');
-      const initialSteps = initialRecipe.steps || '';
+      const initialSteps = normalizeFontTags(initialRecipe.steps || '');
       setSteps(initialSteps);
+      setFontLevel(3);
       if (isWeb && webEditor.current) {
         webEditor.current.innerHTML = initialSteps;
       } else {
@@ -308,6 +379,7 @@ export default function AddRecipeModal({
       } else {
         richText.current?.setContentHTML?.('');
       }
+      setFontLevel(3);
     } else if (!visible) {
       // resetear cuando se cierra
       setName('');
@@ -318,6 +390,7 @@ export default function AddRecipeModal({
       setIngredients([]);
       setSelectMode(false);
       setSelected([]);
+      setFontLevel(3);
     }
   }, [visible, initialRecipe]);
 
@@ -597,6 +670,21 @@ const save = () => {
 
           {/* Pasos */}
           <Text style={styles.label}>{t('system.recipes.add.stepsLabel')}</Text>
+          <View style={styles.stepControls}>
+            <TouchableOpacity
+              onPress={() => changeFontSize(-1)}
+              style={styles.stepBtn}
+            >
+              <Text style={styles.stepBtnTxt}>A-</Text>
+            </TouchableOpacity>
+            <Text style={styles.stepSize}>{parseInt(sizeMap[fontLevel])}</Text>
+            <TouchableOpacity
+              onPress={() => changeFontSize(1)}
+              style={styles.stepBtn}
+            >
+              <Text style={styles.stepBtnTxt}>A+</Text>
+            </TouchableOpacity>
+          </View>
           {isWeb ? (
             <>
               <div
@@ -607,6 +695,7 @@ const save = () => {
                   ...StyleSheet.flatten(styles.rich),
                   minHeight: 120,
                   outline: 'none',
+                  fontSize: 16,
                 }}
                 onInput={handleWebChange}
                 onKeyUp={saveRange}
@@ -703,8 +792,13 @@ const save = () => {
                 ref={richText}
                 initialContentHTML={steps}
                 style={[styles.rich, { minHeight: 120 }]}
+                editorStyle={{
+                  cssText: `color:${palette.text};`,
+                  contentCSSText: `color:${palette.text};`,
+                }}
                 placeholder={t('system.recipes.add.stepsPlaceholder')}
-                onChange={setSteps}
+                onChange={html => setSteps(normalizeFontTags(html))}
+                onMessage={handleEditorMessage}
               />
               <RichToolbar
                 editor={richText}
@@ -889,6 +983,23 @@ const createStyles = (palette) => StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+
+  stepControls: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginBottom: 6,
+  },
+  stepSize: { color: palette.text, alignSelf: 'center', marginHorizontal: 6 },
+  stepBtn: {
+    backgroundColor: palette.surface3,
+    borderColor: palette.border,
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    marginLeft: 6,
+  },
+  stepBtnTxt: { color: palette.text, fontSize: 16 },
 
   // image
   image: { width: '60%',

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -167,10 +167,10 @@ export default function RecipeDetailScreen({ route }) {
           <RenderHtml
             contentWidth={width - 56}
             source={{ html: recipe.steps }}
-            baseStyle={{ color: palette.text, lineHeight: 20 }}
+            baseStyle={{ color: palette.text, lineHeight: 20, fontSize: 16 }}
             tagsStyles={{
-              p: { color: palette.text },
-              li: { color: palette.text },
+              p: { color: palette.text, lineHeight: 20, fontSize: 16 },
+              li: { color: palette.text, lineHeight: 20, fontSize: 16 },
             }}
             renderersProps={{ img: { enableExperimentalPercentWidth: true } }}
             domVisitors={domVisitors}


### PR DESCRIPTION
## Summary
- display numeric font size of currently selected step text
- keep selection intact when adjusting font size and update indicator accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68afd3be1adc8324ba46e799f5fe0d0f