### PR TITLE
feat: show selected text font size in recipe steps

### DIFF
--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -51,6 +51,7 @@ export default function AddRecipeModal({
   const [difficulty, setDifficulty] = useState('');
   const [ingredients, setIngredients] = useState([]);
   const [steps, setSteps] = useState('');
+  const [fontLevel, setFontLevel] = useState(3); // track last used font size level
   const richText = useRef(null);
   const webEditor = useRef(null);
   const fileInput = useRef(null);
@@ -73,9 +74,17 @@ export default function AddRecipeModal({
     }
   };
 
+  const sizeMap = { 1: '10px', 2: '13px', 3: '16px', 4: '18px', 5: '24px', 6: '32px', 7: '48px' };
+  const normalizeFontTags = html =>
+    html
+      ? html.replace(/<font[^>]*size="([1-7])"[^>]*>(.*?)<\/font>/gi, (_, s, c) =>
+          `<span style="font-size:${sizeMap[s]};">${c}</span>`,
+        )
+      : '';
+
   const handleWebChange = () => {
     if (isWeb && webEditor.current) {
-      setSteps(webEditor.current.innerHTML);
+      setSteps(normalizeFontTags(webEditor.current.innerHTML));
     }
   };
 
@@ -93,6 +102,7 @@ export default function AddRecipeModal({
       const asset = result.assets[0];
       const uri = `data:${asset.mimeType || 'image/jpeg'};base64,${asset.base64}`;
       richText.current?.insertImage(uri);
+      alignImage('center');
     }
   };
 
@@ -102,6 +112,7 @@ export default function AddRecipeModal({
     const reader = new FileReader();
     reader.onload = () => {
       document.execCommand('insertImage', false, reader.result);
+      alignImage('center');
       handleWebChange();
     };
     reader.readAsDataURL(file);
@@ -110,13 +121,36 @@ export default function AddRecipeModal({
 
   const lastRange = useRef(null);
   const selectedImage = useRef(null);
+  const updateFontFromSelection = () => {
+    if (isWeb) {
+      const sel = window.getSelection();
+      if (sel && sel.focusNode) {
+        const node = sel.focusNode.nodeType === 3 ? sel.focusNode.parentElement : sel.focusNode;
+        if (node) {
+          const size = window.getComputedStyle(node).fontSize;
+          const found = Object.entries(sizeMap).find(([, v]) => parseInt(v) === parseInt(size));
+          if (found) setFontLevel(Number(found[0]));
+        }
+      }
+    } else {
+      richText.current?.commandDOM?.(`(function(){
+        var sel = window.getSelection();
+        if(sel && sel.focusNode){
+          var node = sel.focusNode.nodeType===3? sel.focusNode.parentElement : sel.focusNode;
+          var size = window.getComputedStyle(node).fontSize;
+          window.ReactNativeWebView.postMessage(JSON.stringify({type:'FONT_SIZE', data:size}));
+        }
+      })()`);
+    }
+  };
   const saveRange = e => {
     if (!isWeb) return;
     const sel = window.getSelection();
     if (sel && sel.rangeCount > 0) {
-      lastRange.current = sel.getRangeAt(0);
+      lastRange.current = sel.getRangeAt(0).cloneRange();
     }
     selectedImage.current = e?.target?.tagName === 'IMG' ? e.target : null;
+    updateFontFromSelection();
   };
 
   const resizeImage = pct => {
@@ -138,6 +172,7 @@ export default function AddRecipeModal({
       }
     } else {
       richText.current?.commandDOM?.(`(function(){
+        focusCurrent();
         var sel = window.getSelection();
         if(!sel || !sel.rangeCount) return;
         var range = sel.getRangeAt(0);
@@ -164,6 +199,7 @@ export default function AddRecipeModal({
           }
         }
         if(img){img.style.width='${pct}';}
+        saveSelection();
       })()`);
     }
   };
@@ -189,15 +225,15 @@ export default function AddRecipeModal({
           img.style.alignSelf = 'center';
         } else if (dir === 'left') {
           img.style.display = 'block';
-          img.style.margin = '0';
-          img.style.float = 'left';
-          img.style.marginRight = '8px';
+          img.style.marginLeft = '0';
+          img.style.marginRight = 'auto';
+          img.style.float = '';
           img.style.alignSelf = 'flex-start';
         } else if (dir === 'right') {
           img.style.display = 'block';
-          img.style.margin = '0';
-          img.style.float = 'right';
-          img.style.marginLeft = '8px';
+          img.style.marginLeft = 'auto';
+          img.style.marginRight = '0';
+          img.style.float = '';
           img.style.alignSelf = 'flex-end';
         }
         handleWebChange();
@@ -205,6 +241,7 @@ export default function AddRecipeModal({
       }
     } else {
       richText.current?.commandDOM?.(`(function(){
+        focusCurrent();
         var sel = window.getSelection();
         if(!sel || !sel.rangeCount) return;
         var range = sel.getRangeAt(0);
@@ -239,24 +276,68 @@ export default function AddRecipeModal({
             img.style.alignSelf='center';
           } else if('${dir}'==='left'){
             img.style.display='block';
-            img.style.margin='0';
-            img.style.float='left';
-            img.style.marginRight='8px';
+            img.style.marginLeft='0';
+            img.style.marginRight='auto';
+            img.style.float='';
             img.style.alignSelf='flex-start';
           } else if('${dir}'==='right'){
             img.style.display='block';
-            img.style.margin='0';
-            img.style.float='right';
-            img.style.marginLeft='8px';
+            img.style.marginLeft='auto';
+            img.style.marginRight='0';
+            img.style.float='';
             img.style.alignSelf='flex-end';
           }
         }
+        saveSelection();
       })()`);
     }
   };
 
+  const changeFontSize = dir => {
+    setFontLevel(level => {
+      const next = Math.max(1, Math.min(7, level + dir));
+      if (isWeb) {
+        const sel = window.getSelection();
+        if (lastRange.current && sel) {
+          sel.removeAllRanges();
+          sel.addRange(lastRange.current);
+          document.execCommand('fontSize', false, String(next));
+          handleWebChange();
+          sel.removeAllRanges();
+          sel.addRange(lastRange.current);
+          lastRange.current = sel.getRangeAt(0).cloneRange();
+        } else {
+          document.execCommand('fontSize', false, String(next));
+          handleWebChange();
+        }
+      } else {
+        richText.current?.commandDOM?.(`(function(){
+          focusCurrent();
+          var sel = window.getSelection();
+          if(!sel || !sel.rangeCount) return;
+          var range = sel.getRangeAt(0);
+          document.execCommand('fontSize', false, '${next}');
+          sel.removeAllRanges();
+          sel.addRange(range);
+          saveSelection();
+        })()`);
+      }
+      return next;
+    });
+  };
+
+  const handleEditorMessage = message => {
+    if (message?.type === 'FONT_SIZE') {
+      const px = parseInt(message.data);
+      const found = Object.entries(sizeMap).find(([, v]) => parseInt(v) === px);
+      if (found) setFontLevel(Number(found[0]));
+    }
+  };
+
   const handleToolbarPress = action => {
-    if (action === actions.insertImage) {
+    if (action === 'fontSizeLabel') {
+      return;
+    } else if (action === actions.insertImage) {
       handleInsertImage();
     } else if (action === 'resize100') {
       resizeImage('100%');
@@ -264,6 +345,10 @@ export default function AddRecipeModal({
       resizeImage('50%');
     } else if (action === 'resize25') {
       resizeImage('25%');
+    } else if (action === 'fontDecrease') {
+      changeFontSize(-1);
+    } else if (action === 'fontIncrease') {
+      changeFontSize(1);
     } else if (action === actions.alignLeft) {
       richText.current?.command?.(action);
       alignImage('left');
@@ -278,6 +363,12 @@ export default function AddRecipeModal({
     }
   };
 
+  useEffect(() => {
+    if (!isWeb && visible) {
+      richText.current?.registerToolbar(() => updateFontFromSelection());
+    }
+  }, [visible]);
+
   // cargar/limpiar datos
   useEffect(() => {
     if (visible && initialRecipe) {
@@ -285,8 +376,9 @@ export default function AddRecipeModal({
       setImage(initialRecipe.image || '');
       setPersons(String(initialRecipe.persons || 1));
       setDifficulty(initialRecipe.difficulty || '');
-      const initialSteps = initialRecipe.steps || '';
+      const initialSteps = normalizeFontTags(initialRecipe.steps || '');
       setSteps(initialSteps);
+      setFontLevel(3);
       if (isWeb && webEditor.current) {
         webEditor.current.innerHTML = initialSteps;
       } else {
@@ -308,6 +400,7 @@ export default function AddRecipeModal({
       } else {
         richText.current?.setContentHTML?.('');
       }
+      setFontLevel(3);
     } else if (!visible) {
       // resetear cuando se cierra
       setName('');
@@ -318,6 +411,7 @@ export default function AddRecipeModal({
       setIngredients([]);
       setSelectMode(false);
       setSelected([]);
+      setFontLevel(3);
     }
   }, [visible, initialRecipe]);
 
@@ -607,6 +701,7 @@ const save = () => {
                   ...StyleSheet.flatten(styles.rich),
                   minHeight: 120,
                   outline: 'none',
+                  fontSize: 16,
                 }}
                 onInput={handleWebChange}
                 onKeyUp={saveRange}
@@ -615,22 +710,39 @@ const save = () => {
               />
               <View style={styles.richBar}>
                 <TouchableOpacity
+                  onPress={() => changeFontSize(-1)}
+                  style={styles.richBtn}
+                >
+                  <Text style={{ color: palette.text, fontSize: 16 }}>A-</Text>
+                </TouchableOpacity>
+                <Text style={styles.stepSize}>{parseInt(sizeMap[fontLevel])}</Text>
+                <TouchableOpacity
+                  onPress={() => changeFontSize(1)}
+                  style={styles.richBtn}
+                >
+                  <Text style={{ color: palette.text, fontSize: 16 }}>A+</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
                   onPress={() => document.execCommand('bold')}
                   style={styles.richBtn}
                 >
-                  <Text
-                    style={{ color: palette.text, fontWeight: '700', fontSize: 16 }}
-                  >
+                  <Text style={{ color: palette.text, fontWeight: '700', fontSize: 16 }}>
                     B
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => document.execCommand('italic')}
+                  style={styles.richBtn}
+                >
+                  <Text style={{ color: palette.text, fontSize: 16, fontStyle: 'italic' }}>
+                    I
                   </Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   onPress={() => document.execCommand('underline')}
                   style={styles.richBtn}
                 >
-                  <Text
-                    style={{ color: palette.text, textDecorationLine: 'underline', fontSize: 16 }}
-                  >
+                  <Text style={{ color: palette.text, textDecorationLine: 'underline', fontSize: 16 }}>
                     U
                   </Text>
                 </TouchableOpacity>
@@ -703,13 +815,23 @@ const save = () => {
                 ref={richText}
                 initialContentHTML={steps}
                 style={[styles.rich, { minHeight: 120 }]}
+                editorStyle={{
+                  backgroundColor: palette.surface2,
+                  cssText: `color:${palette.text}; background-color:${palette.surface2};`,
+                  contentCSSText: `color:${palette.text}; background-color:${palette.surface2};`,
+                }}
                 placeholder={t('system.recipes.add.stepsPlaceholder')}
-                onChange={setSteps}
+                onChange={html => setSteps(normalizeFontTags(html))}
+                onMessage={handleEditorMessage}
               />
               <RichToolbar
                 editor={richText}
                 actions={[
+                  'fontDecrease',
+                  'fontSizeLabel',
+                  'fontIncrease',
                   actions.setBold,
+                  actions.setItalic,
                   actions.setUnderline,
                   actions.insertBulletsList,
                   actions.insertOrderedList,
@@ -724,8 +846,17 @@ const save = () => {
                 style={styles.richBar}
                 iconTint={palette.text}
                 selectedIconTint={palette.accent}
-                onPress={handleToolbarPress}
+                onPress={action => action === 'fontSizeLabel' ? null : handleToolbarPress(action)}
                 iconMap={{
+                  fontDecrease: ({ tintColor }) => (
+                    <Text style={{ color: tintColor, fontSize: 16 }}>A-</Text>
+                  ),
+                  fontSizeLabel: () => (
+                    <Text style={styles.stepSize}>{parseInt(sizeMap[fontLevel])}</Text>
+                  ),
+                  fontIncrease: ({ tintColor }) => (
+                    <Text style={{ color: tintColor, fontSize: 16 }}>A+</Text>
+                  ),
                   [actions.insertImage]: ({ tintColor }) => (
                     <Text style={{ color: tintColor }}>🖼️</Text>
                   ),
@@ -748,11 +879,12 @@ const save = () => {
                     <Text style={{ color: tintColor, fontSize: 12 }}>R</Text>
                   ),
                   [actions.setUnderline]: ({ tintColor }) => (
-                    <Text
-                      style={{ color: tintColor, textDecorationLine: 'underline', fontSize: 12 }}
-                    >
+                    <Text style={{ color: tintColor, textDecorationLine: 'underline', fontSize: 12 }}>
                       U
                     </Text>
+                  ),
+                  [actions.setItalic]: ({ tintColor }) => (
+                    <Text style={{ color: tintColor, fontSize: 12, fontStyle: 'italic' }}>I</Text>
                   ),
                 }}
               />
@@ -873,22 +1005,26 @@ const createStyles = (palette) => StyleSheet.create({
     color: palette.text,
   },
   richBar: {
-    backgroundColor: palette.surface2,
-    borderWidth: 1,
-    borderColor: palette.border,
-    borderRadius: 10,
+    backgroundColor: palette.surface3,
+    borderRadius: 16,
     marginTop: 6,
     flexDirection: 'row',
     flexWrap: 'wrap',
     alignItems: 'center',
+    justifyContent: 'center',
     padding: 4,
   },
   richBtn: {
-    padding: 4,
-    marginHorizontal: 2,
+    width: 32,
+    height: 32,
+    margin: 4,
+    borderRadius: 8,
+    backgroundColor: palette.surface2,
     justifyContent: 'center',
     alignItems: 'center',
   },
+
+  stepSize: { color: palette.text, alignSelf: 'center', marginHorizontal: 6 },
 
   // image
   image: { width: '60%',

--- a/MiAppNevera/src/screens/RecipeDetailScreen.js
+++ b/MiAppNevera/src/screens/RecipeDetailScreen.js
@@ -50,15 +50,14 @@ export default function RecipeDetailScreen({ route }) {
           const style = element.attribs.style || '';
           const widthMatch = style.match(/width:\s*[^;]+/);
           const widthStyle = widthMatch ? `${widthMatch[0]};` : '';
-          let alignStyle;
-          if (dir === 'right') {
-            alignStyle = 'align-self:flex-end;margin-left:8px;';
-          } else if (dir === 'center') {
-            alignStyle = 'align-self:center;';
+
+          if (dir === 'center') {
+            element.attribs.style = `${widthStyle}display:block;margin-left:auto;margin-right:auto;`;
+          } else if (dir === 'right') {
+            element.attribs.style = `${widthStyle}display:block;margin-left:auto;margin-right:0;`;
           } else {
-            alignStyle = 'align-self:flex-start;margin-right:8px;';
+            element.attribs.style = `${widthStyle}display:block;margin-left:0;margin-right:auto;`;
           }
-          element.attribs.style = `${widthStyle}${alignStyle}`;
         }
       },
     }),
@@ -167,10 +166,10 @@ export default function RecipeDetailScreen({ route }) {
           <RenderHtml
             contentWidth={width - 56}
             source={{ html: recipe.steps }}
-            baseStyle={{ color: palette.text, lineHeight: 20 }}
+            baseStyle={{ color: palette.text, lineHeight: 20, fontSize: 16 }}
             tagsStyles={{
-              p: { color: palette.text },
-              li: { color: palette.text },
+              p: { color: palette.text, lineHeight: 20, fontSize: 16 },
+              li: { color: palette.text, lineHeight: 20, fontSize: 16 },
             }}
             renderersProps={{ img: { enableExperimentalPercentWidth: true } }}
             domVisitors={domVisitors}


### PR DESCRIPTION
## Summary
- display numeric font size of currently selected step text
- keep selection intact when adjusting font size and update indicator accordingly
- show font size controls only in the bottom toolbar alongside other formatting buttons
- render saved step images on their own row to avoid text wrapping
- ensure image resize buttons function by restoring editor selection before applying width
- mirror step image alignment in recipe view to match the editor
- polish recipe step editor toolbar with styling and italic formatting
- insert step images centered and always block-level so text continues below
- add A-/A+ font size buttons to the bottom toolbar for quick access
- tint Android step editor background to match theme and eliminate white overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68afd3be1adc8324ba46e799f5fe0d0f