### PR TITLE
feat(android): enable image resize options

### DIFF
--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -65,6 +65,8 @@ export default function AddRecipeModal({
   const isEditing = !!initialRecipe;
 
   const pickImage = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) return;
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 0.7,
@@ -93,6 +95,8 @@ export default function AddRecipeModal({
       fileInput.current?.click();
       return;
     }
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) return;
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       base64: true,
@@ -101,7 +105,8 @@ export default function AddRecipeModal({
     if (!result.canceled) {
       const asset = result.assets[0];
       const uri = `data:${asset.mimeType || 'image/jpeg'};base64,${asset.base64}`;
-      richText.current?.insertImage(uri);
+      richText.current?.insertImage({ src: uri, width: '100%' });
+      resizeImage('100%');
       alignImage('center');
     }
   };
@@ -172,7 +177,7 @@ export default function AddRecipeModal({
       }
     } else {
       richText.current?.commandDOM?.(`(function(){
-        focusCurrent();
+        focusCurrent && focusCurrent();
         var sel = window.getSelection();
         if(!sel || !sel.rangeCount) return;
         var range = sel.getRangeAt(0);
@@ -198,8 +203,13 @@ export default function AddRecipeModal({
             }
           }
         }
-        if(img){img.style.width='${pct}';}
-        saveSelection();
+        if(img){
+          img.style.width='${pct}';
+          img.style.height='auto';
+          img.setAttribute('width','${pct}');
+          img.removeAttribute('height');
+        }
+        saveSelection && saveSelection();
       })()`);
     }
   };


### PR DESCRIPTION
## Summary
- ensure RichEditor on Android sets image width/height when resizing so 100/50/25% buttons work
- request media library permission and insert images at 100% width on Android

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b10e5593548324b1376c077a056390