### PR TITLE
fix: install WebView dependency

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -38,6 +38,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "^15.3.0",
     "react-native-web": "^0.20.0",
+    "react-native-webview": "^13.8.0",
     "@expo/metro-runtime": "~5.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix EAS build error by adding missing `react-native-webview` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1131c5bd08324b8e0157d91ac7b29