### PR TITLE
fix: add missing WebView dependency

### DIFF
--- a/MiAppNevera/package.json
+++ b/MiAppNevera/package.json
@@ -38,7 +38,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "^15.3.0",
     "react-native-web": "^0.20.0",
-    "@expo/metro-runtime": "~5.0.4"
+    "@expo/metro-runtime": "~5.0.4",
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@types/react": "~19.0.10",


### PR DESCRIPTION
## Summary
- add `react-native-webview` dependency required by `react-native-pell-rich-editor`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1131c5bd08324b8e0157d91ac7b29