### PR TITLE
feat(android): enable image resize options

### DIFF
--- a/MiAppNevera/src/components/AddRecipeModal.js
+++ b/MiAppNevera/src/components/AddRecipeModal.js
@@ -64,9 +64,22 @@ export default function AddRecipeModal({
 
   const isEditing = !!initialRecipe;
 
+  const ensureMediaPermission = async () => {
+    let perm = await ImagePicker.getMediaLibraryPermissionsAsync();
+    if (perm.granted) return true;
+    perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) {
+      setErrorMsg(t('permiso_galeria') || 'Permiso de galería requerido');
+      return false;
+    }
+    return true;
+  };
+
   const pickImage = async () => {
+    const ok = await ensureMediaPermission();
+    if (!ok) return;
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       quality: 0.7,
     });
     if (!result.canceled) {
@@ -93,15 +106,19 @@ export default function AddRecipeModal({
       fileInput.current?.click();
       return;
     }
+    const ok = await ensureMediaPermission();
+    if (!ok) return;
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       base64: true,
       quality: 0.7,
     });
     if (!result.canceled) {
       const asset = result.assets[0];
       const uri = `data:${asset.mimeType || 'image/jpeg'};base64,${asset.base64}`;
-      richText.current?.insertImage(uri);
+      richText.current?.focusContentEditor();
+      richText.current?.insertImage({ src: uri, width: '100%' });
+      resizeImage('100%');
       alignImage('center');
     }
   };
@@ -172,7 +189,6 @@ export default function AddRecipeModal({
       }
     } else {
       richText.current?.commandDOM?.(`(function(){
-        focusCurrent();
         var sel = window.getSelection();
         if(!sel || !sel.rangeCount) return;
         var range = sel.getRangeAt(0);
@@ -198,8 +214,13 @@ export default function AddRecipeModal({
             }
           }
         }
-        if(img){img.style.width='${pct}';}
-        saveSelection();
+        if(img){
+          img.style.width='${pct}';
+          img.style.height='auto';
+          img.setAttribute('width','${pct}');
+          img.removeAttribute('height');
+        }
+        saveSelection && saveSelection();
       })()`);
     }
   };
@@ -241,7 +262,6 @@ export default function AddRecipeModal({
       }
     } else {
       richText.current?.commandDOM?.(`(function(){
-        focusCurrent();
         var sel = window.getSelection();
         if(!sel || !sel.rangeCount) return;
         var range = sel.getRangeAt(0);
@@ -288,7 +308,7 @@ export default function AddRecipeModal({
             img.style.alignSelf='flex-end';
           }
         }
-        saveSelection();
+        saveSelection && saveSelection();
       })()`);
     }
   };
@@ -312,14 +332,13 @@ export default function AddRecipeModal({
         }
       } else {
         richText.current?.commandDOM?.(`(function(){
-          focusCurrent();
           var sel = window.getSelection();
           if(!sel || !sel.rangeCount) return;
           var range = sel.getRangeAt(0);
           document.execCommand('fontSize', false, '${next}');
           sel.removeAllRanges();
           sel.addRange(range);
-          saveSelection();
+          saveSelection && saveSelection();
         })()`);
       }
       return next;
@@ -337,8 +356,6 @@ export default function AddRecipeModal({
   const handleToolbarPress = action => {
     if (action === 'fontSizeLabel') {
       return;
-    } else if (action === actions.insertImage) {
-      handleInsertImage();
     } else if (action === 'resize100') {
       resizeImage('100%');
     } else if (action === 'resize50') {
@@ -838,16 +855,21 @@ const save = () => {
                   actions.alignLeft,
                   actions.alignCenter,
                   actions.alignRight,
-                  actions.insertImage,
-                  'resize100',
-                  'resize50',
-                  'resize25',
-                ]}
-                style={styles.richBar}
-                iconTint={palette.text}
-                selectedIconTint={palette.accent}
-                onPress={action => action === 'fontSizeLabel' ? null : handleToolbarPress(action)}
-                iconMap={{
+                actions.insertImage,
+                'resize100',
+                'resize50',
+                'resize25',
+              ]}
+              style={styles.richBar}
+              iconTint={palette.text}
+              selectedIconTint={palette.accent}
+              onPressAddImage={handleInsertImage}
+              onPress={action =>
+                action === 'fontSizeLabel' || action === actions.insertImage
+                  ? null
+                  : handleToolbarPress(action)
+              }
+              iconMap={{
                   fontDecrease: ({ tintColor }) => (
                     <Text style={{ color: tintColor, fontSize: 16 }}>A-</Text>
                   ),


### PR DESCRIPTION
## Summary
- ensure RichEditor on Android sets image width/height when resizing so 100/50/25% buttons work
- request media library permission before selecting recipe images on Android
- wire up RichToolbar insert-image button to actually open the library on Android
- replace deprecated expo-image-picker MediaTypeOptions and focus editor before inserting images so selections persist

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b10e5593548324b1376c077a056390